### PR TITLE
fix(rebuild): address full audit findings — measurement correctness, control plane, Zig data path, CI

### DIFF
--- a/.github/workflows/rebuild-test.yml
+++ b/.github/workflows/rebuild-test.yml
@@ -87,9 +87,13 @@ jobs:
 
   # RDMA e2e tests using soft-RoCE (rdma_rxe) inside a privileged container.
   # GitHub-hosted runners are real VMs (so privileged Docker containers do
-  # work), but whether the underlying host kernel ships/allows loading the
-  # rdma_rxe module is outside our control and can change with the runner
-  # image at any time. `continue-on-error: true` so an environment-level
+  # work), but the rdma_rxe module is not always present on the host kernel
+  # image (e.g. Azure-based runner kernels ship it in a separate
+  # linux-modules-extra package, or omit it entirely). We install the
+  # matching modules-extra package and modprobe it on the host below, but
+  # this is still best-effort: package availability and module support can
+  # change with the runner image at any time, and there is no guarantee the
+  # attempt succeeds. `continue-on-error: true` so an environment-level
   # soft-RoCE failure (e.g. "rdma_rxe module not found") does not fail the
   # whole workflow; a real regression in the probe/ACK path itself should
   # still be investigated by reading the job logs.
@@ -103,6 +107,25 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install and load rdma_rxe kernel module (best-effort)
+        run: |
+          set +e
+          echo "Installing linux-modules-extra-$(uname -r) (provides rdma_rxe)..."
+          sudo apt-get update
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+          if [ $? -ne 0 ]; then
+            echo "::warning::Failed to install linux-modules-extra-$(uname -r); rdma_rxe may be unavailable on this runner kernel"
+          fi
+
+          echo "Loading rdma_rxe module on host..."
+          sudo modprobe rdma_rxe
+          if [ $? -eq 0 ]; then
+            echo "rdma_rxe module loaded successfully"
+          else
+            echo "::warning::modprobe rdma_rxe failed; soft-RoCE e2e test below is expected to fail on this runner"
+          fi
+          exit 0
 
       - name: Run RDMA e2e tests (soft-RoCE)
         run: make test-e2e

--- a/.github/workflows/rebuild-test.yml
+++ b/.github/workflows/rebuild-test.yml
@@ -88,15 +88,20 @@ jobs:
   # RDMA e2e tests using soft-RoCE (rdma_rxe) inside a privileged container.
   # GitHub-hosted runners are real VMs (so privileged Docker containers do
   # work), but the rdma_rxe module is not always present on the host kernel
-  # image (e.g. Azure-based runner kernels ship it in a separate
-  # linux-modules-extra package, or omit it entirely). We install the
-  # matching modules-extra package and modprobe it on the host below, but
-  # this is still best-effort: package availability and module support can
-  # change with the runner image at any time, and there is no guarantee the
-  # attempt succeeds. `continue-on-error: true` so an environment-level
-  # soft-RoCE failure (e.g. "rdma_rxe module not found") does not fail the
-  # whole workflow; a real regression in the probe/ACK path itself should
-  # still be investigated by reading the job logs.
+  # image. We attempt to install the matching linux-modules-extra-$(uname -r)
+  # package and modprobe rdma_rxe on the host below, but this is a confirmed
+  # environment-level limitation on the current runner image, not just a
+  # missing-package issue: as of 2026-07-04, on kernel 6.17.0-1018-azure the
+  # linux-modules-extra-6.17.0-1018-azure package installs successfully, yet
+  # it does not contain rdma_rxe.ko at all ("modprobe: FATAL: Module rdma_rxe
+  # not found in directory /lib/modules/6.17.0-1018-azure") -- the Ubuntu
+  # linux-azure kernel flavor GitHub Actions runners use apparently does not
+  # build the soft-RoCE driver, unlike linux-generic. There is no further
+  # apt-level fix for this; it would require a different runner
+  # image/kernel flavor (e.g. self-hosted or a non-Azure kernel) to resolve.
+  # `continue-on-error: true` so this does not fail the whole workflow; a
+  # real regression in the probe/ACK path itself should still be
+  # investigated by reading the job logs.
   e2e-rdma:
     name: e2e-rdma (soft-RoCE, best-effort)
     runs-on: ubuntu-latest

--- a/.github/workflows/rebuild-test.yml
+++ b/.github/workflows/rebuild-test.yml
@@ -1,0 +1,108 @@
+name: Rebuild Tests
+
+# Validates rebuild/ (the active codebase). The legacy top-level
+# implementation is covered separately by go-test.yml.
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'rebuild/**'
+      - '.github/workflows/rebuild-test.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'rebuild/**'
+      - '.github/workflows/rebuild-test.yml'
+
+# Prevent concurrent runs of the same workflow on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: rebuild
+
+jobs:
+  # Full build (Zig static lib + CGO agent + pure-Go controller) and the
+  # Go unit test suite. Excludes ./e2e/..., which requires either live
+  # Docker infrastructure (see e2e-controller) or RDMA hardware/soft-RoCE
+  # (see e2e-rdma) and is not runnable as a plain `go test`.
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.0'
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install system dependencies (protoc, libibverbs, librdmacm)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler libibverbs-dev librdmacm-dev
+
+      - name: Install protoc Go plugins
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Generate protobuf bindings
+        run: make generate-proto
+
+      - name: go vet
+        run: make vet
+
+      - name: Build (Zig library + CGO agent + controller)
+        run: make build
+
+      - name: Run Go unit tests (excludes ./e2e/...)
+        run: make test-all
+
+  # Agent-to-Controller e2e tests: pure-Go gRPC path against a real
+  # rqlite-backed Controller, no RDMA hardware needed. Runs entirely via
+  # docker compose (see docker-compose.e2e-controller.yml).
+  e2e-controller:
+    name: e2e-controller
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run Agent-to-Controller e2e tests
+        run: make test-e2e-controller
+
+  # RDMA e2e tests using soft-RoCE (rdma_rxe) inside a privileged container.
+  # GitHub-hosted runners are real VMs (so privileged Docker containers do
+  # work), but whether the underlying host kernel ships/allows loading the
+  # rdma_rxe module is outside our control and can change with the runner
+  # image at any time. `continue-on-error: true` so an environment-level
+  # soft-RoCE failure (e.g. "rdma_rxe module not found") does not fail the
+  # whole workflow; a real regression in the probe/ACK path itself should
+  # still be investigated by reading the job logs.
+  e2e-rdma:
+    name: e2e-rdma (soft-RoCE, best-effort)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run RDMA e2e tests (soft-RoCE)
+        run: make test-e2e

--- a/rebuild/.gitignore
+++ b/rebuild/.gitignore
@@ -1,0 +1,7 @@
+# Generated protobuf bindings (regenerate with `make generate-proto`)
+proto/controller_agent/*.pb.go
+
+# Build outputs
+bin/
+zig/zig-out/
+zig/.zig-cache/

--- a/rebuild/CLAUDE.md
+++ b/rebuild/CLAUDE.md
@@ -14,7 +14,7 @@ All commands must be run from within the `rebuild/` directory. This is a separat
 
 ```bash
 make build           # Full pipeline: Zig library → protobuf codegen → Go binaries
-make build-zig       # Build zig/zig-out/lib/librdmabridge.a only (requires Zig 0.16+)
+make build-zig       # Build zig/zig-out/lib/librdmabridge.a only (requires Zig 0.15.2)
 make generate-proto  # Regenerate protobuf Go bindings
 make build-controller  # CGO_ENABLED=0, no Zig link
 make build-agent       # CGO_ENABLED=1, links librdmabridge.a
@@ -30,9 +30,11 @@ After modifying Zig source in `zig/src/`: run `make build-zig` before `make buil
 make test                                       # go test -v ./internal/probe/... (pure Go, no RDMA hardware needed)
 go test -v ./internal/probe/... -run TestName  # Run a specific test
 go test -race ./internal/probe/...             # Run with race detector
+make vet                                        # go vet ./...
+make test-all                                   # go test on all packages except ./e2e/... (Linux, full CGO/RDMA build env)
 ```
 
-The `internal/probe/` package is the only package with tests that run without RDMA hardware. Tests requiring actual RDMA devices or soft-RoCE must be run on Linux with the appropriate hardware.
+The `internal/probe/` package is the only package guaranteed to have tests that run without RDMA hardware; other packages may or may not have tests depending on what has been added. `make test-all` runs everything except `./e2e/...`, which requires either live infrastructure (`test-e2e-controller`) or RDMA hardware/soft-RoCE (`test-e2e`) and is exercised via those dedicated targets instead. Tests requiring actual RDMA devices or soft-RoCE must be run on Linux with the appropriate hardware.
 
 ## Architecture
 
@@ -46,7 +48,7 @@ R-Pingmesh rebuild is a clean-room redesign of the SIGCOMM 2024 R-Pingmesh syste
 
 **Ring buffer event delivery** — Zig's CQ poller thread writes `rdma_completion_event_t` into a lock-free SPSC ring buffer. Go polls via `rdma_event_ring_poll()` in a goroutine — never as a Cgo callback. This is why `EventRing` must be created *before* `Queue` and passed into `rdma_create_queue()`. The ring is shared between the Zig producer and Go consumer across `internal/rdmabridge/bridge.go` ↔ `zig/src/ring.zig`.
 
-**40-byte BigEndian wire format** — The probe packet uses explicit BigEndian serialization (no packed structs). The format is defined in `zig/src/packet.zig` and must stay in sync with `internal/probe/types.go`. Both sides implement independent `serialize`/`deserialize` functions. A version byte at offset 0 enables future format changes.
+**40-byte BigEndian wire format** — The probe packet uses explicit BigEndian serialization (no packed structs). The format is defined in `zig/src/packet.zig` (send/recv, GRH parsing) and must stay in sync with the Go side of the bridge: `internal/rdmabridge/bridge.go` (Serialize/Deserialize across the Cgo boundary) and `internal/agent/responder.go` (interprets the decoded fields). Both sides implement independent `serialize`/`deserialize` functions. A version byte at offset 0 enables future format changes.
 
 **Sequence number format** — `high 32 bits = random agentEpoch | low 32 bits = monotonic counter`. The epoch is randomised on startup to prevent ACK misrouting after agent restarts. Defined in `internal/agent/prober.go`.
 
@@ -78,7 +80,7 @@ The Zig library exposes a C-ABI defined in `zig/include/rdma_bridge.h`. The Go b
 | T3 | Responder NIC HW recv completion | `zig/src/cq.zig` on responder |
 | T4 | Responder NIC HW first-ACK send completion | `zig/src/cq.zig` on responder |
 | T5 | Prober NIC HW first-ACK recv completion | `zig/src/cq.zig` on prober |
-| T6 | Go `time.Now().UnixNano()` when second ACK is processed | `internal/agent/prober.go` |
+| T6 | Go `CLOCK_MONOTONIC` via `unix.ClockGettime()` when second ACK is processed | `internal/agent/prober.go` |
 
 Metrics: `NetworkRTT = (T5-T2)-(T4-T3)`, `ProberDelay = (T6-T1)-(T5-T2)`, `ResponderDelay = T4-T3`.
 
@@ -102,7 +104,7 @@ Environment variables: `RQLITE_DB_URI` for controller database connection.
 ## Requirements
 
 - Go 1.26+
-- Zig 0.16+
+- Zig 0.15.2 (the version verified in e2e/CI; see `build.zig`, `Dockerfile.e2e`, `docker-compose.e2e.yml`)
 - protoc, protoc-gen-go, protoc-gen-go-grpc
 - libibverbs-dev, librdmacm-dev (Linux only; for agent build and RDMA testing)
 - rqlite (for controller and integration tests)

--- a/rebuild/Dockerfile.controller
+++ b/rebuild/Dockerfile.controller
@@ -1,8 +1,10 @@
 # Build stage for the rpingmesh controller.
 # CGO_ENABLED=0 — no RDMA or Zig dependencies needed.
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
-# Install protoc and Go protobuf plugins for code generation.
+# Install protoc and Go protobuf plugins for code generation. This layer
+# only depends on apt/Go tool versions, not application source, so it stays
+# cached across source-only rebuilds.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         protobuf-compiler \
     && rm -rf /var/lib/apt/lists/* \
@@ -11,24 +13,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Copy module files first for Docker layer caching.
-COPY go.mod ./
-# go.sum may not exist yet; copy conditionally.
-COPY go.su[m] ./
+# Copy module files first and resolve dependencies before copying the rest
+# of the source tree, so `go mod download` is only re-run when go.mod/go.sum
+# change (not on every source edit). go.sum is trusted as-is; it is expected
+# to already be complete and committed (no `go mod tidy` in the container).
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy proto definitions and generate Go bindings.
-COPY proto/ proto/
+# Copy remaining source and generate protobuf bindings.
+COPY . .
 RUN cd proto/controller_agent && \
     protoc --go_out=. --go_opt=paths=source_relative \
            --go-grpc_out=. --go-grpc_opt=paths=source_relative \
            controller_agent.proto
 
-# Copy remaining source and resolve dependencies.
-COPY . .
-RUN go mod tidy && go mod download
-
 # Build the controller binary.
-RUN CGO_ENABLED=0 GOOS=linux go build -o /app/bin/rpingmesh-controller ./cmd/controller/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -o /app/bin/rpingmesh-controller ./cmd/controller/
 
 # Runtime image — minimal footprint.
 FROM debian:bookworm-slim

--- a/rebuild/Dockerfile.e2e
+++ b/rebuild/Dockerfile.e2e
@@ -29,8 +29,11 @@ RUN set -eux; \
     DPKG_ARCH="$(dpkg --print-architecture)"; \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${DPKG_ARCH}.tar.gz" | tar -xz -C /usr/local; \
     /usr/local/go/bin/go version
-ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH=/go
+# /go/bin must be on PATH for `protoc` to find the protoc-gen-go/
+# protoc-gen-go-grpc plugins installed below via `go install` (which places
+# binaries in $GOPATH/bin, not next to the go tool itself).
+ENV PATH="/usr/local/go/bin:/go/bin:${PATH}"
 
 # Install Zig (URL format: zig-<arch>-linux-<version>.tar.xz)
 RUN set -eux; \
@@ -41,17 +44,23 @@ RUN set -eux; \
     ln -sf "/usr/local/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig; \
     zig version
 
-WORKDIR /workspace/rebuild
-
-# Copy rebuild/ source tree
-COPY . .
-
-# Install protoc Go plugins for gRPC code generation
+# Install protoc Go plugins for gRPC code generation. Independent of
+# application source, so this layer stays cached across source-only rebuilds.
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
     && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
-# Resolve all Go module dependencies (go.mod starts minimal)
-RUN go mod tidy
+WORKDIR /workspace/rebuild
+
+# Copy module files first and resolve dependencies before copying the rest
+# of the source tree, so `go mod download` is only re-run when go.mod/go.sum
+# change (not on every source edit). go.sum is trusted as-is; it is expected
+# to already be complete and committed (no `go mod tidy` in the container).
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy rebuild/ source tree
+COPY . .
 
 # Generate protobuf Go bindings (required before compiling packages that import them)
 RUN cd proto/controller_agent && \
@@ -63,7 +72,9 @@ RUN cd proto/controller_agent && \
 RUN make build-zig
 
 # Verify the e2e test package compiles with CGO and the bridge library
-RUN CGO_ENABLED=1 go test -c -o /dev/null ./e2e/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=1 go test -c -o /dev/null ./e2e/
 
 RUN chmod +x scripts/run-e2e.sh
 

--- a/rebuild/Dockerfile.e2e-controller
+++ b/rebuild/Dockerfile.e2e-controller
@@ -1,8 +1,10 @@
 # E2E test runner for Agent-to-Controller tests.
 # Generates proto bindings, resolves dependencies, and runs Go tests.
-FROM golang:1.26-bookworm
+FROM golang:1.26.0-bookworm
 
-# Install protoc for code generation.
+# Install protoc for code generation. This layer only depends on apt/Go tool
+# versions, not application source, so it stays cached across source-only
+# rebuilds.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         protobuf-compiler netcat-openbsd \
     && rm -rf /var/lib/apt/lists/* \
@@ -11,19 +13,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Copy module files first for Docker layer caching.
-COPY go.mod ./
-COPY go.su[m] ./
+# Copy module files first and resolve dependencies before copying the rest
+# of the source tree, so `go mod download` is only re-run when go.mod/go.sum
+# change (not on every source edit). go.sum is trusted as-is; it is expected
+# to already be complete and committed (no `go mod tidy` in the container).
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy proto definitions and generate Go bindings.
-COPY proto/ proto/
+# Copy remaining source and generate protobuf bindings.
+COPY . .
 RUN cd proto/controller_agent && \
     protoc --go_out=. --go_opt=paths=source_relative \
            --go-grpc_out=. --go-grpc_opt=paths=source_relative \
            controller_agent.proto
-
-# Copy remaining source and resolve dependencies.
-COPY . .
-RUN go mod tidy && go mod download
 
 CMD ["go", "test", "-v", "-count=1", "-timeout", "120s", "./e2e/controller/..."]

--- a/rebuild/Makefile
+++ b/rebuild/Makefile
@@ -1,8 +1,9 @@
 # R-Pingmesh Rebuild - Build System
-# Requires: Go 1.26+, Zig 0.16+, protoc, clang, libibverbs-dev, librdmacm-dev
+# Requires: Go 1.26+, Zig 0.15.2 (the version verified in e2e/CI), protoc,
+# clang, libibverbs-dev, librdmacm-dev
 
 .PHONY: all build build-zig build-go build-controller build-agent \
-        generate generate-proto clean test test-go \
+        generate generate-proto clean test test-go test-all vet \
         test-e2e setup-colima test-e2e-controller clean-e2e-controller help
 
 # Directories
@@ -50,12 +51,31 @@ build-agent:
 	CGO_ENABLED=1 go build -o $(AGENT_BIN) ./cmd/agent/
 	@echo "==> Agent built: $(AGENT_BIN)"
 
-# Run Go tests (probe package is pure Go, no RDMA needed)
+# Run Go tests. NOTE: this only covers internal/probe/... (pure Go, no RDMA
+# hardware needed). Use `make test-all` to run every package's tests (Linux,
+# full CGO/RDMA build env) or `make test-e2e` / `make test-e2e-controller`
+# for the Docker-based end-to-end suites.
 test: test-go
 
 test-go:
 	@echo "==> Running Go tests..."
 	go test -v ./internal/probe/...
+	@echo "==> Tests complete"
+
+# Run `go vet` across the whole module.
+vet:
+	@echo "==> Running go vet..."
+	go vet ./...
+	@echo "==> Vet complete"
+
+# Run all Go tests in the module (excluding ./e2e/..., which requires live
+# infrastructure or RDMA hardware/soft-RoCE and is exercised by
+# test-e2e / test-e2e-controller instead). Requires the full CGO/RDMA build
+# environment (libibverbs-dev, librdmacm-dev, librdmabridge.a already built),
+# so this is intended for Linux, not local macOS development.
+test-all:
+	@echo "==> Running all Go tests (excluding ./e2e/...)..."
+	go test $$(go list ./... | grep -v '/e2e')
 	@echo "==> Tests complete"
 
 # Install rdma_rxe kernel module on the Colima VM (run once before first test-e2e).
@@ -103,7 +123,9 @@ help:
 	@echo "  generate             Generate all code (proto)"
 	@echo "  generate-proto       Generate protobuf Go code"
 	@echo "  test                 Run tests"
-	@echo "  test-go              Run Go tests"
+	@echo "  test-go              Run Go tests (internal/probe only, pure Go)"
+	@echo "  vet                  Run go vet ./..."
+	@echo "  test-all             Run go test on all packages except ./e2e/... (Linux, full build env)"
 	@echo "  setup-colima         Install rdma_rxe kernel module on Colima VM (run once)"
 	@echo "  test-e2e             Run RDMA e2e tests via Docker (requires Colima)"
 	@echo "  test-e2e-controller  Run Agent-to-Controller E2E tests (Docker)"
@@ -111,5 +133,5 @@ help:
 	@echo "  clean                Remove all build artifacts"
 	@echo ""
 	@echo "Requirements:"
-	@echo "  Go 1.26+, Zig 0.16+, protoc, libibverbs-dev, librdmacm-dev"
+	@echo "  Go 1.26+, Zig 0.15.2, protoc, libibverbs-dev, librdmacm-dev"
 	@echo "  For test-e2e: colima running, run 'make setup-colima' first"

--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -83,7 +83,7 @@ Prober                          Responder
 | T3 | NIC recv completion (CQ) | HW wallclock (fallback: SW) |
 | T4 | NIC send completion (CQ) | HW wallclock (fallback: SW) |
 | T5 | NIC recv completion (CQ) | HW wallclock (fallback: SW) |
-| T6 | Go, upon processing second ACK | `time.Now()` (Go monotonic) |
+| T6 | Go, upon processing second ACK | `CLOCK_MONOTONIC` via `unix.ClockGettime()` |
 
 HW timestamp support is detected at device open time via `ibv_query_device_ex`.
 When HW timestamps are unavailable (`EOPNOTSUPP`), software timestamps from
@@ -161,7 +161,7 @@ rebuild/
 | Dependency | Version | Purpose |
 |------------|---------|---------|
 | Go | 1.26.0+ | Agent and controller binaries |
-| Zig | 0.16+ | RDMA data-path library |
+| Zig | 0.15.2 | RDMA data-path library (the version verified in e2e/CI; see `build.zig`, `Dockerfile.e2e`) |
 | protoc | 3.x | Protocol buffer compilation |
 | protoc-gen-go | latest | Go protobuf codegen |
 | protoc-gen-go-grpc | latest | Go gRPC codegen |
@@ -416,6 +416,14 @@ sudo rdma link add rxe0 type rxe netdev eth0
 # Then run the agent against a local controller and rqlite instance
 ```
 
+> **Note:** `TestProbeToOTelMetrics` (the full probe-to-OTel e2e test, see
+> `make test-e2e`) asserts on the *shape* of the recorded metrics rather than
+> requiring every probe to succeed (`probeSuccess == 0` is tolerated). Under
+> soft-RoCE, software timestamps and the shared-namespace veth topology used
+> in CI are not guaranteed to produce a fully successful probe/ACK round
+> trip on every run, so this test does not guarantee the success path is
+> always exercised end-to-end.
+
 ## Development
 
 ### Modifying the Zig Library
@@ -457,9 +465,48 @@ sudo rdma link add rxe0 type rxe netdev eth0
 - **No TLS on gRPC.** Controller-agent communication uses plaintext gRPC, assuming
   a trusted internal network. mTLS can be added via gRPC transport credentials.
 
-- **No rate limiting on probe sends.** The `target_probe_rate_per_second` config
-  field is defined but not enforced with a token bucket. The probe interval
-  provides coarse rate control.
+- **Only a single, uniform probe rate cap.** The Prober enforces
+  `target_probe_rate_per_second` as a per-target cap (the aggregate limit
+  scales with the pinglist size). The paper's per-probe-type differentiated
+  rates (e.g. ToR-mesh probes at 10pps, with a separate rate for inter-ToR
+  probes) are not implemented.
+
+- **Inter-ToR pinglist coverage is a simplified random sample, not a
+  probabilistic ECMP coverage guarantee.** The paper's Eq. (1) derives the
+  number of samples needed to cover ECMP paths with a target probability;
+  this rebuild instead picks a fixed, configurable number of random ToRs
+  (`N`) without that coverage-probability derivation.
+
+- **No periodic 5-tuple rotation.** The paper rotates ~20% of probe 5-tuples
+  every hour to shift ECMP path selection over time and catch a wider set of
+  paths. This rebuild's `flow_label` is derived deterministically from
+  `(requester_gid, target_gid)` and does not rotate.
+
+- **Analyzer and Service Tracing remain out of scope.** As noted above, the
+  data-aggregation/anomaly-detection Analyzer (switch/link fault
+  localization, priority ranking) and eBPF-based service tracing from the
+  original design are not part of this rebuild.
+
+- **No agent self-protection.** There is no hard CPU/memory cap on the
+  agent process and no fail-closed behavior (e.g. backing off or shutting
+  down probing) when local resource usage or error rates spike.
+
+- **Address Handle `sl` / `traffic_class` are always 0.** `ibv_ah_attr`
+  fields used for PFC priority (service level) and DSCP (traffic class) are
+  not configurable. Deployments relying on PFC/DSCP-based QoS should be
+  aware probes do not carry the expected markings.
+
+- **No automatic recovery from RDMA device runtime failures.** If an RDMA
+  device fails or is removed after the agent has started, there is no
+  detection/re-initialization path; the affected Prober/Responder simply
+  stops functioning until the agent is restarted.
+
+- **No systemd unit or OS packaging.** Deployment artifacts (systemd units,
+  .deb/.rpm packages, etc.) are not provided. There is intentionally no
+  Agent Dockerfile: the agent binary requires `CGO_ENABLED=1` and a real (or
+  soft-RoCE) RDMA device, which is impractical to containerize generically;
+  only the Controller (`Dockerfile.controller`) and test-only images
+  (`Dockerfile.e2e`, `Dockerfile.e2e-controller`) are provided.
 
 ## References
 

--- a/rebuild/cmd/agent/main.go
+++ b/rebuild/cmd/agent/main.go
@@ -50,7 +50,7 @@ func main() {
 // lifecycle until a termination signal is received.
 func run(cmd *cobra.Command, args []string) error {
 	// Load configuration from file, environment variables, and CLI flags.
-	cfg, err := config.LoadAgentConfig(configPath)
+	cfg, err := config.LoadAgentConfig(configPath, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to load agent configuration: %w", err)
 	}

--- a/rebuild/cmd/controller/main.go
+++ b/rebuild/cmd/controller/main.go
@@ -43,7 +43,7 @@ func main() {
 // starts the gRPC server, and blocks until a shutdown signal is received.
 func run(cmd *cobra.Command, args []string) error {
 	// Load configuration from file, env vars, and flags.
-	cfg, err := config.LoadControllerConfig(configPath)
+	cfg, err := config.LoadControllerConfig(configPath, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -63,10 +63,18 @@ func run(cmd *cobra.Command, args []string) error {
 		Str("listenAddr", cfg.ListenAddr).
 		Str("databaseURI", cfg.DatabaseURI).
 		Str("logLevel", cfg.LogLevel).
+		Int("activeThresholdSec", cfg.ActiveThresholdSec).
+		Int("staleThresholdSec", cfg.StaleThresholdSec).
+		Int("interTorSampleSize", cfg.InterTorSampleSize).
 		Msg("Starting rpingmesh-controller")
 
 	// Initialize RNIC registry backed by rqlite.
-	reg, err := registry.NewRnicRegistry(cfg.DatabaseURI)
+	reg, err := registry.NewRnicRegistry(
+		cfg.DatabaseURI,
+		cfg.ActiveThresholdSec,
+		cfg.StaleThresholdSec,
+		cfg.InterTorSampleSize,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize registry: %w", err)
 	}

--- a/rebuild/docker-compose.e2e-controller.yml
+++ b/rebuild/docker-compose.e2e-controller.yml
@@ -45,6 +45,8 @@ services:
       go test -v -count=1 -timeout 120s ./e2e/controller/...
     restart: "no"
 
-volumes:
-  go_mod_cache:
-  go_build_cache:
+# NOTE: no top-level `volumes:` for a Go module/build cache here. Dependency
+# resolution happens at image-build time via BuildKit cache mounts in
+# Dockerfile.e2e-controller (`--mount=type=cache,target=/go/pkg/mod`), not at
+# container-run time, so a named volume mounted into this service would
+# never be populated or read.

--- a/rebuild/go.mod
+++ b/rebuild/go.mod
@@ -13,7 +13,9 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
+	golang.org/x/sys v0.40.0
 	google.golang.org/grpc v1.79.1
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -39,9 +41,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -21,6 +22,25 @@ import (
 const (
 	metricsShutdownTimeout = 5 * time.Second
 	eventRingCapacity      = 1024 // Power of 2 for optimal SPSC ring performance.
+
+	// heartbeatInterval is the period between periodic re-registration
+	// heartbeats sent to the controller. The controller's liveness check
+	// considers an agent dead once last_updated_epoch is older than 300s,
+	// so this must be well under that threshold.
+	heartbeatInterval = 60 * time.Second
+
+	// heartbeatFailureEscalationThreshold is the number of consecutive
+	// heartbeat failures after which log severity is escalated from Warn
+	// to Error, to surface sustained controller unreachability without
+	// being noisy about single transient failures.
+	heartbeatFailureEscalationThreshold = 3
+
+	// Initial registration retry parameters: exponential backoff starting
+	// at registerRetryInitialBackoff, doubling up to registerRetryMaxBackoff,
+	// for up to registerRetryMaxAttempts total attempts.
+	registerRetryInitialBackoff = 1 * time.Second
+	registerRetryMaxBackoff     = 30 * time.Second
+	registerRetryMaxAttempts    = 6
 )
 
 // Agent orchestrates all R-Pingmesh agent components: RDMA context, devices,
@@ -38,6 +58,12 @@ type Agent struct {
 	proberRing *rdmabridge.EventRing
 	respRings  []*rdmabridge.EventRing
 	logger     zerolog.Logger
+
+	// heartbeatStopCh and heartbeatWg control the lifecycle of the
+	// background heartbeat goroutine that periodically re-registers with
+	// the controller to keep the agent's registry entry alive.
+	heartbeatStopCh chan struct{}
+	heartbeatWg     sync.WaitGroup
 }
 
 // NewAgent creates a new Agent instance with the given configuration.
@@ -102,6 +128,12 @@ func (a *Agent) Initialize(ctx context.Context) error {
 		return fmt.Errorf("failed to create prober: %w", err)
 	}
 	a.prober = prober
+	if a.cfg.TargetProbeRatePerSecond > 0 {
+		// Per-target rate cap; the prober scales the aggregate limit with the
+		// pinglist size. Differentiated per-pinglist-type rates are a
+		// documented limitation (see README Limitations).
+		a.prober.SetPerTargetRateLimit(float64(a.cfg.TargetProbeRatePerSecond))
+	}
 
 	// Step 6: Create one responder per device.
 	a.logger.Info().Int("device_count", len(a.devices)).Msg("Creating responders")
@@ -160,9 +192,10 @@ func (a *Agent) Initialize(ctx context.Context) error {
 	return nil
 }
 
-// registerWithController builds a registration request from the agent's
-// configuration and device/responder state, then sends it to the controller.
-func (a *Agent) registerWithController(ctx context.Context) error {
+// buildRegistrationRequest builds a registration request from the agent's
+// configuration and device/responder state. It is used both for the initial
+// registration and for periodic heartbeat re-registrations.
+func (a *Agent) buildRegistrationRequest() *controller_agent.AgentRegistrationRequest {
 	rnics := make([]*controller_agent.RnicInfo, 0, len(a.responders))
 
 	for i, resp := range a.responders {
@@ -187,23 +220,77 @@ func (a *Agent) registerWithController(ctx context.Context) error {
 			Msg("Prepared RNIC info for registration")
 	}
 
-	req := &controller_agent.AgentRegistrationRequest{
+	return &controller_agent.AgentRegistrationRequest{
 		AgentId:  a.cfg.AgentID,
 		Hostname: a.cfg.HostName,
 		TorId:    a.cfg.TorID,
 		Rnics:    rnics,
 	}
+}
 
-	_, err := a.grpcClient.RegisterAgent(ctx, req)
+// registerAttemptErr builds an error describing why a single registration
+// attempt was considered a failure, checking both the RPC error and the
+// resp.Success field. The controller contract allows it to signal failure
+// via either channel (a gRPC error, e.g. codes.Internal, or a false Success
+// with a populated Message), so both must be checked.
+func registerAttemptErr(resp *controller_agent.AgentRegistrationResponse, err error) error {
 	if err != nil {
 		return fmt.Errorf("RegisterAgent failed: %w", err)
 	}
-
-	a.logger.Info().
-		Str("agent_id", a.cfg.AgentID).
-		Int("rnic_count", len(rnics)).
-		Msg("Agent registered with controller")
+	if !resp.GetSuccess() {
+		return fmt.Errorf("agent registration rejected by controller: %s", resp.GetMessage())
+	}
 	return nil
+}
+
+// registerWithController sends the agent's registration request to the
+// controller, retrying with exponential backoff on failure. A failure is
+// anything that fails either the err or the resp.Success check, since the
+// controller may report a rejected registration via a gRPC error, a
+// Success=false response, or both. It returns an error only if every
+// attempt fails.
+func (a *Agent) registerWithController(ctx context.Context) error {
+	req := a.buildRegistrationRequest()
+
+	backoff := registerRetryInitialBackoff
+	var lastErr error
+
+	for attempt := 1; attempt <= registerRetryMaxAttempts; attempt++ {
+		resp, err := a.grpcClient.RegisterAgent(ctx, req)
+		attemptErr := registerAttemptErr(resp, err)
+		if attemptErr == nil {
+			a.logger.Info().
+				Str("agent_id", a.cfg.AgentID).
+				Int("rnic_count", len(req.GetRnics())).
+				Str("message", resp.GetMessage()).
+				Msg("Agent registered with controller")
+			return nil
+		}
+		lastErr = attemptErr
+
+		if attempt == registerRetryMaxAttempts {
+			break
+		}
+
+		a.logger.Warn().Err(lastErr).
+			Int("attempt", attempt).
+			Int("max_attempts", registerRetryMaxAttempts).
+			Dur("backoff", backoff).
+			Msg("Agent registration attempt failed, retrying")
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("registration cancelled: %w", ctx.Err())
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > registerRetryMaxBackoff {
+			backoff = registerRetryMaxBackoff
+		}
+	}
+
+	return fmt.Errorf("agent registration failed after %d attempts: %w", registerRetryMaxAttempts, lastErr)
 }
 
 // Start begins all agent components: responders, prober, cluster monitor,
@@ -227,6 +314,10 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start cluster monitor: %w", err)
 	}
 
+	// Start the heartbeat goroutine to periodically re-register with the
+	// controller, keeping the agent's registry entry alive.
+	a.startHeartbeat(ctx)
+
 	// Start the metrics result consumer if metrics are enabled.
 	if a.metrics != nil {
 		a.metrics.StartResultConsumer(ctx, a.prober.Results(), a.cfg.TorID)
@@ -248,6 +339,10 @@ func (a *Agent) Stop(ctx context.Context) {
 	if a.monitor != nil {
 		a.monitor.Stop()
 	}
+
+	// Stop the heartbeat goroutine before closing the gRPC client, since
+	// both it and the cluster monitor depend on grpcClient being open.
+	a.stopHeartbeat()
 
 	// Stop the prober to cease outgoing probes.
 	if a.prober != nil {
@@ -298,6 +393,76 @@ func (a *Agent) Stop(ctx context.Context) {
 	a.respRings = nil
 
 	a.logger.Info().Msg("Agent stopped")
+}
+
+// startHeartbeat launches the background goroutine that periodically
+// re-sends the agent's registration to the controller. This refreshes the
+// controller's last_updated_epoch liveness field, without which the
+// controller's registry considers the agent dead ~5 minutes after startup
+// and drops it from distributed pinglists (and evicts it entirely after
+// ~15 minutes).
+func (a *Agent) startHeartbeat(ctx context.Context) {
+	a.heartbeatStopCh = make(chan struct{})
+	a.heartbeatWg.Add(1)
+	go a.heartbeatLoop(ctx)
+}
+
+// stopHeartbeat signals the heartbeat goroutine to exit and waits for it to
+// finish. It is a no-op if the heartbeat was never started.
+func (a *Agent) stopHeartbeat() {
+	if a.heartbeatStopCh == nil {
+		return
+	}
+	close(a.heartbeatStopCh)
+	a.heartbeatWg.Wait()
+}
+
+// heartbeatLoop periodically re-sends the agent's registration to the
+// controller until the context is cancelled or stopHeartbeat is called.
+// Failures are logged but never terminate the process: a transient
+// controller outage should not bring down an otherwise healthy agent, and
+// the next tick will simply retry.
+func (a *Agent) heartbeatLoop(ctx context.Context) {
+	defer a.heartbeatWg.Done()
+
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	consecutiveFailures := 0
+
+	for {
+		select {
+		case <-a.heartbeatStopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			req := a.buildRegistrationRequest()
+			resp, err := a.grpcClient.RegisterAgent(ctx, req)
+			if attemptErr := registerAttemptErr(resp, err); attemptErr != nil {
+				consecutiveFailures++
+				a.logHeartbeatFailure(consecutiveFailures, attemptErr)
+				continue
+			}
+			consecutiveFailures = 0
+			a.logger.Debug().
+				Str("agent_id", a.cfg.AgentID).
+				Msg("Heartbeat re-registration succeeded")
+		}
+	}
+}
+
+// logHeartbeatFailure logs a heartbeat failure, escalating the log level
+// from Warn to Error once consecutive failures reach the escalation
+// threshold, to surface sustained controller unreachability.
+func (a *Agent) logHeartbeatFailure(consecutiveFailures int, err error) {
+	event := a.logger.Warn()
+	if consecutiveFailures >= heartbeatFailureEscalationThreshold {
+		event = a.logger.Error()
+	}
+	event.Err(err).
+		Int("consecutive_failures", consecutiveFailures).
+		Msg("Heartbeat re-registration failed, agent continues running")
 }
 
 // Run is the main lifecycle method. It initializes the agent, starts all

--- a/rebuild/internal/agent/cluster_monitor.go
+++ b/rebuild/internal/agent/cluster_monitor.go
@@ -35,6 +35,17 @@ type ClusterMonitor struct {
 	stopCh         chan struct{}
 	wg             sync.WaitGroup
 	logger         zerolog.Logger
+
+	// lastTorMeshTargets and lastInterTorTargets cache the most recently
+	// fetched successful pinglist for each type. When a fetch for one
+	// pinglist type fails while the other succeeds, the cached value for
+	// the failed type is reused instead of treating it as empty. This
+	// prevents a transient failure of a single pinglist type from wiping
+	// out the other type's live, healthy targets. These fields are only
+	// ever touched from the single monitor loop goroutine (Start ensures
+	// at most one is running), so no additional synchronization is needed.
+	lastTorMeshTargets  []*controller_agent.PingTarget
+	lastInterTorTargets []*controller_agent.PingTarget
 }
 
 // NewClusterMonitor creates a new ClusterMonitor that will poll the controller
@@ -123,57 +134,55 @@ func (m *ClusterMonitor) monitorLoop(ctx context.Context) {
 	}
 }
 
-// updateTargets fetches the combined pinglist and pushes targets to the prober.
-// If the fetch returns a non-empty list, the prober's targets are replaced.
-// If both fetches fail, the prober keeps its previous targets to avoid
-// clearing healthy targets on a transient controller failure.
+// updateTargets fetches the combined pinglist and pushes targets to the
+// prober. fetchPinglists always returns a usable list (falling back to
+// per-type cached values on failure), so the result is always pushed.
 func (m *ClusterMonitor) updateTargets(ctx context.Context) {
 	targets := m.fetchPinglists(ctx)
-	if targets != nil {
-		m.prober.UpdateTargets(targets)
-	}
+	m.prober.UpdateTargets(targets)
 }
 
 // fetchPinglists requests both TOR_MESH and INTER_TOR pinglists from the
-// controller, merges the results, and returns the combined list.
+// controller and merges the results.
 //
-// If both fetches fail, nil is returned so the caller knows not to update
-// the prober (preserving previous targets). If at least one succeeds, the
-// successfully fetched targets are returned (which may be empty if the
-// controller has no targets for that type).
+// Each pinglist type is handled independently: on success its result
+// replaces the cached value for that type; on failure the previously
+// cached value for that type is reused. This prevents a failure in one
+// pinglist type (e.g. INTER_TOR) from wiping out live, healthy targets of
+// the other type (e.g. TOR_MESH) that were just fetched successfully, and
+// still gracefully degrades to the last known-good targets if a fetch
+// keeps failing repeatedly.
 func (m *ClusterMonitor) fetchPinglists(ctx context.Context) []*controller_agent.PingTarget {
-	var (
-		torMeshTargets  []*controller_agent.PingTarget
-		interTorTargets []*controller_agent.PingTarget
-		torMeshErr      error
-		interTorErr     error
-	)
-
 	// Fetch ToR-mesh pinglist (targets within the same ToR).
-	torMeshTargets, torMeshErr = m.client.GetPinglist(
+	torMeshTargets, torMeshErr := m.client.GetPinglist(
 		ctx, m.agentID, m.torID, m.requesterGID,
 		controller_agent.PinglistType_TOR_MESH,
 	)
 	if torMeshErr != nil {
 		m.logger.Error().Err(torMeshErr).
-			Msg("Failed to fetch TOR_MESH pinglist")
+			Int("cached_count", len(m.lastTorMeshTargets)).
+			Msg("Failed to fetch TOR_MESH pinglist, reusing cached targets")
+		torMeshTargets = m.lastTorMeshTargets
+	} else {
+		m.lastTorMeshTargets = torMeshTargets
 	}
 
 	// Fetch inter-ToR pinglist (targets across different ToRs).
-	interTorTargets, interTorErr = m.client.GetPinglist(
+	interTorTargets, interTorErr := m.client.GetPinglist(
 		ctx, m.agentID, m.torID, m.requesterGID,
 		controller_agent.PinglistType_INTER_TOR,
 	)
 	if interTorErr != nil {
 		m.logger.Error().Err(interTorErr).
-			Msg("Failed to fetch INTER_TOR pinglist")
+			Int("cached_count", len(m.lastInterTorTargets)).
+			Msg("Failed to fetch INTER_TOR pinglist, reusing cached targets")
+		interTorTargets = m.lastInterTorTargets
+	} else {
+		m.lastInterTorTargets = interTorTargets
 	}
 
-	// If both fetches failed, return nil to signal the caller that the
-	// prober should keep its existing targets.
 	if torMeshErr != nil && interTorErr != nil {
-		m.logger.Warn().Msg("Both pinglist fetches failed, keeping previous targets")
-		return nil
+		m.logger.Warn().Msg("Both pinglist fetches failed, falling back to cached targets")
 	}
 
 	// Combine the results from both pinglist types.

--- a/rebuild/internal/agent/cluster_monitor_test.go
+++ b/rebuild/internal/agent/cluster_monitor_test.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// pinglistResponse is a single canned GetPinglist result used by
+// mockControllerClient.
+type pinglistResponse struct {
+	targets []*controller_agent.PingTarget
+	err     error
+}
+
+// mockControllerClient is a test double for the ControllerClient interface.
+// It lets tests script a per-pinglist-type sequence of results so that
+// ClusterMonitor's fetch/cache/combine behavior can be tested without a
+// real gRPC connection to a controller.
+type mockControllerClient struct {
+	mu        sync.Mutex
+	responses map[controller_agent.PinglistType][]pinglistResponse
+	callIndex map[controller_agent.PinglistType]int
+}
+
+func newMockControllerClient() *mockControllerClient {
+	return &mockControllerClient{
+		responses: make(map[controller_agent.PinglistType][]pinglistResponse),
+		callIndex: make(map[controller_agent.PinglistType]int),
+	}
+}
+
+// enqueue appends a scripted response for the given pinglist type. Calls to
+// GetPinglist for that type consume the queue in order; once exhausted, the
+// last enqueued response is returned for all further calls.
+func (m *mockControllerClient) enqueue(ptype controller_agent.PinglistType, targets []*controller_agent.PingTarget, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responses[ptype] = append(m.responses[ptype], pinglistResponse{targets: targets, err: err})
+}
+
+// GetPinglist implements the ControllerClient interface.
+func (m *mockControllerClient) GetPinglist(
+	_ context.Context,
+	_, _, _ string,
+	ptype controller_agent.PinglistType,
+) ([]*controller_agent.PingTarget, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	queue := m.responses[ptype]
+	if len(queue) == 0 {
+		return nil, nil
+	}
+
+	idx := m.callIndex[ptype]
+	if idx >= len(queue) {
+		idx = len(queue) - 1
+	} else {
+		m.callIndex[ptype] = idx + 1
+	}
+	resp := queue[idx]
+	return resp.targets, resp.err
+}
+
+// newTestProber builds a Prober suitable for ClusterMonitor tests. It
+// bypasses NewProber (which requires a real RDMA device) since only the
+// unexported targets field, set via UpdateTargets, is exercised here.
+func newTestProber() *Prober {
+	return &Prober{logger: zerolog.Nop()}
+}
+
+// newTestClusterMonitor builds a ClusterMonitor wired to the given mock
+// client and prober, with logging silenced.
+func newTestClusterMonitor(client ControllerClient, prober *Prober) *ClusterMonitor {
+	m := NewClusterMonitor(client, prober, "agent-1", "tor-1", "gid-requester", 1)
+	m.logger = zerolog.Nop()
+	return m
+}
+
+func targetWithGID(gid string) *controller_agent.PingTarget {
+	return &controller_agent.PingTarget{TargetGid: gid}
+}
+
+func gidsOf(targets []*controller_agent.PingTarget) []string {
+	gids := make([]string, len(targets))
+	for i, target := range targets {
+		gids[i] = target.GetTargetGid()
+	}
+	return gids
+}
+
+func TestClusterMonitor_FetchPinglists_Success(t *testing.T) {
+	client := newMockControllerClient()
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, []*controller_agent.PingTarget{targetWithGID("tor-a")}, nil)
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, []*controller_agent.PingTarget{targetWithGID("inter-a")}, nil)
+
+	monitor := newTestClusterMonitor(client, newTestProber())
+
+	combined := monitor.fetchPinglists(context.Background())
+
+	if got := gidsOf(combined); len(got) != 2 || got[0] != "tor-a" || got[1] != "inter-a" {
+		t.Fatalf("unexpected combined targets: %v", got)
+	}
+}
+
+func TestClusterMonitor_FetchPinglists_PartialFailure_ReusesCache(t *testing.T) {
+	client := newMockControllerClient()
+	// First cycle: both pinglist types succeed, populating the per-type cache.
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, []*controller_agent.PingTarget{targetWithGID("tor-a")}, nil)
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, []*controller_agent.PingTarget{targetWithGID("inter-a")}, nil)
+	// Second cycle: TOR_MESH succeeds with a refreshed target, INTER_TOR fails.
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, []*controller_agent.PingTarget{targetWithGID("tor-b")}, nil)
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, nil, errors.New("controller unreachable"))
+
+	monitor := newTestClusterMonitor(client, newTestProber())
+
+	if first := monitor.fetchPinglists(context.Background()); len(first) != 2 {
+		t.Fatalf("expected 2 targets on first fetch, got %d", len(first))
+	}
+
+	second := monitor.fetchPinglists(context.Background())
+	got := gidsOf(second)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 targets on second fetch (cached INTER_TOR reused), got %d (%v)", len(got), got)
+	}
+
+	present := map[string]bool{got[0]: true, got[1]: true}
+	if !present["tor-b"] {
+		t.Errorf("expected refreshed TOR_MESH target 'tor-b' in combined result, got %v", got)
+	}
+	if !present["inter-a"] {
+		t.Errorf("expected cached INTER_TOR target 'inter-a' to be reused after fetch failure, got %v", got)
+	}
+}
+
+func TestClusterMonitor_FetchPinglists_BothFail_ReusesCache(t *testing.T) {
+	client := newMockControllerClient()
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, []*controller_agent.PingTarget{targetWithGID("tor-a")}, nil)
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, []*controller_agent.PingTarget{targetWithGID("inter-a")}, nil)
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, nil, errors.New("timeout"))
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, nil, errors.New("timeout"))
+
+	monitor := newTestClusterMonitor(client, newTestProber())
+
+	first := gidsOf(monitor.fetchPinglists(context.Background()))
+	second := gidsOf(monitor.fetchPinglists(context.Background()))
+
+	if len(second) != len(first) {
+		t.Fatalf("expected cached targets to be preserved when both fetches fail: first=%v second=%v", first, second)
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("target %d changed after both-fail cycle: got %s, want %s", i, second[i], first[i])
+		}
+	}
+}
+
+func TestClusterMonitor_UpdateTargets_PushesToProber(t *testing.T) {
+	client := newMockControllerClient()
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, []*controller_agent.PingTarget{targetWithGID("tor-a")}, nil)
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, nil, nil)
+
+	prober := newTestProber()
+	monitor := newTestClusterMonitor(client, prober)
+
+	monitor.updateTargets(context.Background())
+
+	if len(prober.targets) != 1 || prober.targets[0].GetTargetGid() != "tor-a" {
+		t.Errorf("expected prober targets to be updated with fetched pinglist, got %v", gidsOf(prober.targets))
+	}
+}
+
+func TestClusterMonitor_Stop_ReturnsQuickly(t *testing.T) {
+	client := newMockControllerClient()
+	client.enqueue(controller_agent.PinglistType_TOR_MESH, nil, nil)
+	client.enqueue(controller_agent.PinglistType_INTER_TOR, nil, nil)
+
+	// A long update interval ensures this test only passes if Stop wakes
+	// the monitor loop via stopCh rather than waiting for the next tick.
+	monitor := NewClusterMonitor(client, newTestProber(), "agent-1", "tor-1", "gid-requester", 3600)
+	monitor.logger = zerolog.Nop()
+
+	if err := monitor.Start(context.Background()); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		monitor.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("Stop took too long: %v", elapsed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return within 5s; monitor loop likely blocked on the ticker instead of stopCh")
+	}
+}

--- a/rebuild/internal/agent/controller_client/controller_client.go
+++ b/rebuild/internal/agent/controller_client/controller_client.go
@@ -7,6 +7,7 @@ package controller_client
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -14,6 +15,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+// rpcTimeout bounds every individual RPC to the controller. Without this,
+// a hung or unreachable controller would block the caller indefinitely:
+// for RegisterAgent that stalls agent startup/heartbeat, and for
+// GetPinglist that stalls ClusterMonitor.Stop() (which waits for the
+// in-flight fetch to return before the monitor goroutine can exit).
+const rpcTimeout = 10 * time.Second
 
 // GRPCControllerClient implements the agent.ControllerClient interface using
 // gRPC to communicate with the controller service. It wraps a single gRPC
@@ -82,7 +90,10 @@ func (c *GRPCControllerClient) RegisterAgent(
 		Int("rnic_count", len(req.GetRnics())).
 		Msg("Sending agent registration request")
 
-	resp, err := c.client.RegisterAgent(ctx, req)
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	resp, err := c.client.RegisterAgent(rpcCtx, req)
 	if err != nil {
 		return nil, fmt.Errorf("RegisterAgent RPC failed: %w", err)
 	}
@@ -126,7 +137,10 @@ func (c *GRPCControllerClient) GetPinglist(
 		Str("pinglist_type", ptype.String()).
 		Msg("Requesting pinglist from controller")
 
-	resp, err := c.client.GetPinglist(ctx, req)
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	resp, err := c.client.GetPinglist(rpcCtx, req)
 	if err != nil {
 		return nil, fmt.Errorf("GetPinglist RPC failed (type=%s): %w", ptype.String(), err)
 	}

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -15,6 +16,7 @@ import (
 	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
 	"github.com/yuuki/rpingmesh/rebuild/internal/rdmabridge"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+	"golang.org/x/sys/unix"
 )
 
 // Default constants for the Prober.
@@ -30,19 +32,19 @@ const (
 	// is considered stale and eligible for cleanup.
 	stalePendingTimeout = 30 * time.Second
 
-	// stalePendingCleanupInterval determines how often the probe loop
-	// checks for stale pending probes (every N ticks of the probe loop).
-	stalePendingCleanupInterval = 100
+	// stalePendingCleanupPeriod is the wall-clock interval between stale-pending
+	// sweeps. Using elapsed time (rather than a tick count) decouples cleanup
+	// cadence from the probe interval, so the sweep runs at a predictable rate
+	// regardless of how frequently probes are sent.
+	stalePendingCleanupPeriod = 10 * time.Second
 )
 
 // pendingProbe holds the in-flight state for a single probe awaiting ACKs.
+// The 6-timestamp bookkeeping lives in the embedded PendingMeasurement, which
+// accepts the two ACKs in either arrival order.
 type pendingProbe struct {
 	target    *controller_agent.PingTarget
-	t1        uint64 // Prober send time (CLOCK_MONOTONIC via Zig)
-	t2        uint64 // NIC HW timestamp of probe send completion (or SW fallback)
-	t3        uint64 // Responder recv timestamp (filled on first ACK)
-	t4        uint64 // Responder first ACK send completion (filled on second ACK)
-	t5        uint64 // Prober first ACK recv timestamp (filled on first ACK)
+	meas      *probe.PendingMeasurement
 	createdAt time.Time
 }
 
@@ -61,11 +63,23 @@ type Prober struct {
 	agentEpoch    uint32 // Random epoch prefix for sequence number collision prevention
 	resultChan    chan *probe.ProbeResult
 	running       atomic.Bool
+	stopMu        sync.Mutex    // guards stopCh (re)creation across Start/Stop
 	stopCh        chan struct{} // closed by Stop() to wake goroutines immediately
 	wg            sync.WaitGroup
 	probeInterval time.Duration
 	probeTimeout  uint32 // ms
-	logger        zerolog.Logger
+
+	// queueMu guards access to the queue pointer so that GetQueueInfo cannot
+	// race with Destroy() setting queue to nil.
+	queueMu sync.RWMutex
+
+	// rateMu guards the send-rate limiter, which SetPerTargetRateLimit may update from
+	// a different goroutine than the probe loop.
+	rateMu       sync.Mutex // guards limiter and perTargetPPS; lock order: targetsMu -> rateMu
+	limiter      probe.RateLimiter
+	perTargetPPS float64
+
+	logger zerolog.Logger
 }
 
 // NewProber creates a new Prober with a sender-type RDMA queue bound to the
@@ -76,6 +90,13 @@ type Prober struct {
 // agent lifetimes do not collide: the high 32 bits of each sequence number
 // contain the epoch, and the low 32 bits are a monotonic counter.
 func NewProber(device *rdmabridge.Device, ring *rdmabridge.EventRing, probeIntervalMS uint32) (*Prober, error) {
+	// A zero interval would make probeLoop call time.NewTicker(0), which panics.
+	// Reject it here rather than at Start time so the misconfiguration surfaces
+	// during construction. (The signature already returns an error.)
+	if probeIntervalMS == 0 {
+		return nil, fmt.Errorf("probeIntervalMS must be greater than 0")
+	}
+
 	queue, err := device.CreateQueue(rdmabridge.QueueTypeSender, ring)
 	if err != nil {
 		return nil, err
@@ -113,6 +134,13 @@ func (p *Prober) Start(ctx context.Context) error {
 		return nil // already running
 	}
 
+	// Recreate stopCh so a prober can be started again after a previous Stop()
+	// closed it. Stop() has already waited for the old goroutines to exit
+	// (running is false here), so no goroutine references the old channel.
+	p.stopMu.Lock()
+	p.stopCh = make(chan struct{})
+	p.stopMu.Unlock()
+
 	p.wg.Add(2)
 	go p.probeLoop(ctx)
 	go p.ackProcessLoop(ctx)
@@ -131,9 +159,56 @@ func (p *Prober) Stop() {
 	if !p.running.CompareAndSwap(true, false) {
 		return // not running
 	}
+	p.stopMu.Lock()
 	close(p.stopCh)
+	p.stopMu.Unlock()
 	p.wg.Wait()
 	p.logger.Info().Msg("Prober stopped")
+}
+
+// SetPerTargetRateLimit caps the probe send rate to at most pps packets per
+// second per target. The aggregate limiter rate is recomputed as
+// pps * len(targets) here and on every UpdateTargets call, so the configured
+// per-target cadence is preserved as the pinglist grows or shrinks. A
+// non-positive pps disables rate limiting. Safe to call while running.
+func (p *Prober) SetPerTargetRateLimit(pps float64) {
+	p.targetsMu.RLock()
+	n := len(p.targets)
+	p.targetsMu.RUnlock()
+
+	p.rateMu.Lock()
+	p.perTargetPPS = pps
+	p.limiter.SetRate(pps * float64(n))
+	p.rateMu.Unlock()
+	p.logger.Info().
+		Float64("per_target_pps", pps).
+		Int("targets", n).
+		Msg("Probe send rate limit updated")
+}
+
+// nowMonotonicNS returns the current CLOCK_MONOTONIC time in nanoseconds. It
+// must be used for T6 instead of time.Now().UnixNano() (a wall-clock reading)
+// so that ProberDelay = (T6-T1) - (T5-T2) is arithmetically sound in both
+// timestamp modes:
+//
+//   - SW fallback: T1, T2, T5 are all CLOCK_MONOTONIC on the prober host, and
+//     T6 now matches that domain, so every term shares one clock.
+//   - HW timestamps: T2 and T5 are NIC wall-clock timestamps, but only their
+//     difference (T5-T2) is used, which is self-consistent within the NIC
+//     clock. T1 and T6 are the host CLOCK_MONOTONIC pair whose difference
+//     (T6-T1) is likewise self-consistent. Subtracting the two durations is
+//     valid because both clocks advance at ~1 ns/ns. Using a wall-clock T6
+//     here would instead make (T6-T1) a cross-domain difference and corrupt
+//     ProberDelay.
+func nowMonotonicNS() uint64 {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
+		// clock_gettime(CLOCK_MONOTONIC) does not fail in practice on Linux;
+		// fall back to the process-monotonic reading embedded in time.Now to
+		// avoid returning zero, which the RTT validator would reject.
+		return uint64(time.Now().UnixNano())
+	}
+	return uint64(ts.Nano())
 }
 
 // UpdateTargets replaces the current list of probe targets. This is called
@@ -142,6 +217,16 @@ func (p *Prober) UpdateTargets(targets []*controller_agent.PingTarget) {
 	p.targetsMu.Lock()
 	defer p.targetsMu.Unlock()
 	p.targets = targets
+
+	// Keep the aggregate limiter in sync with the per-target rate so the
+	// per-target cadence survives pinglist size changes. Lock order is
+	// always targetsMu -> rateMu.
+	p.rateMu.Lock()
+	if p.perTargetPPS > 0 {
+		p.limiter.SetRate(p.perTargetPPS * float64(len(targets)))
+	}
+	p.rateMu.Unlock()
+
 	p.logger.Info().
 		Int("count", len(targets)).
 		Msg("Probe targets updated")
@@ -162,7 +247,7 @@ func (p *Prober) probeLoop(ctx context.Context) {
 	ticker := time.NewTicker(p.probeInterval)
 	defer ticker.Stop()
 
-	var tickCount uint64
+	lastCleanup := time.Now()
 
 	p.logger.Info().
 		Dur("interval", p.probeInterval).
@@ -178,19 +263,24 @@ func (p *Prober) probeLoop(ctx context.Context) {
 			// the next ticker fire, which could be up to probeInterval away.
 			return
 		case <-ticker.C:
-			tickCount++
-			p.sendProbes()
+			p.sendProbes(ctx)
 
-			// Periodically clean up stale pending probes to prevent memory leaks.
-			if tickCount%stalePendingCleanupInterval == 0 {
+			// Clean up stale pending probes on a wall-clock cadence so the
+			// sweep frequency does not depend on the probe interval.
+			if time.Since(lastCleanup) >= stalePendingCleanupPeriod {
 				p.cleanupStalePending()
+				lastCleanup = time.Now()
 			}
 		}
 	}
 }
 
 // sendProbes reads the current target list and sends one probe to each target.
-func (p *Prober) sendProbes() {
+// It checks for shutdown (ctx cancellation or Stop) before each target so that
+// Stop() is not blocked for up to probeSendTimeoutMS * len(targets); each
+// SendProbe can block for up to probeSendTimeoutMS, so without these checks a
+// large target list could delay shutdown by many seconds.
+func (p *Prober) sendProbes(ctx context.Context) {
 	p.targetsMu.RLock()
 	targets := make([]*controller_agent.PingTarget, len(p.targets))
 	copy(targets, p.targets)
@@ -201,8 +291,24 @@ func (p *Prober) sendProbes() {
 	}
 
 	for _, target := range targets {
+		// Abort the batch promptly on shutdown instead of walking the entire
+		// target list while blocking on SendProbe for each one.
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopCh:
+			return
+		default:
+		}
+
 		if target == nil {
 			continue
+		}
+
+		// Apply the optional send-rate limit, spacing sends across targets.
+		// The wait is interruptible so Stop() is not delayed by the limiter.
+		if !p.rateLimitWait(ctx) {
+			return
 		}
 
 		// Generate a globally-unique sequence number:
@@ -239,12 +345,13 @@ func (p *Prober) sendProbes() {
 			continue
 		}
 
-		// Record the pending probe with T1 and T2 from the send result.
+		// Record the pending probe with T1 and T2 from the send result. The
+		// PendingMeasurement will absorb the two ACKs in whatever order they
+		// arrive.
 		p.pendingMu.Lock()
 		p.pending[seqNum] = &pendingProbe{
 			target:    target,
-			t1:        result.T1NS,
-			t2:        result.T2NS,
+			meas:      probe.NewPendingMeasurement(result.T1NS, result.T2NS),
 			createdAt: time.Now(),
 		}
 		p.pendingMu.Unlock()
@@ -256,6 +363,32 @@ func (p *Prober) sendProbes() {
 			Uint64("t1_ns", result.T1NS).
 			Uint64("t2_ns", result.T2NS).
 			Msg("Probe sent, awaiting ACKs")
+	}
+}
+
+// rateLimitWait blocks for the duration required by the configured send-rate
+// limit before the next probe may be sent. It returns false if the wait was
+// interrupted by ctx cancellation or Stop(), in which case the caller should
+// abandon the current send batch. When rate limiting is disabled it returns
+// true immediately.
+func (p *Prober) rateLimitWait(ctx context.Context) bool {
+	p.rateMu.Lock()
+	wait := p.limiter.Reserve(time.Now())
+	p.rateMu.Unlock()
+
+	if wait <= 0 {
+		return true
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-p.stopCh:
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -357,9 +490,10 @@ func (p *Prober) handleACKEvent(event *rdmabridge.CompletionEvent) {
 	}
 }
 
-// handleFirstACK processes a first ACK event. It extracts T3 (responder
-// recv timestamp) and records T5 (prober recv timestamp from the NIC HW
-// or SW timestamp on this completion).
+// handleFirstACK processes a first ACK event. It records T3 (responder recv
+// timestamp, authoritative from the first ACK) and T5 (prober recv timestamp
+// from the NIC HW or SW timestamp on this completion). If the second ACK has
+// already arrived, this completes the measurement.
 func (p *Prober) handleFirstACK(seqNum uint64, event *rdmabridge.CompletionEvent) {
 	p.pendingMu.Lock()
 	pp, ok := p.pending[seqNum]
@@ -371,31 +505,36 @@ func (p *Prober) handleFirstACK(seqNum uint64, event *rdmabridge.CompletionEvent
 		return
 	}
 
-	// T3 is the responder's recv timestamp, carried in the ACK event.
-	pp.t3 = event.T3
-
-	// T5 is the prober's recv timestamp for the first ACK, taken from
-	// the NIC completion event (HW or SW timestamp).
-	pp.t5 = event.TimestampNS
-
+	// T5 is the prober's recv timestamp for the first ACK, taken from the NIC
+	// completion event (HW or SW timestamp). T3 is the responder recv timestamp
+	// carried in the ACK payload.
+	pp.meas.ApplyFirstAck(event.T3, event.TimestampNS)
+	result := p.finalizeIfCompleteLocked(seqNum, pp)
 	p.pendingMu.Unlock()
 
 	p.logger.Debug().
 		Uint64("seq", seqNum).
-		Uint64("t3_ns", pp.t3).
-		Uint64("t5_ns", pp.t5).
+		Uint64("t3_ns", event.T3).
+		Uint64("t5_ns", event.TimestampNS).
 		Msg("First ACK received")
+
+	if result != nil {
+		p.deliverResult(seqNum, pp.target, result)
+	}
 }
 
 // handleSecondACK processes a second ACK event, which carries T3 and T4
-// (responder-side timestamps). T6 is captured as the current Go monotonic
-// time since the ring buffer completion event does not provide a Go-side
-// timestamp for the second ACK arrival. With all 6 timestamps available,
-// it builds a ProbeResult, calculates RTT, and sends the result to the
-// results channel.
+// (responder-side timestamps). T6 is captured on the prober host from
+// CLOCK_MONOTONIC (the same clock domain as T1) because the ring buffer
+// completion event does not carry a host-side timestamp for the second ACK
+// arrival. If the first ACK has already arrived, this completes the
+// measurement; otherwise the pending entry waits for it (out-of-order ACKs are
+// supported).
 func (p *Prober) handleSecondACK(seqNum uint64, event *rdmabridge.CompletionEvent) {
-	// Capture T6 immediately upon processing the second ACK.
-	t6 := uint64(time.Now().UnixNano())
+	// Capture T6 immediately upon processing the second ACK, using the same
+	// CLOCK_MONOTONIC domain as T1 so that (T6 - T1) in ProberDelay is a valid
+	// same-domain difference.
+	t6 := nowMonotonicNS()
 
 	p.pendingMu.Lock()
 	pp, ok := p.pending[seqNum]
@@ -407,50 +546,60 @@ func (p *Prober) handleSecondACK(seqNum uint64, event *rdmabridge.CompletionEven
 		return
 	}
 
-	// The second ACK carries T3 and T4 in the event payload. If the first
-	// ACK has already filled T3, prefer the first ACK's value (it arrived
-	// earlier and is more accurate). Otherwise, use the second ACK's T3.
-	t3 := pp.t3
-	if t3 == 0 {
-		t3 = event.T3
+	// The second ACK carries T3 and T4 in the event payload. T3 here is only
+	// used if the first ACK has not yet supplied it (see PendingMeasurement).
+	pp.meas.ApplySecondAck(event.T3, event.T4, t6)
+	result := p.finalizeIfCompleteLocked(seqNum, pp)
+	p.pendingMu.Unlock()
+
+	p.logger.Debug().
+		Uint64("seq", seqNum).
+		Uint64("t4_ns", event.T4).
+		Uint64("t6_ns", t6).
+		Msg("Second ACK received")
+
+	if result != nil {
+		p.deliverResult(seqNum, pp.target, result)
 	}
-	t4 := event.T4
+}
+
+// finalizeIfCompleteLocked builds a ProbeResult and removes the pending entry
+// once both ACKs have arrived. It returns nil while the measurement is still
+// waiting for the other ACK. The caller must hold pendingMu.
+func (p *Prober) finalizeIfCompleteLocked(seqNum uint64, pp *pendingProbe) *probe.ProbeResult {
+	if !pp.meas.Complete() {
+		return nil
+	}
 
 	// Build the target GID from the pending probe's target information.
 	var targetGID [16]byte
-	parsedGID, err := probe.ParseGID(pp.target.GetTargetGid())
-	if err == nil {
+	if parsedGID, err := probe.ParseGID(pp.target.GetTargetGid()); err == nil {
 		targetGID = parsedGID
 	}
 
-	// Construct the complete ProbeResult with all 6 timestamps.
-	result := &probe.ProbeResult{
-		SequenceNum:    seqNum,
-		TargetGID:      targetGID,
-		TargetQPN:      pp.target.GetTargetQpn(),
-		FlowLabel:      pp.target.GetFlowLabel(),
-		T1:             pp.t1,
-		T2:             pp.t2,
-		T3:             t3,
-		T4:             t4,
-		T5:             pp.t5,
-		T6:             t6,
-		Success:        true,
-		TargetIP:       pp.target.GetTargetIp(),
-		TargetHostname: pp.target.GetTargetHostname(),
-		TargetTorID:    pp.target.GetTargetTorId(),
-	}
+	result := pp.meas.Result()
+	result.SequenceNum = seqNum
+	result.TargetGID = targetGID
+	result.TargetQPN = pp.target.GetTargetQpn()
+	result.FlowLabel = pp.target.GetFlowLabel()
+	result.Success = true
+	result.TargetIP = pp.target.GetTargetIp()
+	result.TargetHostname = pp.target.GetTargetHostname()
+	result.TargetTorID = pp.target.GetTargetTorId()
 
-	// Remove from pending map now that the probe is complete.
 	delete(p.pending, seqNum)
-	p.pendingMu.Unlock()
+	return &result
+}
 
-	// Calculate RTT metrics from the 6 timestamps.
+// deliverResult computes RTT metrics for a completed probe and emits it on the
+// results channel. It is called without holding pendingMu so a slow consumer
+// cannot stall ACK processing under the lock.
+func (p *Prober) deliverResult(seqNum uint64, target *controller_agent.PingTarget, result *probe.ProbeResult) {
 	rtt := probe.CalculateRTT(result)
 
 	p.logger.Debug().
 		Uint64("seq", seqNum).
-		Str("target_gid", pp.target.GetTargetGid()).
+		Str("target_gid", target.GetTargetGid()).
 		Uint64("t1", result.T1).
 		Uint64("t2", result.T2).
 		Uint64("t3", result.T3).
@@ -476,30 +625,63 @@ func (p *Prober) handleSecondACK(seqNum uint64, event *rdmabridge.CompletionEven
 
 // cleanupStalePending removes entries from the pending map that are older
 // than stalePendingTimeout. This prevents memory leaks from probes whose
-// ACK responses were lost or never arrived.
+// ACK responses were lost or never arrived. Each expired probe is emitted as
+// a failed ProbeResult so packet loss / timeouts are visible in the
+// probe_failed_total metric instead of vanishing silently.
 func (p *Prober) cleanupStalePending() {
 	now := time.Now()
-	var cleaned int
+	var stale []*probe.ProbeResult
 
 	p.pendingMu.Lock()
 	for seqNum, pp := range p.pending {
 		if now.Sub(pp.createdAt) > stalePendingTimeout {
+			result := pp.meas.Result()
+			result.SequenceNum = seqNum
+			result.TargetQPN = pp.target.GetTargetQpn()
+			result.FlowLabel = pp.target.GetFlowLabel()
+			result.Success = false
+			result.ErrorMessage = "timed out waiting for ACKs"
+			result.TargetIP = pp.target.GetTargetIp()
+			result.TargetHostname = pp.target.GetTargetHostname()
+			result.TargetTorID = pp.target.GetTargetTorId()
+			if parsedGID, err := probe.ParseGID(pp.target.GetTargetGid()); err == nil {
+				result.TargetGID = parsedGID
+			}
+			stale = append(stale, &result)
 			delete(p.pending, seqNum)
-			cleaned++
 		}
 	}
 	p.pendingMu.Unlock()
 
-	if cleaned > 0 {
+	// Emit outside pendingMu; non-blocking like deliverResult so a slow
+	// consumer cannot stall the probe loop.
+	for _, result := range stale {
+		select {
+		case p.resultChan <- result:
+		default:
+			p.logger.Warn().
+				Uint64("seq", result.SequenceNum).
+				Msg("Result channel full, dropping timed-out probe result")
+		}
+	}
+
+	if len(stale) > 0 {
 		p.logger.Info().
-			Int("cleaned", cleaned).
-			Msg("Cleaned up stale pending probes")
+			Int("cleaned", len(stale)).
+			Msg("Expired stale pending probes emitted as failures")
 	}
 }
 
 // GetQueueInfo returns the queue metadata (QPN, timestamp mode) for this
-// prober's sender queue. This can be used for logging and diagnostics.
+// prober's sender queue. This can be used for logging and diagnostics. It is
+// safe to call after Destroy(): a zero-valued QueueInfo is returned once the
+// queue has been torn down.
 func (p *Prober) GetQueueInfo() rdmabridge.QueueInfo {
+	p.queueMu.RLock()
+	defer p.queueMu.RUnlock()
+	if p.queue == nil {
+		return rdmabridge.QueueInfo{}
+	}
 	return p.queue.Info
 }
 
@@ -512,9 +694,11 @@ func (p *Prober) GetQueueInfo() rdmabridge.QueueInfo {
 func (p *Prober) Destroy() {
 	p.Stop()
 	close(p.resultChan)
+	p.queueMu.Lock()
 	if p.queue != nil {
 		p.queue.Destroy()
 		p.queue = nil
 	}
+	p.queueMu.Unlock()
 	p.logger.Info().Msg("Prober destroyed")
 }

--- a/rebuild/internal/agent/responder.go
+++ b/rebuild/internal/agent/responder.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"encoding/binary"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -26,8 +25,15 @@ type Responder struct {
 	ring    *rdmabridge.EventRing
 	device  *rdmabridge.Device
 	running atomic.Bool
+	stopMu  sync.Mutex    // guards stopCh (re)creation across Start/Stop
+	stopCh  chan struct{} // closed by Stop() to wake the process loop immediately
 	wg      sync.WaitGroup
-	logger  zerolog.Logger
+
+	// queueMu guards access to the queue pointer so that GetQueueInfo cannot
+	// race with Destroy() setting queue to nil.
+	queueMu sync.RWMutex
+
+	logger zerolog.Logger
 }
 
 // NewResponder creates a new Responder with a responder-type RDMA queue
@@ -56,6 +62,13 @@ func (r *Responder) Start(ctx context.Context) error {
 		return nil // already running
 	}
 
+	// Recreate stopCh so the responder can be restarted after a previous
+	// Stop() closed it. Stop() has already waited for the old goroutine to
+	// exit (running is false here), so nothing references the old channel.
+	r.stopMu.Lock()
+	r.stopCh = make(chan struct{})
+	r.stopMu.Unlock()
+
 	r.wg.Add(1)
 	go r.processLoop(ctx)
 
@@ -66,11 +79,15 @@ func (r *Responder) Start(ctx context.Context) error {
 }
 
 // Stop signals the responder to stop processing and waits for the
-// background goroutine to exit.
+// background goroutine to exit. Closing stopCh wakes the loop immediately
+// instead of waiting out an idle sleep or a long in-flight ACK batch.
 func (r *Responder) Stop() {
 	if !r.running.CompareAndSwap(true, false) {
 		return // not running
 	}
+	r.stopMu.Lock()
+	close(r.stopCh)
+	r.stopMu.Unlock()
 	r.wg.Wait()
 	r.logger.Info().Msg("Responder stopped")
 }
@@ -87,22 +104,57 @@ func (r *Responder) processLoop(ctx context.Context) {
 		idleSleep = 100 * time.Microsecond
 	)
 
+	// idleTimer is reused on each empty-poll iteration to avoid allocating a
+	// new timer on every spin.
+	idleTimer := time.NewTimer(idleSleep)
+	defer idleTimer.Stop()
+
 	for r.running.Load() {
-		// Check for context cancellation.
+		// Check for shutdown or context cancellation on every iteration.
 		select {
 		case <-ctx.Done():
 			r.running.Store(false)
+			return
+		case <-r.stopCh:
 			return
 		default:
 		}
 
 		events := r.ring.Poll(maxBatch)
 		if len(events) == 0 {
-			time.Sleep(idleSleep)
+			// No events yet; wait briefly, but wake immediately on shutdown so
+			// Stop() is not delayed by the idle sleep.
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
+				}
+			}
+			idleTimer.Reset(idleSleep)
+			select {
+			case <-ctx.Done():
+				r.running.Store(false)
+				return
+			case <-r.stopCh:
+				return
+			case <-idleTimer.C:
+			}
 			continue
 		}
 
 		for i := range events {
+			// Each handleEvent may block for up to two ACK sends
+			// (ackSendTimeoutMS each). Across a full batch that is many
+			// seconds, so check for shutdown before every event to keep Stop()
+			// responsive.
+			select {
+			case <-ctx.Done():
+				r.running.Store(false)
+				return
+			case <-r.stopCh:
+				return
+			default:
+			}
 			r.handleEvent(&events[i])
 		}
 	}
@@ -189,8 +241,14 @@ func (r *Responder) handleEvent(event *rdmabridge.CompletionEvent) {
 
 // GetQueueInfo returns the queue metadata (QPN, timestamp mode) for
 // registration with the controller so that remote probers know where
-// to send probes.
+// to send probes. It is safe to call after Destroy(): a zero-valued QueueInfo
+// is returned once the queue has been torn down.
 func (r *Responder) GetQueueInfo() rdmabridge.QueueInfo {
+	r.queueMu.RLock()
+	defer r.queueMu.RUnlock()
+	if r.queue == nil {
+		return rdmabridge.QueueInfo{}
+	}
 	return r.queue.Info
 }
 
@@ -198,10 +256,12 @@ func (r *Responder) GetQueueInfo() rdmabridge.QueueInfo {
 // RDMA queue, freeing all associated resources (QP, CQ, MRs).
 func (r *Responder) Destroy() {
 	r.Stop()
+	r.queueMu.Lock()
 	if r.queue != nil {
 		r.queue.Destroy()
 		r.queue = nil
 	}
+	r.queueMu.Unlock()
 	r.logger.Info().Msg("Responder destroyed")
 }
 
@@ -224,15 +284,20 @@ func (r *Responder) Destroy() {
 func buildRecvPacketPayload(event *rdmabridge.CompletionEvent) []byte {
 	buf := make([]byte, rdmabridge.ProbePacketSize)
 
-	buf[0] = rdmabridge.PacketVersion
-	buf[1] = rdmabridge.MsgTypeProbe
-	buf[2] = rdmabridge.AckTypeNone
-	buf[3] = event.Flags
-	binary.BigEndian.PutUint64(buf[4:12], event.SequenceNum)
-	binary.BigEndian.PutUint64(buf[12:20], event.T1)
-	binary.BigEndian.PutUint64(buf[20:28], event.T3)
-	binary.BigEndian.PutUint64(buf[28:36], event.T4)
-	// bytes 36-39: reserved padding (already zero from make)
+	// Reuse the single canonical wire-format serializer so the offset layout
+	// lives in exactly one place (rdmabridge.SerializeProbePacket) rather than
+	// being re-implemented here.
+	pkt := &rdmabridge.ProbePacket{
+		Version:     rdmabridge.PacketVersion,
+		MsgType:     rdmabridge.MsgTypeProbe,
+		AckType:     rdmabridge.AckTypeNone,
+		Flags:       event.Flags,
+		SequenceNum: event.SequenceNum,
+		T1:          event.T1,
+		T3:          event.T3,
+		T4:          event.T4,
+	}
+	rdmabridge.SerializeProbePacket(pkt, buf)
 
 	return buf
 }

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -28,10 +28,14 @@ type AgentConfig struct {
 	TargetProbeRatePerSecond  int      `mapstructure:"target_probe_rate_per_second"`
 }
 
-// LoadAgentConfig loads agent configuration from a YAML file, environment variables,
-// and applies defaults. Environment variables use the prefix RPINGMESH_ and replace
-// hyphens with underscores (e.g., RPINGMESH_CONTROLLER_ADDR).
-func LoadAgentConfig(configPath string) (*AgentConfig, error) {
+// LoadAgentConfig loads agent configuration from a YAML file, environment
+// variables, CLI flags, and applies defaults. Precedence (highest to
+// lowest) is: CLI flag > environment variable > YAML file > default.
+// Environment variables use the prefix RPINGMESH_ and replace hyphens with
+// underscores (e.g., RPINGMESH_CONTROLLER_ADDR). If flags is non-nil, it is
+// bound to viper so that explicitly-set flags take priority; pass the same
+// FlagSet given to BindAgentFlags.
+func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, error) {
 	v := viper.New()
 
 	// Set defaults
@@ -53,6 +57,14 @@ func LoadAgentConfig(configPath string) (*AgentConfig, error) {
 	v.SetEnvPrefix("RPINGMESH")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
+
+	// Bind CLI flags so that explicitly-set flags take precedence over
+	// environment variables, config file values, and defaults.
+	if flags != nil {
+		if err := bindPFlags(v, flags); err != nil {
+			return nil, err
+		}
+	}
 
 	// Load config file if a path was provided
 	if configPath != "" {
@@ -106,12 +118,28 @@ func LoadAgentConfig(configPath string) (*AgentConfig, error) {
 		TargetProbeRatePerSecond:  v.GetInt("target_probe_rate_per_second"),
 	}
 
-	// Validate GID index is non-negative
-	if config.GIDIndex < 0 {
-		return nil, fmt.Errorf("gid_index must be >= 0, got: %d", config.GIDIndex)
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	return config, nil
+}
+
+// Validate checks that the agent configuration is well-formed. It returns
+// an error describing the first invalid field encountered.
+func (c *AgentConfig) Validate() error {
+	// GID index must be non-negative; it indexes into the RNIC's GID table.
+	if c.GIDIndex < 0 {
+		return fmt.Errorf("gid_index must be >= 0, got: %d", c.GIDIndex)
+	}
+
+	// A zero or negative probe interval would make time.NewTicker panic at
+	// runtime, so reject it up front instead of failing deep in the prober.
+	if c.ProbeIntervalMS == 0 {
+		return fmt.Errorf("probe_interval_ms must be > 0, got: %d", c.ProbeIntervalMS)
+	}
+
+	return nil
 }
 
 // BindAgentFlags binds common agent CLI flags to a pflag.FlagSet.

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -1,0 +1,312 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// writeYAML writes content to a temp file named name inside t.TempDir() and
+// returns its path.
+func writeYAML(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+	return path
+}
+
+// --- ControllerConfig ---
+
+func TestLoadControllerConfig_Defaults(t *testing.T) {
+	cfg, err := LoadControllerConfig("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ListenAddr != ":50051" {
+		t.Errorf("ListenAddr = %q, want :50051", cfg.ListenAddr)
+	}
+	if cfg.DatabaseURI != "http://localhost:4001" {
+		t.Errorf("DatabaseURI = %q, want http://localhost:4001", cfg.DatabaseURI)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want info", cfg.LogLevel)
+	}
+	if cfg.ActiveThresholdSec != DefaultActiveThresholdSec {
+		t.Errorf("ActiveThresholdSec = %d, want %d", cfg.ActiveThresholdSec, DefaultActiveThresholdSec)
+	}
+	if cfg.StaleThresholdSec != DefaultStaleThresholdSec {
+		t.Errorf("StaleThresholdSec = %d, want %d", cfg.StaleThresholdSec, DefaultStaleThresholdSec)
+	}
+	if cfg.InterTorSampleSize != DefaultInterTorSampleSize {
+		t.Errorf("InterTorSampleSize = %d, want %d", cfg.InterTorSampleSize, DefaultInterTorSampleSize)
+	}
+}
+
+func TestLoadControllerConfig_FileOverridesDefault(t *testing.T) {
+	path := writeYAML(t, "controller.yaml", "listen_addr: \":9000\"\n")
+
+	cfg, err := LoadControllerConfig(path, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenAddr != ":9000" {
+		t.Errorf("ListenAddr = %q, want :9000 (from file)", cfg.ListenAddr)
+	}
+	// Untouched keys still fall back to defaults.
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want info (default)", cfg.LogLevel)
+	}
+}
+
+func TestLoadControllerConfig_EnvOverridesFile(t *testing.T) {
+	path := writeYAML(t, "controller.yaml", "listen_addr: \":9000\"\n")
+	t.Setenv("RPINGMESH_LISTEN_ADDR", ":9100")
+
+	cfg, err := LoadControllerConfig(path, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenAddr != ":9100" {
+		t.Errorf("ListenAddr = %q, want :9100 (env overrides file)", cfg.ListenAddr)
+	}
+}
+
+func TestLoadControllerConfig_FlagOverridesEnvAndFile(t *testing.T) {
+	path := writeYAML(t, "controller.yaml", "listen_addr: \":9000\"\n")
+	t.Setenv("RPINGMESH_LISTEN_ADDR", ":9100")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	BindControllerFlags(flags)
+	if err := flags.Set("listen-addr", ":9200"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg, err := LoadControllerConfig(path, flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenAddr != ":9200" {
+		t.Errorf("ListenAddr = %q, want :9200 (flag overrides env and file)", cfg.ListenAddr)
+	}
+}
+
+func TestLoadControllerConfig_UnsetFlagDoesNotOverrideEnv(t *testing.T) {
+	t.Setenv("RPINGMESH_LISTEN_ADDR", ":9100")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	BindControllerFlags(flags)
+	// Do not call flags.Set: the flag keeps its unset default value and
+	// must not shadow the environment variable.
+
+	cfg, err := LoadControllerConfig("", flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenAddr != ":9100" {
+		t.Errorf("ListenAddr = %q, want :9100 (unset flag must not override env)", cfg.ListenAddr)
+	}
+}
+
+func TestLoadControllerConfig_InvalidLogLevel(t *testing.T) {
+	t.Setenv("RPINGMESH_LOG_LEVEL", "not-a-level")
+
+	if _, err := LoadControllerConfig("", nil); err == nil {
+		t.Fatal("expected an error for an invalid log_level, got nil")
+	}
+}
+
+func TestLoadControllerConfig_InvalidDatabaseURI(t *testing.T) {
+	t.Setenv("RPINGMESH_DATABASE_URI", "not a url")
+
+	if _, err := LoadControllerConfig("", nil); err == nil {
+		t.Fatal("expected an error for an invalid database_uri, got nil")
+	}
+}
+
+func TestLoadControllerConfig_EmptyListenAddr(t *testing.T) {
+	// Note: an empty *environment variable* is treated by viper as unset
+	// (see Viper's getEnv, which only honors env vars with a non-empty
+	// value unless AllowEmptyEnv is set), so an explicit empty value must
+	// come from the config file to exercise this validation path.
+	path := writeYAML(t, "controller.yaml", "listen_addr: \"\"\n")
+
+	if _, err := LoadControllerConfig(path, nil); err == nil {
+		t.Fatal("expected an error for an empty listen_addr, got nil")
+	}
+}
+
+func TestControllerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ControllerConfig
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid listen addr",
+			cfg: ControllerConfig{
+				ListenAddr: "not-a-valid-addr-no-colon", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-positive active threshold",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 0, StaleThresholdSec: 900, InterTorSampleSize: 5,
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-positive stale threshold",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: -1, InterTorSampleSize: 5,
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-positive inter-tor sample size",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 0,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// --- AgentConfig ---
+
+func TestLoadAgentConfig_Defaults(t *testing.T) {
+	cfg, err := LoadAgentConfig("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ControllerAddr != "localhost:50051" {
+		t.Errorf("ControllerAddr = %q, want localhost:50051", cfg.ControllerAddr)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want info", cfg.LogLevel)
+	}
+	if cfg.ProbeIntervalMS != 500 {
+		t.Errorf("ProbeIntervalMS = %d, want 500", cfg.ProbeIntervalMS)
+	}
+	if !cfg.MetricsEnabled {
+		t.Error("MetricsEnabled = false, want true")
+	}
+	if cfg.TargetProbeRatePerSecond != DefaultTargetProbeRatePerSecond {
+		t.Errorf("TargetProbeRatePerSecond = %d, want %d", cfg.TargetProbeRatePerSecond, DefaultTargetProbeRatePerSecond)
+	}
+	// AgentID and HostName fall back to the OS hostname when unset.
+	if cfg.AgentID == "" {
+		t.Error("AgentID should fall back to hostname, got empty string")
+	}
+	if cfg.HostName == "" {
+		t.Error("HostName should be auto-detected, got empty string")
+	}
+}
+
+func TestLoadAgentConfig_FlagOverridesEnvAndFile(t *testing.T) {
+	path := writeYAML(t, "agent.yaml", "controller_addr: \"file-addr:1\"\n")
+	t.Setenv("RPINGMESH_CONTROLLER_ADDR", "env-addr:2")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	BindAgentFlags(flags)
+	if err := flags.Set("controller-addr", "flag-addr:3"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	cfg, err := LoadAgentConfig(path, flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ControllerAddr != "flag-addr:3" {
+		t.Errorf("ControllerAddr = %q, want flag-addr:3 (flag overrides env and file)", cfg.ControllerAddr)
+	}
+}
+
+func TestLoadAgentConfig_EnvOverridesFile(t *testing.T) {
+	path := writeYAML(t, "agent.yaml", "controller_addr: \"file-addr:1\"\n")
+	t.Setenv("RPINGMESH_CONTROLLER_ADDR", "env-addr:2")
+
+	cfg, err := LoadAgentConfig(path, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ControllerAddr != "env-addr:2" {
+		t.Errorf("ControllerAddr = %q, want env-addr:2 (env overrides file)", cfg.ControllerAddr)
+	}
+}
+
+func TestLoadAgentConfig_NegativeGIDIndex(t *testing.T) {
+	t.Setenv("RPINGMESH_GID_INDEX", "-1")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for a negative gid_index, got nil")
+	}
+}
+
+func TestLoadAgentConfig_ZeroProbeInterval(t *testing.T) {
+	t.Setenv("RPINGMESH_PROBE_INTERVAL_MS", "0")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for probe_interval_ms=0 (would panic time.NewTicker), got nil")
+	}
+}
+
+func TestAgentConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     AgentConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid",
+			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 500},
+			wantErr: false,
+		},
+		{
+			name:    "negative gid index",
+			cfg:     AgentConfig{GIDIndex: -1, ProbeIntervalMS: 500},
+			wantErr: true,
+		},
+		{
+			name:    "zero probe interval",
+			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 0},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/rebuild/internal/config/controller_config.go
+++ b/rebuild/internal/config/controller_config.go
@@ -2,35 +2,72 @@ package config
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
+// Default threshold values for the controller's RNIC registry. These mirror
+// registry.Default{Active,Stale}ThresholdSec / DefaultInterTorSampleSize so
+// that config defaults and registry defaults stay in sync without the
+// config package importing the controller/registry package.
+const (
+	// DefaultActiveThresholdSec is the window (seconds) within which an
+	// RNIC entry is considered "active" for pinglist generation.
+	DefaultActiveThresholdSec = 300
+	// DefaultStaleThresholdSec is the window (seconds) after which an RNIC
+	// entry is considered stale and removed.
+	DefaultStaleThresholdSec = 900
+	// DefaultInterTorSampleSize is the default number of distinct ToRs
+	// sampled for inter-ToR pinglist generation.
+	DefaultInterTorSampleSize = 5
+)
+
 // ControllerConfig holds all configuration for the controller.
 type ControllerConfig struct {
-	ListenAddr  string `mapstructure:"listen_addr"`
-	DatabaseURI string `mapstructure:"database_uri"`
-	LogLevel    string `mapstructure:"log_level"`
+	ListenAddr         string `mapstructure:"listen_addr"`
+	DatabaseURI        string `mapstructure:"database_uri"`
+	LogLevel           string `mapstructure:"log_level"`
+	ActiveThresholdSec int    `mapstructure:"active_threshold_sec"`
+	StaleThresholdSec  int    `mapstructure:"stale_threshold_sec"`
+	InterTorSampleSize int    `mapstructure:"inter_tor_sample_size"`
 }
 
-// LoadControllerConfig loads controller configuration from a YAML file, environment
-// variables, and applies defaults. Environment variables use the prefix RPINGMESH_
-// and replace dots with underscores (e.g., RPINGMESH_LISTEN_ADDR).
-func LoadControllerConfig(configPath string) (*ControllerConfig, error) {
+// LoadControllerConfig loads controller configuration from a YAML file,
+// environment variables, CLI flags, and applies defaults. Precedence
+// (highest to lowest) is: CLI flag > environment variable > YAML file >
+// default. Environment variables use the prefix RPINGMESH_ and replace dots
+// with underscores (e.g., RPINGMESH_LISTEN_ADDR). If flags is non-nil, it is
+// bound to viper via BindPFlags so that explicitly-set flags take priority;
+// pass the same FlagSet given to BindControllerFlags.
+func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerConfig, error) {
 	v := viper.New()
 
 	// Set defaults
 	v.SetDefault("listen_addr", ":50051")
 	v.SetDefault("database_uri", "http://localhost:4001")
 	v.SetDefault("log_level", "info")
+	v.SetDefault("active_threshold_sec", DefaultActiveThresholdSec)
+	v.SetDefault("stale_threshold_sec", DefaultStaleThresholdSec)
+	v.SetDefault("inter_tor_sample_size", DefaultInterTorSampleSize)
 
 	// Enable environment variable override with RPINGMESH_ prefix
 	v.SetEnvPrefix("RPINGMESH")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
+
+	// Bind CLI flags so that explicitly-set flags take precedence over
+	// environment variables, config file values, and defaults.
+	if flags != nil {
+		if err := bindPFlags(v, flags); err != nil {
+			return nil, err
+		}
+	}
 
 	// Load config file if a path was provided
 	if configPath != "" {
@@ -54,12 +91,75 @@ func LoadControllerConfig(configPath string) (*ControllerConfig, error) {
 	}
 
 	config := &ControllerConfig{
-		ListenAddr:  v.GetString("listen_addr"),
-		DatabaseURI: v.GetString("database_uri"),
-		LogLevel:    v.GetString("log_level"),
+		ListenAddr:         v.GetString("listen_addr"),
+		DatabaseURI:        v.GetString("database_uri"),
+		LogLevel:           v.GetString("log_level"),
+		ActiveThresholdSec: v.GetInt("active_threshold_sec"),
+		StaleThresholdSec:  v.GetInt("stale_threshold_sec"),
+		InterTorSampleSize: v.GetInt("inter_tor_sample_size"),
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
 	}
 
 	return config, nil
+}
+
+// bindPFlags binds each flag in flags to v under a key with hyphens
+// replaced by underscores (e.g. "listen-addr" -> "listen_addr"), so that CLI
+// flag names resolve to the same viper key used by the YAML config,
+// environment variables (via SetEnvKeyReplacer), and struct mapstructure
+// tags. viper.BindPFlags alone would bind flags under their literal
+// hyphenated names, which would never match a "_"-separated lookup key and
+// would silently make flags dead weight.
+func bindPFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	var bindErr error
+	flags.VisitAll(func(f *pflag.Flag) {
+		if bindErr != nil {
+			return
+		}
+		key := strings.ReplaceAll(f.Name, "-", "_")
+		if err := v.BindPFlag(key, f); err != nil {
+			bindErr = fmt.Errorf("failed to bind flag %q: %w", f.Name, err)
+		}
+	})
+	return bindErr
+}
+
+// Validate checks that the controller configuration is well-formed. It
+// returns an error describing the first invalid field encountered.
+func (c *ControllerConfig) Validate() error {
+	if strings.TrimSpace(c.ListenAddr) == "" {
+		return fmt.Errorf("listen_addr must not be empty")
+	}
+	if _, _, err := net.SplitHostPort(c.ListenAddr); err != nil {
+		return fmt.Errorf("listen_addr %q is not a valid address: %w", c.ListenAddr, err)
+	}
+
+	if strings.TrimSpace(c.DatabaseURI) == "" {
+		return fmt.Errorf("database_uri must not be empty")
+	}
+	u, err := url.Parse(c.DatabaseURI)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("database_uri %q is not a valid URL", c.DatabaseURI)
+	}
+
+	if _, err := zerolog.ParseLevel(c.LogLevel); err != nil {
+		return fmt.Errorf("log_level %q is not a known level: %w", c.LogLevel, err)
+	}
+
+	if c.ActiveThresholdSec <= 0 {
+		return fmt.Errorf("active_threshold_sec must be > 0, got: %d", c.ActiveThresholdSec)
+	}
+	if c.StaleThresholdSec <= 0 {
+		return fmt.Errorf("stale_threshold_sec must be > 0, got: %d", c.StaleThresholdSec)
+	}
+	if c.InterTorSampleSize <= 0 {
+		return fmt.Errorf("inter_tor_sample_size must be > 0, got: %d", c.InterTorSampleSize)
+	}
+
+	return nil
 }
 
 // BindControllerFlags binds common controller CLI flags to a pflag.FlagSet.
@@ -68,4 +168,7 @@ func BindControllerFlags(flags *pflag.FlagSet) {
 	flags.String("listen-addr", ":50051", "Address to listen on for gRPC connections")
 	flags.String("database-uri", "http://localhost:4001", "rqlite database connection URI")
 	flags.String("log-level", "info", "Log level (debug, info, warn, error)")
+	flags.Int("active-threshold-sec", DefaultActiveThresholdSec, "Window (seconds) within which an RNIC is considered active")
+	flags.Int("stale-threshold-sec", DefaultStaleThresholdSec, "Window (seconds) after which an inactive RNIC is removed")
+	flags.Int("inter-tor-sample-size", DefaultInterTorSampleSize, "Number of distinct ToRs sampled for inter-ToR pinglists")
 }

--- a/rebuild/internal/controller/pinglist/pinglist.go
+++ b/rebuild/internal/controller/pinglist/pinglist.go
@@ -5,17 +5,25 @@ import (
 	"hash/fnv"
 
 	"github.com/rs/zerolog/log"
-	"github.com/yuuki/rpingmesh/rebuild/internal/controller/registry"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 )
 
-// PinglistGenerator generates probe target lists for agents.
-type PinglistGenerator struct {
-	registry *registry.RnicRegistry
+// RnicSource is the subset of registry.RnicRegistry's read API required to
+// generate pinglists. It is declared here, at the point of use, so that
+// PinglistGenerator can be unit tested against a fake instead of a real
+// rqlite-backed registry.
+type RnicSource interface {
+	GetRNICsByToR(ctx context.Context, torID string) ([]*controller_agent.RnicInfo, error)
+	GetSampleRNICsFromOtherToRs(ctx context.Context, excludeTorID string) ([]*controller_agent.RnicInfo, error)
 }
 
-// NewPinglistGenerator creates a new PinglistGenerator backed by the given RNIC registry.
-func NewPinglistGenerator(registry *registry.RnicRegistry) *PinglistGenerator {
+// PinglistGenerator generates probe target lists for agents.
+type PinglistGenerator struct {
+	registry RnicSource
+}
+
+// NewPinglistGenerator creates a new PinglistGenerator backed by the given RNIC source.
+func NewPinglistGenerator(registry RnicSource) *PinglistGenerator {
 	return &PinglistGenerator{
 		registry: registry,
 	}

--- a/rebuild/internal/controller/pinglist/pinglist_test.go
+++ b/rebuild/internal/controller/pinglist/pinglist_test.go
@@ -1,0 +1,103 @@
+package pinglist
+
+import "testing"
+
+// TestDeterministicFlowLabel_Deterministic verifies that the same
+// requester/target GID pair always produces the same flow label, and that
+// swapping the pair (or changing either GID) changes the result.
+func TestDeterministicFlowLabel_Deterministic(t *testing.T) {
+	requesterGID := "fe80::1"
+	targetGID := "fe80::2"
+
+	got1 := deterministicFlowLabel(requesterGID, targetGID)
+	got2 := deterministicFlowLabel(requesterGID, targetGID)
+	if got1 != got2 {
+		t.Fatalf("deterministicFlowLabel is not deterministic: %d != %d", got1, got2)
+	}
+
+	if reversed := deterministicFlowLabel(targetGID, requesterGID); reversed == got1 {
+		t.Errorf("deterministicFlowLabel(target, requester) = %d, expected different value than deterministicFlowLabel(requester, target) = %d", reversed, got1)
+	}
+
+	if other := deterministicFlowLabel(requesterGID, "fe80::3"); other == got1 {
+		t.Errorf("deterministicFlowLabel with a different targetGID unexpectedly matched: %d", other)
+	}
+}
+
+// TestDeterministicFlowLabel_Range verifies that the flow label is always
+// masked to 20 bits (0-0xFFFFF), as required for ibv_ah_attr.grh.flow_label.
+func TestDeterministicFlowLabel_Range(t *testing.T) {
+	pairs := [][2]string{
+		{"fe80::1", "fe80::2"},
+		{"fe80::aaaa", "fe80::bbbb"},
+		{"", ""},
+		{"a", "b"},
+	}
+
+	for _, p := range pairs {
+		got := deterministicFlowLabel(p[0], p[1])
+		if got > 0xFFFFF {
+			t.Errorf("deterministicFlowLabel(%q, %q) = %#x, want <= 0xFFFFF", p[0], p[1], got)
+		}
+	}
+}
+
+// TestDeterministicSourcePort_Deterministic verifies determinism and that
+// the salt differentiates the source port hash from the flow label hash.
+func TestDeterministicSourcePort_Deterministic(t *testing.T) {
+	requesterGID := "fe80::1"
+	targetGID := "fe80::2"
+
+	got1 := deterministicSourcePort(requesterGID, targetGID)
+	got2 := deterministicSourcePort(requesterGID, targetGID)
+	if got1 != got2 {
+		t.Fatalf("deterministicSourcePort is not deterministic: %d != %d", got1, got2)
+	}
+}
+
+// TestDeterministicSourcePort_Range verifies the source port falls within
+// the ephemeral port range 49152-65535.
+func TestDeterministicSourcePort_Range(t *testing.T) {
+	pairs := [][2]string{
+		{"fe80::1", "fe80::2"},
+		{"fe80::aaaa", "fe80::bbbb"},
+		{"", ""},
+		{"a", "b"},
+	}
+
+	for _, p := range pairs {
+		got := deterministicSourcePort(p[0], p[1])
+		if got < 49152 || got > 65535 {
+			t.Errorf("deterministicSourcePort(%q, %q) = %d, want in range [49152, 65535]", p[0], p[1], got)
+		}
+	}
+}
+
+// TestDeterministicPriority_Deterministic verifies determinism.
+func TestDeterministicPriority_Deterministic(t *testing.T) {
+	requesterGID := "fe80::1"
+	targetGID := "fe80::2"
+
+	got1 := deterministicPriority(requesterGID, targetGID)
+	got2 := deterministicPriority(requesterGID, targetGID)
+	if got1 != got2 {
+		t.Fatalf("deterministicPriority is not deterministic: %d != %d", got1, got2)
+	}
+}
+
+// TestDeterministicPriority_Range verifies the priority is always in 0-7.
+func TestDeterministicPriority_Range(t *testing.T) {
+	pairs := [][2]string{
+		{"fe80::1", "fe80::2"},
+		{"fe80::aaaa", "fe80::bbbb"},
+		{"", ""},
+		{"a", "b"},
+	}
+
+	for _, p := range pairs {
+		got := deterministicPriority(p[0], p[1])
+		if got > 7 {
+			t.Errorf("deterministicPriority(%q, %q) = %d, want in range [0, 7]", p[0], p[1], got)
+		}
+	}
+}

--- a/rebuild/internal/controller/registry/registry.go
+++ b/rebuild/internal/controller/registry/registry.go
@@ -11,15 +11,56 @@ import (
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 )
 
+// Default thresholds used when the caller does not supply a positive value
+// to NewRnicRegistry. These mirror the values that were previously
+// hardcoded directly into the SQL queries.
+const (
+	// DefaultActiveThresholdSec is the window (in seconds) within which an
+	// RNIC entry's last_updated_epoch must fall to be considered "active"
+	// for pinglist generation and lookups.
+	DefaultActiveThresholdSec = 300
+
+	// DefaultStaleThresholdSec is the window (in seconds) after which an
+	// RNIC entry is considered stale and eligible for removal.
+	DefaultStaleThresholdSec = 900
+
+	// DefaultInterTorSampleSize is the default number of distinct ToRs
+	// sampled for inter-ToR pinglist generation.
+	DefaultInterTorSampleSize = 5
+)
+
 // RnicRegistry manages RNIC information stored in rqlite.
 type RnicRegistry struct {
 	conn *gorqlite.Connection
+
+	// activeThresholdSec is the "active" window (seconds) used by queries
+	// that only consider recently-updated RNIC entries.
+	activeThresholdSec int
+	// staleThresholdSec is the window (seconds) after which entries are
+	// considered stale and removed or excluded.
+	staleThresholdSec int
+	// interTorSampleSize caps the number of distinct ToRs sampled by
+	// GetSampleRNICsFromOtherToRs.
+	interTorSampleSize int
 }
 
-// NewRnicRegistry creates a new RNIC registry connected to the given rqlite URI.
-// It initializes the database schema (table + indexes) before returning.
-func NewRnicRegistry(dbURI string) (*RnicRegistry, error) {
+// NewRnicRegistry creates a new RNIC registry connected to the given rqlite
+// URI. It initializes the database schema (table + indexes) before
+// returning. activeThresholdSec, staleThresholdSec, and interTorSampleSize
+// configure the thresholds described above; a value <= 0 falls back to the
+// corresponding Default* constant.
+func NewRnicRegistry(dbURI string, activeThresholdSec, staleThresholdSec, interTorSampleSize int) (*RnicRegistry, error) {
 	log.Info().Str("dbURI", dbURI).Msg("Initializing RNIC registry with rqlite")
+
+	if activeThresholdSec <= 0 {
+		activeThresholdSec = DefaultActiveThresholdSec
+	}
+	if staleThresholdSec <= 0 {
+		staleThresholdSec = DefaultStaleThresholdSec
+	}
+	if interTorSampleSize <= 0 {
+		interTorSampleSize = DefaultInterTorSampleSize
+	}
 
 	conn, err := gorqlite.Open(dbURI)
 	if err != nil {
@@ -27,7 +68,10 @@ func NewRnicRegistry(dbURI string) (*RnicRegistry, error) {
 	}
 
 	registry := &RnicRegistry{
-		conn: conn,
+		conn:               conn,
+		activeThresholdSec: activeThresholdSec,
+		staleThresholdSec:  staleThresholdSec,
+		interTorSampleSize: interTorSampleSize,
 	}
 
 	if err := registry.initializeSchema(); err != nil {
@@ -48,8 +92,12 @@ func (r *RnicRegistry) Close() error {
 
 // initializeSchema creates the rnics table and associated indexes if they
 // do not already exist. Each index is created in a separate write call
-// because rqlite's WriteOne executes a single statement at a time.
+// because rqlite's WriteOne executes a single statement at a time. This
+// runs once at startup, before any request-scoped context exists, so it
+// uses context.Background().
 func (r *RnicRegistry) initializeSchema() error {
+	ctx := context.Background()
+
 	createTableSQL := `
 	CREATE TABLE IF NOT EXISTS rnics (
 		rnic_gid TEXT PRIMARY KEY,
@@ -63,7 +111,7 @@ func (r *RnicRegistry) initializeSchema() error {
 		last_updated_epoch INTEGER NOT NULL
 	);`
 
-	if _, err := r.conn.WriteOne(createTableSQL); err != nil {
+	if _, err := r.conn.WriteOneContext(ctx, createTableSQL); err != nil {
 		return fmt.Errorf("failed to create rnics table: %w", err)
 	}
 
@@ -76,7 +124,7 @@ func (r *RnicRegistry) initializeSchema() error {
 	}
 
 	for _, idx := range indexes {
-		if _, err := r.conn.WriteOne(idx); err != nil {
+		if _, err := r.conn.WriteOneContext(ctx, idx); err != nil {
 			return fmt.Errorf("failed to create index: %w", err)
 		}
 	}
@@ -84,18 +132,27 @@ func (r *RnicRegistry) initializeSchema() error {
 	return nil
 }
 
-// RegisterRNIC upserts an RNIC entry in the registry. The last_updated_epoch
-// field is set to the current Unix timestamp (seconds).
-func (r *RnicRegistry) RegisterRNIC(
+// RegisterRNICs upserts all of the given RNIC entries for a single agent as
+// one atomic rqlite transaction (WriteParameterizedContext executes all
+// statements as a single transaction). This guarantees that a partial
+// failure (e.g. a constraint violation on one RNIC) never leaves some of the
+// agent's RNICs registered while others are silently dropped. The
+// last_updated_epoch field is set to the current Unix timestamp (seconds)
+// for every row.
+func (r *RnicRegistry) RegisterRNICs(
 	ctx context.Context,
 	agentID string,
 	agentIP string,
-	rnic *controller_agent.RnicInfo,
+	rnics []*controller_agent.RnicInfo,
 ) error {
+	if len(rnics) == 0 {
+		return nil
+	}
+
 	log.Info().
 		Str("agentID", agentID).
-		Str("rnicGID", rnic.GetGid()).
-		Msg("Registering RNIC")
+		Int("rnicCount", len(rnics)).
+		Msg("Registering RNICs")
 
 	upsertSQL := `
 	INSERT OR REPLACE INTO rnics
@@ -104,30 +161,40 @@ func (r *RnicRegistry) RegisterRNIC(
 
 	now := time.Now().Unix()
 
-	stmt := gorqlite.ParameterizedStatement{
-		Query: upsertSQL,
-		Arguments: []interface{}{
-			rnic.GetGid(),
-			rnic.GetQpn(),
-			agentID,
-			agentIP,
-			rnic.GetIpAddress(),
-			rnic.GetTorId(),
-			rnic.GetHostName(),
-			rnic.GetDeviceName(),
-			now,
-		},
+	statements := make([]gorqlite.ParameterizedStatement, 0, len(rnics))
+	for _, rnic := range rnics {
+		statements = append(statements, gorqlite.ParameterizedStatement{
+			Query: upsertSQL,
+			Arguments: []interface{}{
+				rnic.GetGid(),
+				rnic.GetQpn(),
+				agentID,
+				agentIP,
+				rnic.GetIpAddress(),
+				rnic.GetTorId(),
+				rnic.GetHostName(),
+				rnic.GetDeviceName(),
+				now,
+			},
+		})
 	}
 
-	if _, err := r.conn.WriteOneParameterized(stmt); err != nil {
-		return fmt.Errorf("failed to register RNIC: %w", err)
+	results, err := r.conn.WriteParameterizedContext(ctx, statements)
+	if err != nil {
+		return fmt.Errorf("failed to register RNICs: %w", err)
+	}
+
+	for i, res := range results {
+		if res.Err != nil {
+			return fmt.Errorf("failed to register RNIC %s: %w", rnics[i].GetGid(), res.Err)
+		}
 	}
 
 	return nil
 }
 
-// GetRNICsByToR returns all active RNICs (updated within the last 5 minutes)
-// belonging to the specified ToR switch.
+// GetRNICsByToR returns all active RNICs (updated within the configured
+// active-threshold window) belonging to the specified ToR switch.
 func (r *RnicRegistry) GetRNICsByToR(
 	ctx context.Context,
 	torID string,
@@ -138,14 +205,14 @@ func (r *RnicRegistry) GetRNICsByToR(
 	SELECT rnic_gid, qpn, rnic_ip, hostname, tor_id, device_name
 	FROM rnics
 	WHERE tor_id = ?
-	AND last_updated_epoch > (strftime('%s','now') - 300);`
+	AND last_updated_epoch > (strftime('%s','now') - ?);`
 
 	stmt := gorqlite.ParameterizedStatement{
 		Query:     querySQL,
-		Arguments: []interface{}{torID},
+		Arguments: []interface{}{torID, r.activeThresholdSec},
 	}
 
-	result, err := r.conn.QueryOneParameterized(stmt)
+	result, err := r.conn.QueryOneParameterizedContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query RNICs by ToR: %w", err)
 	}
@@ -154,8 +221,13 @@ func (r *RnicRegistry) GetRNICsByToR(
 }
 
 // GetSampleRNICsFromOtherToRs returns one representative RNIC from each ToR
-// other than the excluded one, limited to 5 ToRs. Only active entries
-// (updated within the last 5 minutes) are considered.
+// other than the excluded one, up to interTorSampleSize distinct ToRs. Only
+// active entries (updated within the configured active-threshold window)
+// are considered. Candidate rows are fetched in random order (ORDER BY
+// RANDOM()) so that, across repeated calls, a different representative ToR
+// set and RNIC is chosen each time rather than always sampling the same
+// fixed 5 ToRs and RNICs (as GROUP BY without ORDER BY would, since SQLite
+// does not guarantee which row within a group is returned).
 func (r *RnicRegistry) GetSampleRNICsFromOtherToRs(
 	ctx context.Context,
 	excludeTorID string,
@@ -166,26 +238,46 @@ func (r *RnicRegistry) GetSampleRNICsFromOtherToRs(
 	SELECT rnic_gid, qpn, rnic_ip, hostname, tor_id, device_name
 	FROM rnics
 	WHERE tor_id != ?
-	AND last_updated_epoch > (strftime('%s','now') - 300)
-	GROUP BY tor_id
-	LIMIT 5;`
+	AND last_updated_epoch > (strftime('%s','now') - ?)
+	ORDER BY RANDOM();`
 
 	stmt := gorqlite.ParameterizedStatement{
 		Query:     querySQL,
-		Arguments: []interface{}{excludeTorID},
+		Arguments: []interface{}{excludeTorID, r.activeThresholdSec},
 	}
 
-	result, err := r.conn.QueryOneParameterized(stmt)
+	result, err := r.conn.QueryOneParameterizedContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query sample RNICs from other ToRs: %w", err)
 	}
 
-	return scanRnicInfoRows(result)
+	candidates, err := scanRnicInfoRows(result)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pick at most one RNIC per distinct ToR, up to interTorSampleSize
+	// ToRs. Since candidates arrived in random order, this yields a
+	// randomly chosen representative ToR set and RNIC on each call.
+	seenToRs := make(map[string]bool, r.interTorSampleSize)
+	sampled := make([]*controller_agent.RnicInfo, 0, r.interTorSampleSize)
+	for _, rnic := range candidates {
+		if seenToRs[rnic.GetTorId()] {
+			continue
+		}
+		seenToRs[rnic.GetTorId()] = true
+		sampled = append(sampled, rnic)
+		if len(sampled) >= r.interTorSampleSize {
+			break
+		}
+	}
+
+	return sampled, nil
 }
 
 // GetRNICInfo looks up a single RNIC by GID (primary key) or IP address.
-// Only active entries (updated within the last 5 minutes) are returned.
-// Returns (nil, nil) when no matching entry is found.
+// Only active entries (updated within the configured active-threshold
+// window) are returned. Returns (nil, nil) when no matching entry is found.
 func (r *RnicRegistry) GetRNICInfo(
 	ctx context.Context,
 	targetIP string,
@@ -208,11 +300,11 @@ func (r *RnicRegistry) GetRNICInfo(
 		SELECT rnic_gid, qpn, rnic_ip, hostname, tor_id, device_name
 		FROM rnics
 		WHERE rnic_gid = ?
-		AND last_updated_epoch > (strftime('%s','now') - 300)
+		AND last_updated_epoch > (strftime('%s','now') - ?)
 		LIMIT 1;`
 		stmt = gorqlite.ParameterizedStatement{
 			Query:     querySQL,
-			Arguments: []interface{}{targetGID},
+			Arguments: []interface{}{targetGID, r.activeThresholdSec},
 		}
 	} else {
 		// Fallback to IP-based lookup.
@@ -220,15 +312,15 @@ func (r *RnicRegistry) GetRNICInfo(
 		SELECT rnic_gid, qpn, rnic_ip, hostname, tor_id, device_name
 		FROM rnics
 		WHERE rnic_ip = ?
-		AND last_updated_epoch > (strftime('%s','now') - 300)
+		AND last_updated_epoch > (strftime('%s','now') - ?)
 		LIMIT 1;`
 		stmt = gorqlite.ParameterizedStatement{
 			Query:     querySQL,
-			Arguments: []interface{}{targetIP},
+			Arguments: []interface{}{targetIP, r.activeThresholdSec},
 		}
 	}
 
-	result, err := r.conn.QueryOneParameterized(stmt)
+	result, err := r.conn.QueryOneParameterizedContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query RNIC info: %w", err)
 	}
@@ -254,16 +346,21 @@ func (r *RnicRegistry) GetRNICInfo(
 	}, nil
 }
 
-// CleanupStaleEntries removes RNIC entries that have not been updated in
-// the last 15 minutes (900 seconds).
+// CleanupStaleEntries removes RNIC entries that have not been updated
+// within the configured stale-threshold window.
 func (r *RnicRegistry) CleanupStaleEntries(ctx context.Context) error {
 	log.Info().Msg("Cleaning up stale RNIC entries")
 
 	cleanupSQL := `
 	DELETE FROM rnics
-	WHERE last_updated_epoch < (strftime('%s','now') - 900);`
+	WHERE last_updated_epoch < (strftime('%s','now') - ?);`
 
-	result, err := r.conn.WriteOne(cleanupSQL)
+	stmt := gorqlite.ParameterizedStatement{
+		Query:     cleanupSQL,
+		Arguments: []interface{}{r.staleThresholdSec},
+	}
+
+	result, err := r.conn.WriteOneParameterizedContext(ctx, stmt)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup stale entries: %w", err)
 	}
@@ -275,51 +372,28 @@ func (r *RnicRegistry) CleanupStaleEntries(ctx context.Context) error {
 	return nil
 }
 
-// ListAllRNICs returns all active RNICs (updated within the last 15 minutes),
-// ordered by tor_id and hostname.
+// ListAllRNICs returns all active RNICs (updated within the configured
+// stale-threshold window), ordered by tor_id and hostname.
 func (r *RnicRegistry) ListAllRNICs(ctx context.Context) ([]*controller_agent.RnicInfo, error) {
 	log.Debug().Msg("Listing all active RNICs")
 
 	querySQL := `
 	SELECT rnic_gid, qpn, rnic_ip, hostname, tor_id, device_name
 	FROM rnics
-	WHERE last_updated_epoch > (strftime('%s','now') - 900)
+	WHERE last_updated_epoch > (strftime('%s','now') - ?)
 	ORDER BY tor_id, hostname;`
 
-	result, err := r.conn.QueryOne(querySQL)
+	stmt := gorqlite.ParameterizedStatement{
+		Query:     querySQL,
+		Arguments: []interface{}{r.staleThresholdSec},
+	}
+
+	result, err := r.conn.QueryOneParameterizedContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list RNICs: %w", err)
 	}
 
 	return scanRnicInfoRows(result)
-}
-
-// GetTorIDs returns the distinct set of ToR switch IDs that have at least
-// one active RNIC (updated within the last 15 minutes).
-func (r *RnicRegistry) GetTorIDs(ctx context.Context) ([]string, error) {
-	log.Debug().Msg("Getting active ToR IDs")
-
-	querySQL := `
-	SELECT DISTINCT tor_id
-	FROM rnics
-	WHERE last_updated_epoch > (strftime('%s','now') - 900)
-	ORDER BY tor_id;`
-
-	result, err := r.conn.QueryOne(querySQL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ToR IDs: %w", err)
-	}
-
-	var torIDs []string
-	for result.Next() {
-		var torID string
-		if err := result.Scan(&torID); err != nil {
-			return nil, fmt.Errorf("failed to scan ToR ID row: %w", err)
-		}
-		torIDs = append(torIDs, torID)
-	}
-
-	return torIDs, nil
 }
 
 // scanRnicInfoRows is a helper that iterates over query result rows and

--- a/rebuild/internal/controller/service.go
+++ b/rebuild/internal/controller/service.go
@@ -6,25 +6,35 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller/pinglist"
-	"github.com/yuuki/rpingmesh/rebuild/internal/controller/registry"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// registryClient is the subset of registry.RnicRegistry's API used directly
+// by ControllerService (RegisterRNICs) and, via the embedded
+// PinglistGenerator, its read methods (GetRNICsByToR,
+// GetSampleRNICsFromOtherToRs). It is declared here, at the point of use, so
+// that RegisterAgent and GetPinglist can be unit tested against a fake
+// instead of a real rqlite-backed registry.
+type registryClient interface {
+	pinglist.RnicSource
+	RegisterRNICs(ctx context.Context, agentID, agentIP string, rnics []*controller_agent.RnicInfo) error
+}
 
 // ControllerService implements the gRPC ControllerService defined in
 // controller_agent.proto. It handles agent registration and pinglist
 // distribution.
 type ControllerService struct {
 	controller_agent.UnimplementedControllerServiceServer
-	registry *registry.RnicRegistry
+	registry registryClient
 	pinglist *pinglist.PinglistGenerator
 }
 
 // NewControllerService creates a new ControllerService backed by the given
 // RNIC registry. A PinglistGenerator is automatically created from the
 // registry.
-func NewControllerService(reg *registry.RnicRegistry) *ControllerService {
+func NewControllerService(reg registryClient) *ControllerService {
 	return &ControllerService{
 		registry: reg,
 		pinglist: pinglist.NewPinglistGenerator(reg),
@@ -55,22 +65,27 @@ func (s *ControllerService) RegisterAgent(
 		Int("rnicCount", len(req.GetRnics())).
 		Msg("Agent registration request")
 
-	// Register each RNIC with hostname and tor_id from the request.
-	for _, rnic := range req.GetRnics() {
+	// Apply hostname and tor_id from the top-level request to every RNIC.
+	rnics := req.GetRnics()
+	for _, rnic := range rnics {
 		rnic.HostName = req.GetHostname()
 		rnic.TorId = req.GetTorId()
+	}
 
-		if err := s.registry.RegisterRNIC(ctx, req.GetAgentId(), req.GetAgentIp(), rnic); err != nil {
-			log.Error().Err(err).
-				Str("agentID", req.GetAgentId()).
-				Str("rnicGID", rnic.GetGid()).
-				Msg("Failed to register RNIC")
+	// Register all RNICs for this agent as a single atomic operation. A
+	// partial failure (e.g. one malformed RNIC) must not silently leave
+	// some of the agent's RNICs registered while others are dropped, so any
+	// error here fails the whole registration rather than being swallowed.
+	if err := s.registry.RegisterRNICs(ctx, req.GetAgentId(), req.GetAgentIp(), rnics); err != nil {
+		log.Error().Err(err).
+			Str("agentID", req.GetAgentId()).
+			Int("rnicCount", len(rnics)).
+			Msg("Failed to register RNICs")
 
-			return &controller_agent.AgentRegistrationResponse{
-				Success: false,
-				Message: fmt.Sprintf("failed to register RNIC %s: %s", rnic.GetGid(), err.Error()),
-			}, nil
-		}
+		return &controller_agent.AgentRegistrationResponse{
+			Success: false,
+			Message: fmt.Sprintf("failed to register RNICs: %s", err.Error()),
+		}, status.Errorf(codes.Internal, "failed to register RNICs: %v", err)
 	}
 
 	log.Info().

--- a/rebuild/internal/controller/service_test.go
+++ b/rebuild/internal/controller/service_test.go
@@ -1,0 +1,234 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeRegistry implements registryClient without any real rqlite backend,
+// so that ControllerService's RegisterAgent/GetPinglist request handling
+// (validation, error mapping) can be unit tested in isolation.
+type fakeRegistry struct {
+	registerErr   error
+	registerCalls int
+	lastAgentID   string
+	lastAgentIP   string
+	lastRnics     []*controller_agent.RnicInfo
+
+	torMeshRnics  []*controller_agent.RnicInfo
+	torMeshErr    error
+	interTorRnics []*controller_agent.RnicInfo
+	interTorErr   error
+}
+
+func (f *fakeRegistry) RegisterRNICs(_ context.Context, agentID, agentIP string, rnics []*controller_agent.RnicInfo) error {
+	f.registerCalls++
+	f.lastAgentID = agentID
+	f.lastAgentIP = agentIP
+	f.lastRnics = rnics
+	return f.registerErr
+}
+
+func (f *fakeRegistry) GetRNICsByToR(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+	return f.torMeshRnics, f.torMeshErr
+}
+
+func (f *fakeRegistry) GetSampleRNICsFromOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+	return f.interTorRnics, f.interTorErr
+}
+
+func statusCode(t *testing.T, err error) codes.Code {
+	t.Helper()
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a gRPC status error, got: %v", err)
+	}
+	return st.Code()
+}
+
+func TestRegisterAgent_MissingAgentID(t *testing.T) {
+	svc := NewControllerService(&fakeRegistry{})
+
+	_, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
+		TorId: "tor-1",
+	})
+	if err == nil {
+		t.Fatal("expected an error for missing agent_id, got nil")
+	}
+	if got := statusCode(t, err); got != codes.InvalidArgument {
+		t.Errorf("status code = %v, want %v", got, codes.InvalidArgument)
+	}
+}
+
+func TestRegisterAgent_MissingTorID(t *testing.T) {
+	svc := NewControllerService(&fakeRegistry{})
+
+	_, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
+		AgentId: "agent-1",
+	})
+	if err == nil {
+		t.Fatal("expected an error for missing tor_id, got nil")
+	}
+	if got := statusCode(t, err); got != codes.InvalidArgument {
+		t.Errorf("status code = %v, want %v", got, codes.InvalidArgument)
+	}
+}
+
+func TestRegisterAgent_RegistryFailure(t *testing.T) {
+	fake := &fakeRegistry{registerErr: errors.New("write failed")}
+	svc := NewControllerService(fake)
+
+	resp, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
+		AgentId: "agent-1",
+		TorId:   "tor-1",
+		Rnics: []*controller_agent.RnicInfo{
+			{Gid: "gid-1"},
+			{Gid: "gid-2"},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected an error when the registry fails, got nil")
+	}
+	if got := statusCode(t, err); got != codes.Internal {
+		t.Errorf("status code = %v, want %v", got, codes.Internal)
+	}
+	if resp == nil {
+		t.Fatal("expected a non-nil response even on failure")
+	}
+	if resp.GetSuccess() {
+		t.Error("resp.Success = true, want false on registry failure")
+	}
+	if fake.registerCalls != 1 {
+		t.Errorf("registerCalls = %d, want 1 (all RNICs registered in a single call)", fake.registerCalls)
+	}
+}
+
+func TestRegisterAgent_Success(t *testing.T) {
+	fake := &fakeRegistry{}
+	svc := NewControllerService(fake)
+
+	resp, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
+		AgentId:  "agent-1",
+		AgentIp:  "10.0.0.1",
+		Hostname: "host-1",
+		TorId:    "tor-1",
+		Rnics: []*controller_agent.RnicInfo{
+			{Gid: "gid-1"},
+			{Gid: "gid-2"},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Errorf("resp.Success = false, want true; message: %s", resp.GetMessage())
+	}
+	if fake.registerCalls != 1 {
+		t.Errorf("registerCalls = %d, want 1", fake.registerCalls)
+	}
+	if fake.lastAgentID != "agent-1" || fake.lastAgentIP != "10.0.0.1" {
+		t.Errorf("registry received agentID=%q agentIP=%q, want agent-1/10.0.0.1", fake.lastAgentID, fake.lastAgentIP)
+	}
+	// Hostname and tor_id from the top-level request must be propagated to
+	// every RNIC before registration.
+	for _, rnic := range fake.lastRnics {
+		if rnic.GetHostName() != "host-1" || rnic.GetTorId() != "tor-1" {
+			t.Errorf("rnic %s: hostname=%q torID=%q, want host-1/tor-1", rnic.GetGid(), rnic.GetHostName(), rnic.GetTorId())
+		}
+	}
+}
+
+func TestGetPinglist_MissingAgentID(t *testing.T) {
+	svc := NewControllerService(&fakeRegistry{})
+
+	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
+		RequesterGid: "gid-1",
+	})
+	if err == nil {
+		t.Fatal("expected an error for missing agent_id, got nil")
+	}
+	if got := statusCode(t, err); got != codes.InvalidArgument {
+		t.Errorf("status code = %v, want %v", got, codes.InvalidArgument)
+	}
+}
+
+func TestGetPinglist_MissingRequesterGID(t *testing.T) {
+	svc := NewControllerService(&fakeRegistry{})
+
+	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
+		AgentId: "agent-1",
+	})
+	if err == nil {
+		t.Fatal("expected an error for missing requester_gid, got nil")
+	}
+	if got := statusCode(t, err); got != codes.InvalidArgument {
+		t.Errorf("status code = %v, want %v", got, codes.InvalidArgument)
+	}
+}
+
+func TestGetPinglist_UnknownType(t *testing.T) {
+	svc := NewControllerService(&fakeRegistry{})
+
+	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
+		AgentId:      "agent-1",
+		RequesterGid: "gid-1",
+		Type:         controller_agent.PinglistType(999),
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown pinglist type, got nil")
+	}
+	if got := statusCode(t, err); got != codes.InvalidArgument {
+		t.Errorf("status code = %v, want %v", got, codes.InvalidArgument)
+	}
+}
+
+func TestGetPinglist_TorMeshSuccess(t *testing.T) {
+	fake := &fakeRegistry{
+		torMeshRnics: []*controller_agent.RnicInfo{
+			{Gid: "requester-gid"}, // excluded from results (self)
+			{Gid: "peer-gid", TorId: "tor-1"},
+		},
+	}
+	svc := NewControllerService(fake)
+
+	resp, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
+		AgentId:      "agent-1",
+		RequesterGid: "requester-gid",
+		TorId:        "tor-1",
+		Type:         controller_agent.PinglistType_TOR_MESH,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetTargets()) != 1 {
+		t.Fatalf("got %d targets, want 1 (requester's own RNIC excluded)", len(resp.GetTargets()))
+	}
+	if resp.GetTargets()[0].GetTargetGid() != "peer-gid" {
+		t.Errorf("target GID = %q, want peer-gid", resp.GetTargets()[0].GetTargetGid())
+	}
+}
+
+func TestGetPinglist_RegistryFailure(t *testing.T) {
+	fake := &fakeRegistry{torMeshErr: errors.New("query failed")}
+	svc := NewControllerService(fake)
+
+	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
+		AgentId:      "agent-1",
+		RequesterGid: "gid-1",
+		TorId:        "tor-1",
+		Type:         controller_agent.PinglistType_TOR_MESH,
+	})
+	if err == nil {
+		t.Fatal("expected an error when the registry fails, got nil")
+	}
+	if got := statusCode(t, err); got != codes.Internal {
+		t.Errorf("status code = %v, want %v", got, codes.Internal)
+	}
+}

--- a/rebuild/internal/probe/pending.go
+++ b/rebuild/internal/probe/pending.go
@@ -1,0 +1,72 @@
+package probe
+
+// PendingMeasurement tracks the in-flight 6-timestamp state of a single probe
+// as its two ACKs arrive. The two ACKs may arrive out of order (the second ACK
+// can be delivered before the first), so this state machine records whichever
+// arrives first and only reports completion once both have been seen.
+//
+// PendingMeasurement is NOT safe for concurrent use; callers must provide their
+// own synchronization (the prober guards it with its pending-map mutex).
+//
+// This logic is deliberately kept free of any RDMA/cgo dependency so it can be
+// unit-tested on any platform.
+type PendingMeasurement struct {
+	T1 uint64 // Prober send time (CLOCK_MONOTONIC via Zig)
+	T2 uint64 // NIC HW timestamp of probe send completion (or SW fallback)
+	T3 uint64 // Responder recv timestamp
+	T4 uint64 // Responder first ACK send completion timestamp
+	T5 uint64 // Prober first ACK recv timestamp
+	T6 uint64 // Prober second ACK recv time (CLOCK_MONOTONIC, same domain as T1)
+
+	firstAckArrived  bool
+	secondAckArrived bool
+}
+
+// NewPendingMeasurement creates a pending measurement seeded with T1 and T2,
+// which are known at probe-send time.
+func NewPendingMeasurement(t1, t2 uint64) *PendingMeasurement {
+	return &PendingMeasurement{T1: t1, T2: t2}
+}
+
+// ApplyFirstAck records the timestamps associated with the first ACK: T3 (the
+// responder recv timestamp echoed in the ACK) and T5 (the prober's recv
+// timestamp for this ACK). The first ACK's T3 is treated as authoritative and
+// overwrites any value previously supplied by an out-of-order second ACK.
+func (m *PendingMeasurement) ApplyFirstAck(t3, t5 uint64) {
+	m.T3 = t3
+	m.T5 = t5
+	m.firstAckArrived = true
+}
+
+// ApplySecondAck records the timestamps associated with the second ACK: T3 and
+// T4 (both carried in the ACK payload) and T6 (the prober's recv time for this
+// ACK, captured by the caller). T3 from the second ACK is only used when the
+// first ACK has not yet supplied it, so that the first ACK's value wins once
+// both arrive regardless of ordering.
+func (m *PendingMeasurement) ApplySecondAck(t3, t4, t6 uint64) {
+	if !m.firstAckArrived {
+		m.T3 = t3
+	}
+	m.T4 = t4
+	m.T6 = t6
+	m.secondAckArrived = true
+}
+
+// Complete reports whether both ACKs have arrived and the measurement is ready
+// to be finalized into a ProbeResult.
+func (m *PendingMeasurement) Complete() bool {
+	return m.firstAckArrived && m.secondAckArrived
+}
+
+// Result copies the six timestamps into a ProbeResult. Caller-owned fields
+// (sequence number, target metadata, Success) are filled in by the caller.
+func (m *PendingMeasurement) Result() ProbeResult {
+	return ProbeResult{
+		T1: m.T1,
+		T2: m.T2,
+		T3: m.T3,
+		T4: m.T4,
+		T5: m.T5,
+		T6: m.T6,
+	}
+}

--- a/rebuild/internal/probe/pending_test.go
+++ b/rebuild/internal/probe/pending_test.go
@@ -1,0 +1,96 @@
+package probe
+
+import "testing"
+
+// TestPendingMeasurement_InOrder verifies the normal case where the first ACK
+// arrives before the second ACK.
+func TestPendingMeasurement_InOrder(t *testing.T) {
+	m := NewPendingMeasurement(100, 101)
+
+	if m.Complete() {
+		t.Fatal("measurement should not be complete before any ACK")
+	}
+
+	m.ApplyFirstAck(200 /*t3*/, 301 /*t5*/)
+	if m.Complete() {
+		t.Fatal("measurement should not be complete after only the first ACK")
+	}
+
+	m.ApplySecondAck(200 /*t3*/, 202 /*t4*/, 302 /*t6*/)
+	if !m.Complete() {
+		t.Fatal("measurement should be complete after both ACKs")
+	}
+
+	got := m.Result()
+	want := ProbeResult{T1: 100, T2: 101, T3: 200, T4: 202, T5: 301, T6: 302}
+	if got != want {
+		t.Errorf("Result = %+v, want %+v", got, want)
+	}
+}
+
+// TestPendingMeasurement_OutOfOrder verifies that a second ACK arriving before
+// the first ACK is accepted and the measurement still completes with all six
+// timestamps intact. This is the regression guard for the reorder bug where a
+// second-ACK-first arrival orphaned the first ACK and lost the measurement.
+func TestPendingMeasurement_OutOfOrder(t *testing.T) {
+	m := NewPendingMeasurement(100, 101)
+
+	// Second ACK arrives first: T3, T4, T6 recorded; T5 still unknown.
+	m.ApplySecondAck(200 /*t3*/, 202 /*t4*/, 302 /*t6*/)
+	if m.Complete() {
+		t.Fatal("measurement should not be complete after only the second ACK")
+	}
+
+	// First ACK arrives afterwards: supplies T5 and authoritative T3.
+	m.ApplyFirstAck(200 /*t3*/, 301 /*t5*/)
+	if !m.Complete() {
+		t.Fatal("measurement should be complete after both ACKs (out of order)")
+	}
+
+	got := m.Result()
+	want := ProbeResult{T1: 100, T2: 101, T3: 200, T4: 202, T5: 301, T6: 302}
+	if got != want {
+		t.Errorf("Result = %+v, want %+v", got, want)
+	}
+}
+
+// TestPendingMeasurement_FirstAckT3Wins verifies that when the two ACKs carry
+// differing T3 values (e.g., due to a responder-side quirk), the first ACK's
+// T3 is used regardless of arrival order.
+func TestPendingMeasurement_FirstAckT3Wins(t *testing.T) {
+	// First ACK arrives first, then second ACK carries a different T3.
+	m1 := NewPendingMeasurement(100, 101)
+	m1.ApplyFirstAck(200, 301)
+	m1.ApplySecondAck(999 /*divergent t3*/, 202, 302)
+	if m1.Result().T3 != 200 {
+		t.Errorf("in-order: T3 = %d, want 200 (first ACK wins)", m1.Result().T3)
+	}
+
+	// Second ACK arrives first with a divergent T3, then the first ACK
+	// overwrites it with the authoritative value.
+	m2 := NewPendingMeasurement(100, 101)
+	m2.ApplySecondAck(999 /*divergent t3*/, 202, 302)
+	if m2.Result().T3 != 999 {
+		t.Errorf("out-of-order interim: T3 = %d, want 999 (only second ACK seen)", m2.Result().T3)
+	}
+	m2.ApplyFirstAck(200, 301)
+	if m2.Result().T3 != 200 {
+		t.Errorf("out-of-order final: T3 = %d, want 200 (first ACK wins)", m2.Result().T3)
+	}
+}
+
+// TestPendingMeasurement_ResultFeedsCalculateRTT verifies that a completed
+// measurement produces a ProbeResult that CalculateRTT accepts as valid once
+// the caller-owned Success flag is set.
+func TestPendingMeasurement_ResultFeedsCalculateRTT(t *testing.T) {
+	m := NewPendingMeasurement(100_000, 101_000)
+	m.ApplyFirstAck(200_000, 301_000)
+	m.ApplySecondAck(200_000, 202_000, 302_000)
+
+	res := m.Result()
+	res.Success = true
+	rtt := CalculateRTT(&res)
+	if !rtt.Valid {
+		t.Fatalf("expected valid RTT, got error: %s", rtt.ValidationError)
+	}
+}

--- a/rebuild/internal/probe/probe.go
+++ b/rebuild/internal/probe/probe.go
@@ -49,7 +49,7 @@ type ProbeResult struct {
 	T3             uint64 // Responder recv timestamp (NIC HW or SW)
 	T4             uint64 // Responder first ACK send completion timestamp
 	T5             uint64 // Prober first ACK recv timestamp (NIC HW or SW)
-	T6             uint64 // Prober second ACK recv time (Go MONOTONIC)
+	T6             uint64 // Prober second ACK recv time (CLOCK_MONOTONIC, same domain as T1)
 	Success        bool
 	ErrorMessage   string
 	TargetIP       string
@@ -170,6 +170,32 @@ func CalculateRTT(result *ProbeResult) *RTTResult {
 			ResponderDelay:  responderDelay,
 			Valid:           false,
 			ValidationError: fmt.Sprintf("ResponderDelay (%d ns) exceeds max sane bound (%d ns)", responderDelay, MaxSaneDelay),
+		}
+	}
+
+	// Validate: ProberDelay must be non-negative. A negative value indicates
+	// clock skew or a T6/T1 clock-domain mismatch (T1 and T6 must both be
+	// CLOCK_MONOTONIC on the prober host for this term to be meaningful).
+	if proberDelay < 0 {
+		return &RTTResult{
+			NetworkRTT:      networkRTT,
+			ProberDelay:     proberDelay,
+			ResponderDelay:  responderDelay,
+			Valid:           false,
+			ValidationError: fmt.Sprintf("negative ProberDelay (%d ns) indicates clock skew or T1/T6 clock-domain mismatch", proberDelay),
+		}
+	}
+
+	// Validate: ProberDelay should not exceed the sanity bound. This mirrors
+	// the ResponderDelay check so that a corrupted or wall-clock-contaminated
+	// T6 cannot slip through as a valid measurement.
+	if proberDelay > MaxSaneDelay {
+		return &RTTResult{
+			NetworkRTT:      networkRTT,
+			ProberDelay:     proberDelay,
+			ResponderDelay:  responderDelay,
+			Valid:           false,
+			ValidationError: fmt.Sprintf("ProberDelay (%d ns) exceeds max sane bound (%d ns)", proberDelay, MaxSaneDelay),
 		}
 	}
 

--- a/rebuild/internal/probe/probe_test.go
+++ b/rebuild/internal/probe/probe_test.go
@@ -104,7 +104,7 @@ func TestCalculateRTT_ExceedsMaxSaneRTT(t *testing.T) {
 		T1: 1_000_000_000,
 		T2: 1_000_000_000,
 		T3: 2_000_000_000,
-		T4: 2_000_000_001,                        // Tiny responder delay
+		T4: 2_000_000_001,                          // Tiny responder delay
 		T5: 1_000_000_000 + uint64(11*time.Second), // 11s round trip
 		T6: 1_000_000_000 + uint64(12*time.Second),
 	}
@@ -146,6 +146,52 @@ func TestCalculateRTT_ExceedsMaxSaneDelay(t *testing.T) {
 	rtt := CalculateRTT(result)
 	if rtt.Valid {
 		t.Fatal("expected invalid RTT result when ResponderDelay exceeds max sane bound")
+	}
+}
+
+func TestCalculateRTT_NegativeProberDelay(t *testing.T) {
+	// A negative ProberDelay = (T6-T1) - (T5-T2) indicates clock skew or a
+	// T1/T6 clock-domain mismatch. Here (T5-T2) exceeds (T6-T1) while
+	// NetworkRTT and ResponderDelay stay valid, so the ProberDelay check is
+	// the one that must reject the result.
+	result := &ProbeResult{
+		T1: 100_000,
+		T2: 100_000, // T5-T2 = 200000
+		T3: 150_000,
+		T4: 151_000, // ResponderDelay = 1000 (valid)
+		T5: 300_000, // NetworkRTT = (300000-100000) - 1000 = 199000 (valid)
+		T6: 250_000, // T6-T1 = 150000 < T5-T2 = 200000 => ProberDelay = -50000
+	}
+
+	rtt := CalculateRTT(result)
+	if rtt.Valid {
+		t.Fatal("expected invalid RTT result for negative ProberDelay")
+	}
+	if rtt.ProberDelay >= 0 {
+		t.Errorf("expected negative ProberDelay, got %d", rtt.ProberDelay)
+	}
+}
+
+func TestCalculateRTT_ExceedsMaxSaneProberDelay(t *testing.T) {
+	// ProberDelay exceeds the 1s bound while all other components stay valid.
+	// This is the signature of a wall-clock-contaminated T6 (the exact bug the
+	// T6 clock-domain fix addresses): T6 sits ~2s beyond T1 in an unrelated
+	// domain, inflating (T6-T1) far past (T5-T2).
+	result := &ProbeResult{
+		T1: 100_000,
+		T2: 100_000, // T5-T2 = 200000
+		T3: 150_000,
+		T4: 151_000, // ResponderDelay = 1000 (valid)
+		T5: 300_000, // NetworkRTT = 199000 (valid)
+		T6: 300_000 + uint64(2*time.Second),
+	}
+
+	rtt := CalculateRTT(result)
+	if rtt.Valid {
+		t.Fatal("expected invalid RTT result when ProberDelay exceeds max sane bound")
+	}
+	if rtt.ProberDelay <= MaxSaneDelay {
+		t.Errorf("expected ProberDelay > MaxSaneDelay, got %d", rtt.ProberDelay)
 	}
 }
 
@@ -299,12 +345,12 @@ func TestCalculateRTT_RealisticTimestamps(t *testing.T) {
 	baseNS := uint64(1_000_000_000_000) // 1000 seconds in nanoseconds
 
 	result := &ProbeResult{
-		T1: baseNS,                  // Prober starts sending
-		T2: baseNS + 1_000,         // 1us later: NIC send completion
-		T3: baseNS + 25_000,        // 25us later: responder receives
-		T4: baseNS + 26_000,        // 1us responder processing
-		T5: baseNS + 51_000,        // 51us from T1: first ACK arrives at prober
-		T6: baseNS + 52_000,        // 1us later: second ACK arrives
+		T1: baseNS,          // Prober starts sending
+		T2: baseNS + 1_000,  // 1us later: NIC send completion
+		T3: baseNS + 25_000, // 25us later: responder receives
+		T4: baseNS + 26_000, // 1us responder processing
+		T5: baseNS + 51_000, // 51us from T1: first ACK arrives at prober
+		T6: baseNS + 52_000, // 1us later: second ACK arrives
 	}
 
 	rtt := CalculateRTT(result)

--- a/rebuild/internal/probe/ratelimit.go
+++ b/rebuild/internal/probe/ratelimit.go
@@ -1,0 +1,53 @@
+package probe
+
+import "time"
+
+// RateLimiter is a simple send-spacing rate limiter. It enforces a minimum
+// interval between successive events so that the average rate does not exceed
+// a configured packets-per-second (pps) target.
+//
+// RateLimiter is NOT safe for concurrent use; callers must provide their own
+// synchronization. It is kept free of any RDMA/cgo dependency so it can be
+// unit-tested on any platform. The actual (interruptible) waiting is performed
+// by the caller based on the duration returned by Reserve.
+type RateLimiter struct {
+	minInterval time.Duration
+	next        time.Time // earliest time the next send is allowed
+}
+
+// SetRate configures the limiter to allow at most pps sends per second. A
+// non-positive pps disables rate limiting (Reserve always returns 0).
+func (r *RateLimiter) SetRate(pps float64) {
+	if pps <= 0 {
+		r.minInterval = 0
+		return
+	}
+	r.minInterval = time.Duration(float64(time.Second) / pps)
+}
+
+// Enabled reports whether rate limiting is currently active.
+func (r *RateLimiter) Enabled() bool {
+	return r.minInterval > 0
+}
+
+// Reserve returns how long the caller should wait, relative to now, before
+// performing the next send, and advances the internal schedule so that the
+// following Reserve accounts for this send. When rate limiting is disabled it
+// always returns 0.
+//
+// The schedule is advanced from the later of now and the previously reserved
+// slot, so bursts that fall behind the target rate do not accumulate credit
+// that would later allow an unbounded burst.
+func (r *RateLimiter) Reserve(now time.Time) time.Duration {
+	if r.minInterval <= 0 {
+		return 0
+	}
+
+	var wait time.Duration
+	if now.Before(r.next) {
+		wait = r.next.Sub(now)
+	}
+	// The send happens at now+wait; the next one is allowed one interval later.
+	r.next = now.Add(wait).Add(r.minInterval)
+	return wait
+}

--- a/rebuild/internal/probe/ratelimit_test.go
+++ b/rebuild/internal/probe/ratelimit_test.go
@@ -1,0 +1,90 @@
+package probe
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRateLimiter_Disabled verifies that a limiter with no rate set never asks
+// the caller to wait.
+func TestRateLimiter_Disabled(t *testing.T) {
+	var r RateLimiter
+	if r.Enabled() {
+		t.Fatal("limiter should be disabled by default")
+	}
+	now := time.Unix(0, 0)
+	for i := 0; i < 5; i++ {
+		if w := r.Reserve(now); w != 0 {
+			t.Fatalf("disabled limiter returned non-zero wait %v", w)
+		}
+	}
+}
+
+// TestRateLimiter_ZeroOrNegativeDisables verifies that a non-positive rate
+// disables limiting.
+func TestRateLimiter_ZeroOrNegativeDisables(t *testing.T) {
+	var r RateLimiter
+	r.SetRate(1000)
+	if !r.Enabled() {
+		t.Fatal("limiter should be enabled after SetRate(1000)")
+	}
+	r.SetRate(0)
+	if r.Enabled() {
+		t.Fatal("SetRate(0) should disable the limiter")
+	}
+	r.SetRate(-5)
+	if r.Enabled() {
+		t.Fatal("SetRate(-5) should disable the limiter")
+	}
+}
+
+// TestRateLimiter_SpacingWhenCallerKeepsUp verifies that when the caller sends
+// as fast as allowed, each successive Reserve returns the full inter-send
+// interval.
+func TestRateLimiter_SpacingWhenCallerKeepsUp(t *testing.T) {
+	var r RateLimiter
+	r.SetRate(1000) // 1ms between sends
+	interval := time.Millisecond
+
+	now := time.Unix(100, 0)
+
+	// First send: no prior schedule, so no wait.
+	if w := r.Reserve(now); w != 0 {
+		t.Fatalf("first Reserve wait = %v, want 0", w)
+	}
+
+	// Immediately reserving again (no time elapsed) must wait one interval.
+	if w := r.Reserve(now); w != interval {
+		t.Fatalf("second Reserve wait = %v, want %v", w, interval)
+	}
+
+	// Advancing exactly to the reserved slot and reserving again waits another
+	// full interval.
+	now = now.Add(interval)
+	if w := r.Reserve(now); w != interval {
+		t.Fatalf("third Reserve wait = %v, want %v", w, interval)
+	}
+}
+
+// TestRateLimiter_NoCreditAccumulation verifies that when the caller falls
+// behind (long gaps between Reserve calls), the limiter does not accumulate
+// credit that would permit a later unbounded burst.
+func TestRateLimiter_NoCreditAccumulation(t *testing.T) {
+	var r RateLimiter
+	r.SetRate(1000) // 1ms interval
+
+	now := time.Unix(100, 0)
+	_ = r.Reserve(now) // establishes schedule at now+1ms
+
+	// Caller returns much later than the reserved slot.
+	now = now.Add(1 * time.Second)
+	if w := r.Reserve(now); w != 0 {
+		t.Fatalf("late Reserve wait = %v, want 0 (slot already elapsed)", w)
+	}
+
+	// The very next reservation must still be spaced by one interval; the long
+	// idle gap must not grant a free burst.
+	if w := r.Reserve(now); w != time.Millisecond {
+		t.Fatalf("post-idle Reserve wait = %v, want 1ms", w)
+	}
+}

--- a/rebuild/internal/rdmabridge/bridge.go
+++ b/rebuild/internal/rdmabridge/bridge.go
@@ -348,13 +348,17 @@ func (q *Queue) SendProbe(targetGID [16]byte, targetQPN uint32, seqNum uint64, f
 // of the R-Pingmesh protocol). It echoes T1 from the probe, records T3
 // (receive time), and outputs T4 (the send completion timestamp of this ACK).
 func (q *Queue) SendFirstAck(targetGID [16]byte, targetQPN uint32, flowLabel uint32, recvPacket []byte, recvTimestampNS uint64, timeoutMS uint32) (uint64, error) {
+	// The Zig side unconditionally reads ProbePacketSize bytes from recvPacket,
+	// so a shorter (or nil) slice would cause an out-of-bounds read. Reject it
+	// here rather than passing a too-short buffer across the Cgo boundary.
+	if len(recvPacket) < ProbePacketSize {
+		return 0, fmt.Errorf("recvPacket too short: got %d bytes, need at least %d", len(recvPacket), ProbePacketSize)
+	}
+
 	cGID := goGIDToC(targetGID)
 	var outT4 C.uint64_t
 
-	var pktPtr *C.uint8_t
-	if len(recvPacket) > 0 {
-		pktPtr = (*C.uint8_t)(unsafe.Pointer(&recvPacket[0]))
-	}
+	pktPtr := (*C.uint8_t)(unsafe.Pointer(&recvPacket[0]))
 
 	rc := C.rdma_send_first_ack(
 		q.handle,
@@ -376,12 +380,16 @@ func (q *Queue) SendFirstAck(targetGID [16]byte, targetQPN uint32, flowLabel uin
 // SendSecondAck sends the second ACK containing T3 and T4 so the prober can
 // compute responder processing delay (step 3 of the R-Pingmesh protocol).
 func (q *Queue) SendSecondAck(targetGID [16]byte, targetQPN uint32, flowLabel uint32, recvPacket []byte, t3NS uint64, t4NS uint64, timeoutMS uint32) error {
+	// The Zig side unconditionally reads ProbePacketSize bytes from recvPacket,
+	// so a shorter (or nil) slice would cause an out-of-bounds read. Reject it
+	// here rather than passing a too-short buffer across the Cgo boundary.
+	if len(recvPacket) < ProbePacketSize {
+		return fmt.Errorf("recvPacket too short: got %d bytes, need at least %d", len(recvPacket), ProbePacketSize)
+	}
+
 	cGID := goGIDToC(targetGID)
 
-	var pktPtr *C.uint8_t
-	if len(recvPacket) > 0 {
-		pktPtr = (*C.uint8_t)(unsafe.Pointer(&recvPacket[0]))
-	}
+	pktPtr := (*C.uint8_t)(unsafe.Pointer(&recvPacket[0]))
 
 	rc := C.rdma_send_second_ack(
 		q.handle,

--- a/rebuild/internal/telemetry/otel_metrics.go
+++ b/rebuild/internal/telemetry/otel_metrics.go
@@ -19,7 +19,12 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	// Pinned to v1.39.0 to match the schema URL baked into resource.Default()
+	// by go.opentelemetry.io/otel/sdk v1.40.0's process/telemetry-sdk resource
+	// detectors. A mismatched semconv version here (e.g. v1.26.0) makes
+	// resource.Merge fail with "conflicting Schema URL" on every call,
+	// breaking MetricsCollector initialization entirely.
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 )
 
 // Histogram bucket boundaries in nanoseconds, covering sub-microsecond to
@@ -35,6 +40,27 @@ var rttBucketBoundaries = []float64{
 // flushes accumulated metrics to the collector.
 const periodicReaderInterval = 10 * time.Second
 
+// defaultServiceName is the OTel resource service.name used when
+// NewMetricsCollector is called without a WithServiceName option.
+const defaultServiceName = "rpingmesh-agent"
+
+// Option configures optional parameters for NewMetricsCollector.
+type Option func(*collectorOptions)
+
+// collectorOptions holds the configurable parameters applied via Option.
+type collectorOptions struct {
+	serviceName string
+}
+
+// WithServiceName overrides the OTel resource service.name reported by the
+// MetricsCollector. If not supplied, NewMetricsCollector uses
+// defaultServiceName ("rpingmesh-agent"), preserving prior behavior.
+func WithServiceName(serviceName string) Option {
+	return func(o *collectorOptions) {
+		o.serviceName = serviceName
+	}
+}
+
 // MetricsCollector collects and exports R-Pingmesh probe metrics via OTLP.
 // All recorded metrics use ToR-level attributes (source_tor, target_tor) to
 // maintain low cardinality. GID-level detail is emitted only in debug logs.
@@ -49,13 +75,37 @@ type MetricsCollector struct {
 	logger         zerolog.Logger
 }
 
+// buildResource builds the OTel resource identifying this service, merging
+// process/host defaults with the given service name and a fixed service
+// version. Extracted as its own function so tests can verify service-name
+// parameterization without dialing a real OTLP collector.
+func buildResource(serviceName string) (*resource.Resource, error) {
+	return resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion("0.1.0"),
+		),
+	)
+}
+
 // NewMetricsCollector creates a MetricsCollector that exports OTLP metrics
 // to the given gRPC collector address (e.g., "localhost:4317"). It sets up:
 //   - An OTLP gRPC exporter (insecure) targeting collectorAddr
 //   - A MeterProvider with a periodic reader flushing every 10 seconds
 //   - Histogram instruments for network RTT, prober delay, responder delay
 //   - Counter instruments for probe success, failure, and total counts
-func NewMetricsCollector(ctx context.Context, collectorAddr string) (*MetricsCollector, error) {
+//
+// By default the OTel resource reports service.name="rpingmesh-agent"; pass
+// WithServiceName to override it (e.g. for non-agent processes reusing this
+// collector).
+func NewMetricsCollector(ctx context.Context, collectorAddr string, opts ...Option) (*MetricsCollector, error) {
+	options := collectorOptions{serviceName: defaultServiceName}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	// Create OTLP gRPC exporter targeting the collector.
 	exporter, err := otlpmetricgrpc.New(
 		ctx,
@@ -67,14 +117,7 @@ func NewMetricsCollector(ctx context.Context, collectorAddr string) (*MetricsCol
 	}
 
 	// Build the OTel resource identifying this service.
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName("rpingmesh-agent"),
-			semconv.ServiceVersion("0.1.0"),
-		),
-	)
+	res, err := buildResource(options.serviceName)
 	if err != nil {
 		return nil, err
 	}

--- a/rebuild/internal/telemetry/otel_metrics_test.go
+++ b/rebuild/internal/telemetry/otel_metrics_test.go
@@ -1,0 +1,56 @@
+package telemetry
+
+import (
+	"testing"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+)
+
+// serviceNameOf returns the service.name attribute value from a resource
+// built by buildResource, or ("", false) if it is not present.
+func serviceNameOf(t *testing.T, serviceName string) (string, bool) {
+	t.Helper()
+
+	res, err := buildResource(serviceName)
+	if err != nil {
+		t.Fatalf("buildResource(%q) returned error: %v", serviceName, err)
+	}
+
+	for _, kv := range res.Attributes() {
+		if kv.Key == semconv.ServiceNameKey {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// TestBuildResource_DefaultServiceName verifies that NewMetricsCollector's
+// zero-option behavior (service.name="rpingmesh-agent") is preserved.
+func TestBuildResource_DefaultServiceName(t *testing.T) {
+	got, ok := serviceNameOf(t, defaultServiceName)
+	if !ok {
+		t.Fatal("service.name attribute not found in resource")
+	}
+	if got != "rpingmesh-agent" {
+		t.Errorf("service.name = %q, want rpingmesh-agent", got)
+	}
+}
+
+// TestWithServiceName_Overrides verifies that the WithServiceName option
+// value flows through to the OTel resource's service.name attribute.
+func TestWithServiceName_Overrides(t *testing.T) {
+	options := collectorOptions{serviceName: defaultServiceName}
+	WithServiceName("rpingmesh-controller")(&options)
+
+	if options.serviceName != "rpingmesh-controller" {
+		t.Fatalf("collectorOptions.serviceName = %q, want rpingmesh-controller", options.serviceName)
+	}
+
+	got, ok := serviceNameOf(t, options.serviceName)
+	if !ok {
+		t.Fatal("service.name attribute not found in resource")
+	}
+	if got != "rpingmesh-controller" {
+		t.Errorf("service.name = %q, want rpingmesh-controller", got)
+	}
+}

--- a/rebuild/zig/src/cq.zig
+++ b/rebuild/zig/src/cq.zig
@@ -1,9 +1,14 @@
 // cq.zig - CQ polling thread and completion processing.
 //
 // This module implements the dedicated CQ poller thread that runs per queue.
-// It uses event-driven notification (ibv_get_cq_event / ibv_req_notify_cq)
-// to block until completions arrive, then polls them with the extended CQ API
-// (ibv_start_poll / ibv_next_poll / ibv_end_poll).
+// It uses busy polling, not event-driven notification: no completion
+// channel is created, and ibv_get_cq_event()/ibv_req_notify_cq() are never
+// called. The poller instead calls pollCqCompletions() in a loop, sleeping
+// ~50 microseconds (std.Thread.sleep) between iterations when no
+// completions are found. This trades a small, bounded amount of CPU/latency
+// for simplicity and portability across providers (see the CQ creation
+// comment in queue.zig for why a completion channel was intentionally not
+// used).
 //
 // For receive completions, the poller parses the GRH and probe payload, builds
 // a CompletionEvent, and pushes it into the SPSC ring buffer for consumption
@@ -17,6 +22,13 @@ const types = @import("types.zig");
 const ring = @import("ring.zig");
 const memory = @import("memory.zig");
 const c = types.c;
+
+/// Scoped logger for CQ poller diagnostics. These are std.log.debug calls
+/// (not std.debug.print), so by default (ReleaseSafe/ReleaseFast/ReleaseSmall,
+/// which use log level .info) they compile out entirely -- logEnabled() is
+/// evaluated at comptime, so there is zero per-completion runtime cost in
+/// production builds. Only Debug builds (log level .debug) emit them.
+const log = std.log.scoped(.cq_poller);
 
 // ---------------------------------------------------------------------------
 // GRH parsing
@@ -162,12 +174,12 @@ fn readBigEndianU64(buf: [*]const u8, offset: usize) u64 {
 /// Reads fields at the correct wire format offsets (see ProbePayload comment above).
 fn parseProbePayload(buf: [*]const u8) ProbePayload {
     return ProbePayload{
-        .sequence_num = readBigEndianU64(buf, 4),  // offset 4: after 4-byte header
-        .t1 = readBigEndianU64(buf, 12),            // offset 12
-        .t3 = readBigEndianU64(buf, 20),            // offset 20
-        .t4 = readBigEndianU64(buf, 28),            // offset 28
-        .is_ack = buf[1],                            // msg_type: 0=probe, 1=ack
-        .ack_type = buf[2],                          // ack_type: 0=none, 1=first, 2=second
+        .sequence_num = readBigEndianU64(buf, 4), // offset 4: after 4-byte header
+        .t1 = readBigEndianU64(buf, 12), // offset 12
+        .t3 = readBigEndianU64(buf, 20), // offset 20
+        .t4 = readBigEndianU64(buf, 28), // offset 28
+        .is_ack = buf[1], // msg_type: 0=probe, 1=ack
+        .ack_type = buf[2], // ack_type: 0=none, 1=first, 2=second
     };
 }
 
@@ -210,7 +222,7 @@ pub fn stopCqPollerThread(queue: *types.UdQueue) void {
 ///
 /// The loop continues until queue.running is set to false.
 fn cqPollerLoop(queue: *types.UdQueue) void {
-    std.debug.print("[CQ_POLLER] thread started for queue @{x}\n", .{@intFromPtr(queue)});
+    log.debug("thread started for queue @{x}", .{@intFromPtr(queue)});
     var iter: u64 = 0;
     while (queue.running.load(.acquire)) {
         // Poll recv CQ (handles both IBV_WC_RECV and IBV_WC_SEND opcodes
@@ -225,14 +237,14 @@ fn cqPollerLoop(queue: *types.UdQueue) void {
         iter += 1;
         // Print alive message every 10000 iterations (~0.5s) for debugging
         if (iter % 10000 == 0) {
-            std.debug.print("[CQ_POLLER] @{x} alive iter={d}\n", .{ @intFromPtr(queue), iter });
+            log.debug("@{x} alive iter={d}", .{ @intFromPtr(queue), iter });
         }
 
         // Sleep briefly between polls to reduce CPU usage.
         // 50 microseconds gives good responsiveness while staying efficient.
         std.Thread.sleep(50_000);
     }
-    std.debug.print("[CQ_POLLER] @{x} exiting after {d} iters\n", .{ @intFromPtr(queue), iter });
+    log.debug("@{x} exiting after {d} iters", .{ @intFromPtr(queue), iter });
 }
 
 /// Poll a single CQ for all available completions.
@@ -277,19 +289,19 @@ fn pollCqClassic(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
 fn dispatchClassicWc(queue: *types.UdQueue, wc: *const c.ibv_wc) void {
     const status_int: i32 = @intCast(wc.status);
     if (wc.opcode == c.IBV_WC_SEND) {
-        std.debug.print("[CQ_DISPATCH] @{x} SEND (classic) status={d}\n", .{ @intFromPtr(queue), status_int });
+        log.debug("@{x} SEND (classic) status={d}", .{ @intFromPtr(queue), status_int });
         // Signal the waiting sender thread with a SW timestamp.
         const ts = swTimestampNs();
         queue.send_completion_timestamp.store(ts, .release);
         queue.send_completion_status.store(status_int, .release);
         queue.send_completion_ready.store(true, .release);
     } else if (wc.opcode == c.IBV_WC_RECV) {
-        std.debug.print("[CQ_DISPATCH] @{x} RECV (classic) status={d}\n", .{ @intFromPtr(queue), status_int });
+        log.debug("@{x} RECV (classic) status={d}", .{ @intFromPtr(queue), status_int });
         if (wc.status == c.IBV_WC_SUCCESS) {
             processRecvClassic(queue, wc);
         }
     } else {
-        std.debug.print("[CQ_DISPATCH] @{x} unknown opcode (classic) status={d}\n", .{ @intFromPtr(queue), status_int });
+        log.debug("@{x} unknown opcode (classic) status={d}", .{ @intFromPtr(queue), status_int });
     }
 }
 
@@ -382,19 +394,19 @@ fn dispatchCompletion(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
     const status: i32 = @intCast(cq.status);
 
     if (opcode == c.IBV_WC_SEND) {
-        std.debug.print("[CQ_DISPATCH] @{x} SEND completion status={d}\n", .{ @intFromPtr(queue), status });
+        log.debug("@{x} SEND completion status={d}", .{ @intFromPtr(queue), status });
         // Always signal the sender, regardless of status, so waitSendCompletion
         // can report the error rather than timing out.
         processSendCompletion(queue, cq);
     } else if (opcode == c.IBV_WC_RECV) {
-        std.debug.print("[CQ_DISPATCH] @{x} RECV completion status={d}\n", .{ @intFromPtr(queue), status });
+        log.debug("@{x} RECV completion status={d}", .{ @intFromPtr(queue), status });
         if (status == c.IBV_WC_SUCCESS) {
             processRecvCompletion(queue, cq);
         }
         // Recv errors: buffer slot is effectively lost until queue recreation.
         // For the test scenario this is acceptable.
     } else {
-        std.debug.print("[CQ_DISPATCH] @{x} unknown opcode, status={d}\n", .{ @intFromPtr(queue), status });
+        log.debug("@{x} unknown opcode, status={d}", .{ @intFromPtr(queue), status });
     }
 }
 
@@ -425,9 +437,26 @@ pub fn processRecvCompletion(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
         return;
     };
 
-    // Note: The extended CQ does not request IBV_WC_EX_WITH_FLAGS, so
-    // wc_flags is unavailable here.  For RoCEv2 UD the GRH is always
-    // present (the classic path checks IBV_WC_GRH as a defensive guard).
+    // IBV_WC_GRH (bit 0) indicates the driver wrote a GRH into the receive
+    // buffer. This mirrors the defensive check already present in
+    // processRecvClassic() below, which soft-RoCE (rdma_rxe) exercises but
+    // this extended-CQ path did not previously check at all -- meaning a
+    // production Mellanox NIC completion that ever arrives without a GRH
+    // would have had the first 40 bytes of application payload silently
+    // misparsed as a GRH (corrupting the reported source GID/flow label)
+    // instead of being safely dropped.
+    //
+    // ibv_wc_read_wc_flags() is available unconditionally here: unlike
+    // byte_len, src_qp, or the timestamp fields (which are optional CQE
+    // metadata gated by IBV_WC_EX_WITH_* flags requested at CQ creation
+    // time), wc_flags has no corresponding IBV_WC_EX_WITH_* flag in
+    // libibverbs -- it is a core field, always populated the same way
+    // opcode/status are.
+    const wc_flags = c.ibv_wc_read_wc_flags(cq);
+    if ((wc_flags & c.IBV_WC_GRH) == 0) {
+        memory.postRecvBuffer(queue.qp, queue.recv_mr, queue.recv_buf, slot_index) catch {};
+        return;
+    }
 
     // Parse GRH from the first 40 bytes of the receive buffer
     const grh_info = parseGRH(slot_ptr);

--- a/rebuild/zig/src/device.zig
+++ b/rebuild/zig/src/device.zig
@@ -103,9 +103,9 @@ pub fn getDeviceCount(ctx: *types.RdmaContext) i32 {
 /// This function performs the full device initialization sequence:
 ///   1. Validate the index and open the device context
 ///   2. Allocate a Protection Domain (PD)
-///   3. Find the first active port and query the specified GID
-///   4. Check for hardware timestamp support
-///   5. Populate the DeviceInfo struct with name, GID, and IP
+///   3. Find the first active port and query the specified GID (also
+///      validates the GID's RoCE type via sysfs; see logGidTypeInfo())
+///   4. Populate the DeviceInfo struct with name, GID, and IP
 ///
 /// On failure, all partially allocated resources are cleaned up before
 /// returning the error.
@@ -143,23 +143,23 @@ pub fn openDevice(ctx: *types.RdmaContext, index: i32, gid_index: i32) DeviceErr
     };
     errdefer _ = c.ibv_dealloc_pd(pd);
 
+    // Get device name. This is needed both for the DeviceInfo struct below
+    // and for the sysfs GID-type validation performed inside
+    // findActivePortAndGid(), so it is extracted before that call.
+    const dev_name_ptr = c.ibv_get_device_name(device);
+    var device_name: [64]u8 = [_]u8{0} ** 64;
+    var device_name_len: usize = 0;
+    if (dev_name_ptr != null) {
+        const name_slice = std.mem.sliceTo(dev_name_ptr, 0);
+        device_name_len = @min(name_slice.len, device_name.len - 1);
+        @memcpy(device_name[0..device_name_len], name_slice[0..device_name_len]);
+    }
+
     // Find the first active port and query GID
-    const port_result = findActivePortAndGid(ibv_ctx, gid_index) orelse {
+    const port_result = findActivePortAndGid(ibv_ctx, gid_index, device_name[0..device_name_len]) orelse {
         // Error message already set by findActivePortAndGid
         return DeviceError.NoActivePort;
     };
-
-    // Check hardware timestamp capability
-    const has_hw_timestamps = queryHwTimestampSupport(ibv_ctx);
-
-    // Get device name
-    const dev_name_ptr = c.ibv_get_device_name(device);
-    var device_name: [64]u8 = [_]u8{0} ** 64;
-    if (dev_name_ptr != null) {
-        const name_slice = std.mem.sliceTo(dev_name_ptr, 0);
-        const copy_len = @min(name_slice.len, device_name.len - 1);
-        @memcpy(device_name[0..copy_len], name_slice[0..copy_len]);
-    }
 
     // Format GID and extract IP
     const gid_bytes = types.gidToBytes(port_result.gid);
@@ -185,7 +185,6 @@ pub fn openDevice(ctx: *types.RdmaContext, index: i32, gid_index: i32) DeviceErr
             .active_port = port_result.port_num,
             .active_gid_index = @intCast(gid_index),
         },
-        .has_hw_timestamps = has_hw_timestamps,
     };
 
     return dev;
@@ -226,8 +225,23 @@ pub fn openDeviceByName(ctx: *types.RdmaContext, name: [*:0]const u8, gid_index:
 /// frees the RdmaDevice struct memory. All queues associated with this
 /// device must be destroyed before calling this function.
 pub fn closeDevice(dev: *types.RdmaDevice) void {
-    _ = c.ibv_dealloc_pd(dev.pd);
-    _ = c.ibv_close_device(dev.ctx);
+    const log = std.log.scoped(.rdma_device);
+
+    // Log (rather than silently discard) failures from these teardown
+    // calls. A non-zero return here typically means resources are still
+    // referenced (e.g. a queue/QP was not destroyed first) and is useful
+    // operational signal even though we cannot recover from it at this
+    // point in the shutdown path.
+    const dealloc_ret = c.ibv_dealloc_pd(dev.pd);
+    if (dealloc_ret != 0) {
+        log.err("ibv_dealloc_pd() failed with errno={d}", .{dealloc_ret});
+    }
+
+    const close_ret = c.ibv_close_device(dev.ctx);
+    if (close_ret != 0) {
+        log.err("ibv_close_device() failed with errno={d}", .{close_ret});
+    }
+
     std.heap.page_allocator.destroy(dev);
 }
 
@@ -303,7 +317,14 @@ const PortGidResult = struct {
 ///
 /// Mirrors the Go OpenDevice() logic that iterates ports 1..phys_port_cnt,
 /// queries each port's state, and checks the GID at the given index.
-fn findActivePortAndGid(ibv_ctx: *c.ibv_context, gid_index: i32) ?PortGidResult {
+///
+/// Once a usable GID is found, this also validates its RoCE GID type via
+/// sysfs (see logGidTypeInfo()) and logs a warning if it is not RoCE v2 --
+/// on real Mellanox hardware, gid_index 0 is commonly RoCE v1, which does
+/// not interoperate with a RoCE v2 peer even though the GID itself is
+/// non-zero and otherwise looks valid. This validation is purely
+/// informational: the configured gid_index is still used as-is.
+fn findActivePortAndGid(ibv_ctx: *c.ibv_context, gid_index: i32, dev_name: []const u8) ?PortGidResult {
     // Query device attributes to get the number of physical ports
     var device_attr: c.ibv_device_attr = std.mem.zeroes(c.ibv_device_attr);
     if (c.ibv_query_device(ibv_ctx, &device_attr) != 0) {
@@ -349,6 +370,8 @@ fn findActivePortAndGid(ibv_ctx: *c.ibv_context, gid_index: i32) ?PortGidResult 
             continue;
         }
 
+        logGidTypeInfo(dev_name, port_num, gid_index);
+
         return PortGidResult{
             .port_num = port_num,
             .gid = gid,
@@ -359,17 +382,115 @@ fn findActivePortAndGid(ibv_ctx: *c.ibv_context, gid_index: i32) ?PortGidResult 
     return null;
 }
 
-/// Query whether the device supports hardware completion timestamps.
-///
-/// ibv_query_device_ex() is a static inline wrapper in libibverbs headers and
-/// is not reliably exported as a linkable symbol in all distributions (e.g.,
-/// Debian bookworm libibverbs 44.0). Soft-RoCE (rdma_rxe) does not support
-/// hardware timestamps regardless. The CQ poller in cq.zig automatically falls
-/// back to software timestamps when IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK
-/// is unsupported, so returning false here is safe and correct.
-fn queryHwTimestampSupport(ibv_ctx: *c.ibv_context) bool {
-    _ = ibv_ctx;
-    return false;
+// ---------------------------------------------------------------------------
+// GID type validation (RoCE v1 vs RoCE v2) via sysfs
+// ---------------------------------------------------------------------------
+//
+// libibverbs has no verbs-level API to query whether a given gid_index is
+// RoCE v1, RoCE v1.5, or RoCE v2 -- the kernel exposes this only via sysfs:
+//   /sys/class/infiniband/<dev>/ports/<port>/gid_attrs/types/<index>
+// This matters in practice because production Mellanox NICs frequently
+// populate gid_index 0 with a RoCE v1 entry (for legacy compatibility) and
+// place the RoCE v2 (UDP/IP-routable) entry at a higher index. rdma_rxe
+// (soft-RoCE, used in CI/dev) typically only ever creates RoCE v2 entries,
+// which is why this class of misconfiguration would not be caught by
+// soft-RoCE testing and only surfaces against real hardware.
+
+/// Highest GID table index probed when searching for a RoCE v2 alternative.
+/// 32 comfortably covers the GID table sizes exposed by mlx5 and rdma_rxe.
+const MAX_GID_SEARCH_INDEX: i32 = 32;
+
+/// Coarse classification of a GID table entry's RoCE type, as reported by
+/// the kernel via sysfs gid_attrs/types/<index>.
+const GidType = enum {
+    roce_v1,
+    roce_v1_5,
+    roce_v2,
+    infiniband,
+    unknown,
+};
+
+/// Read and classify the GID type for (dev_name, port_num, gid_index) from
+/// sysfs. Returns null if the sysfs file cannot be opened or read -- this is
+/// expected on older kernels that predate the gid_attrs sysfs interface, or
+/// in restricted containers without /sys mounted, and is not itself an
+/// error.
+fn readGidTypeFromSysfs(dev_name: []const u8, port_num: u8, gid_index: i32) ?GidType {
+    if (dev_name.len == 0) return null;
+
+    var path_buf: [256]u8 = undefined;
+    const path = std.fmt.bufPrint(
+        &path_buf,
+        "/sys/class/infiniband/{s}/ports/{d}/gid_attrs/types/{d}",
+        .{ dev_name, port_num, gid_index },
+    ) catch return null;
+
+    var file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+
+    var content_buf: [64]u8 = undefined;
+    const n = file.readAll(&content_buf) catch return null;
+    const content = std.mem.trim(u8, content_buf[0..n], " \t\r\n");
+
+    // Order matters: check the more specific "RoCE v2" before the "RoCE v1"
+    // substring match. Known kernel strings: "IB/RoCE v1", "RoCE v2".
+    if (std.mem.indexOf(u8, content, "RoCE v2") != null) return .roce_v2;
+    if (std.mem.indexOf(u8, content, "RoCE v1.5") != null) return .roce_v1_5;
+    if (std.mem.indexOf(u8, content, "RoCE v1") != null) return .roce_v1;
+    if (std.mem.indexOf(u8, content, "IB") != null) return .infiniband;
+    return .unknown;
+}
+
+/// Search gid_index 0..MAX_GID_SEARCH_INDEX on the given port for the first
+/// entry classified as RoCE v2. Returns null if none is found (or if sysfs
+/// is unavailable).
+fn findFirstRoceV2GidIndex(dev_name: []const u8, port_num: u8) ?i32 {
+    var idx: i32 = 0;
+    while (idx < MAX_GID_SEARCH_INDEX) : (idx += 1) {
+        if (readGidTypeFromSysfs(dev_name, port_num, idx)) |gt| {
+            if (gt == .roce_v2) return idx;
+        }
+    }
+    return null;
+}
+
+/// Log the GID type of the configured gid_index and warn if it is not
+/// RoCE v2. This is purely diagnostic: it never changes which gid_index is
+/// actually used, so behavior stays conservative and predictable. If a
+/// RoCE v2 entry is found elsewhere on the same port, its index is logged
+/// as a suggestion for the operator to update their configuration with.
+fn logGidTypeInfo(dev_name: []const u8, port_num: u8, gid_index: i32) void {
+    const log = std.log.scoped(.rdma_device);
+
+    const gid_type = readGidTypeFromSysfs(dev_name, port_num, gid_index) orelse {
+        log.warn(
+            "could not determine RoCE GID type via sysfs for gid_index={d} on {s} port {d} " ++
+                "(older kernel or /sys unavailable); proceeding without RoCE v1/v2 validation",
+            .{ gid_index, dev_name, port_num },
+        );
+        return;
+    };
+
+    log.info("gid_index={d} on {s} port {d} has GID type {s}", .{ gid_index, dev_name, port_num, @tagName(gid_type) });
+
+    if (gid_type != .roce_v2) {
+        log.warn(
+            "configured gid_index={d} on {s} port {d} is {s}, not RoCE v2; this is a common " ++
+                "cause of unreachable peers on production Mellanox NICs, which often place a " ++
+                "RoCE v1 entry at gid_index 0",
+            .{ gid_index, dev_name, port_num, @tagName(gid_type) },
+        );
+        if (findFirstRoceV2GidIndex(dev_name, port_num)) |suggested| {
+            log.warn(
+                "found a RoCE v2 GID at gid_index={d} on {s} port {d}; consider updating the " ++
+                    "gid_index configuration (not switched automatically to preserve explicit " ++
+                    "configuration behavior)",
+                .{ suggested, dev_name, port_num },
+            );
+        } else {
+            log.warn("no RoCE v2 GID found on {s} port {d}", .{ dev_name, port_num });
+        }
+    }
 }
 
 /// Format a u8 value as a decimal string into the output buffer.

--- a/rebuild/zig/src/memory.zig
+++ b/rebuild/zig/src/memory.zig
@@ -118,11 +118,29 @@ pub fn allocateBuffers(dev: *types.RdmaDevice, num_slots: u32) MemoryError!Buffe
 
 /// Deregister the Memory Region and free the buffer memory.
 ///
-/// After calling this function, the BufferSet must not be used again.
-/// Any work requests referencing this buffer's lkey will be invalid.
+/// After calling this function, the BufferSet must not be used again on
+/// success. Any work requests referencing this buffer's lkey will be
+/// invalid.
+///
+/// If ibv_dereg_mr() fails (nonzero return), the underlying pages are
+/// deliberately NOT freed and the function returns early. The kernel/HCA
+/// may still hold a reference to this memory (e.g. an outstanding
+/// completion the driver has not fully drained, or a firmware/driver bug on
+/// real hardware -- ibv_dereg_mr() is documented to fail with EBUSY in
+/// exactly this situation). Freeing pages that hardware can still DMA into
+/// would turn into a use-after-free once those pages are reused by the
+/// allocator, which is a far worse outcome than an intentional, bounded
+/// leak on an already-exceptional error path.
 pub fn freeBuffers(buf_set: *BufferSet) void {
-    // Deregister the Memory Region first (before freeing the underlying memory)
-    _ = c.ibv_dereg_mr(buf_set.mr);
+    const dereg_ret = c.ibv_dereg_mr(buf_set.mr);
+    if (dereg_ret != 0) {
+        std.log.scoped(.rdma_memory).err(
+            "ibv_dereg_mr() failed with errno={d}; leaking {d} bytes to avoid a potential use-after-free",
+            .{ dereg_ret, buf_set.size },
+        );
+        types.setLastError("ibv_dereg_mr() failed; buffer intentionally leaked to avoid use-after-free");
+        return;
+    }
 
     // Free the page-aligned buffer
     const slice = buf_set.buf[0..buf_set.size];

--- a/rebuild/zig/src/queue.zig
+++ b/rebuild/zig/src/queue.zig
@@ -56,13 +56,22 @@ pub const QueueError = error{
 ///
 /// This function performs the full queue initialization sequence:
 ///   1. Allocate the UdQueue struct
-///   2. Create a completion channel for event notification
-///   3. Create extended CQs (with HW timestamp fallback)
+///   2. Create extended CQs (with HW timestamp fallback)
+///   3. Allocate send and receive buffers
 ///   4. Create a UD QP with the CQs
 ///   5. Transition the QP through INIT -> RTR -> RTS states
-///   6. Allocate send and receive buffers
-///   7. Post initial receive buffers
-///   8. Start the CQ poller thread
+///   6. Post initial receive buffers
+///   7. Start the CQ poller thread
+///
+/// Buffers are allocated (step 3) before the QP is created (step 4) even
+/// though the QP has no functional dependency on them yet. This ordering is
+/// deliberate: Zig's errdefer unwinds in LIFO order, so registering the
+/// QP-destroy errdefer *after* the buffer-free errdefers guarantees that if
+/// a later step fails (e.g. postInitialRecvBuffers in step 6), the QP is
+/// destroyed before the buffers it may have posted work requests against
+/// are freed. Freeing a buffer while the QP could still reference it via an
+/// outstanding work request would risk the hardware DMA'ing into freed
+/// memory.
 ///
 /// On failure, all partially allocated resources are cleaned up before
 /// returning the error.
@@ -93,19 +102,11 @@ pub fn createQueue(
         }
     }
 
-    // Step 2: Create the UD QP
-    const qp = createUdQp(dev, cq_result.send_cq, cq_result.recv_cq) orelse {
-        types.setLastError("ibv_create_qp() failed");
-        return QueueError.CreateQpFailed;
-    };
-    errdefer _ = c.ibv_destroy_qp(qp);
-
-    // Step 3: Transition QP through INIT -> RTR -> RTS
-    try transitionQpToInit(dev, qp);
-    try transitionQpToRtr(qp);
-    try transitionQpToRts(qp);
-
-    // Step 4: Allocate send and receive buffers
+    // Step 2: Allocate send and receive buffers.
+    //
+    // Allocated before the QP (see the ordering note in the function doc
+    // comment above) so that error-path cleanup destroys the QP before
+    // freeing these buffers.
     const send_bufset = memory.allocateBuffers(dev, types.NUM_SEND_SLOTS) catch {
         types.setLastError("failed to allocate send buffers");
         return QueueError.BufferAllocFailed;
@@ -123,6 +124,22 @@ pub fn createQueue(
         var mutable_recv = recv_bufset;
         memory.freeBuffers(&mutable_recv);
     }
+
+    // Step 3: Create the UD QP.
+    //
+    // Registered after the buffer errdefers above, so on unwind this
+    // errdefer runs *first* -- the QP is destroyed before the buffers are
+    // freed.
+    const qp = createUdQp(dev, cq_result.send_cq, cq_result.recv_cq) orelse {
+        types.setLastError("ibv_create_qp() failed");
+        return QueueError.CreateQpFailed;
+    };
+    errdefer _ = c.ibv_destroy_qp(qp);
+
+    // Step 4: Transition QP through INIT -> RTR -> RTS
+    try transitionQpToInit(dev, qp);
+    try transitionQpToRtr(qp);
+    try transitionQpToRts(qp);
 
     // Initialize the queue struct
     queue.* = types.UdQueue{
@@ -147,13 +164,13 @@ pub fn createQueue(
         .send_completion_status = std.atomic.Value(i32).init(0),
     };
 
-    // Step 5: Post initial receive buffers
+    // Step 6: Post initial receive buffers
     memory.postInitialRecvBuffers(qp, recv_bufset.mr, recv_bufset.buf, types.INITIAL_RECV_BUFFERS) catch {
         types.setLastError("failed to post initial recv buffers");
         return QueueError.PostRecvFailed;
     };
 
-    // Step 6: Start the CQ poller thread
+    // Step 7: Start the CQ poller thread
     cq.startCqPollerThread(queue) catch {
         types.setLastError("failed to start CQ poller thread");
         return QueueError.StartPollerFailed;
@@ -175,23 +192,38 @@ pub fn createQueue(
 ///   4. Destroy CQs
 ///   5. Free the queue struct
 pub fn destroyQueue(queue: *types.UdQueue) void {
+    const log = std.log.scoped(.rdma_queue);
+
     // Stop the CQ poller thread (sets running=false and joins)
     cq.stopCqPollerThread(queue);
 
-    // Destroy the QP first (before CQs, as QP references them)
-    _ = c.ibv_destroy_qp(queue.qp);
+    // Destroy the QP first (before CQs, as QP references them). Log a
+    // failure instead of discarding it -- a nonzero return here is useful
+    // operational signal during teardown even though we cannot recover.
+    const qp_ret = c.ibv_destroy_qp(queue.qp);
+    if (qp_ret != 0) {
+        log.err("ibv_destroy_qp() failed with errno={d}", .{qp_ret});
+    }
 
-    // Free send buffers and deregister send MR
-    _ = c.ibv_dereg_mr(queue.send_mr);
-    const send_total = @as(usize, types.NUM_SEND_SLOTS) * @as(usize, types.SLOT_SIZE);
-    const send_slice = queue.send_buf[0..send_total];
-    std.heap.page_allocator.free(send_slice);
+    // Free send/recv buffers and deregister their MRs by delegating to
+    // memory.freeBuffers(), so the dereg-failure handling (intentional leak
+    // instead of a potential use-after-free; see memory.zig) is defined in
+    // exactly one place instead of being duplicated here.
+    var send_bufset = memory.BufferSet{
+        .buf = queue.send_buf,
+        .mr = queue.send_mr,
+        .num_slots = types.NUM_SEND_SLOTS,
+        .size = @as(usize, types.NUM_SEND_SLOTS) * @as(usize, types.SLOT_SIZE),
+    };
+    memory.freeBuffers(&send_bufset);
 
-    // Free recv buffers and deregister recv MR
-    _ = c.ibv_dereg_mr(queue.recv_mr);
-    const recv_total = @as(usize, types.NUM_RECV_SLOTS) * @as(usize, types.SLOT_SIZE);
-    const recv_slice = queue.recv_buf[0..recv_total];
-    std.heap.page_allocator.free(recv_slice);
+    var recv_bufset = memory.BufferSet{
+        .buf = queue.recv_buf,
+        .mr = queue.recv_mr,
+        .num_slots = types.NUM_RECV_SLOTS,
+        .size = @as(usize, types.NUM_RECV_SLOTS) * @as(usize, types.SLOT_SIZE),
+    };
+    memory.freeBuffers(&recv_bufset);
 
     // Destroy CQs (convert from ibv_cq_ex back to ibv_cq for destruction)
     destroyCqEx(queue.recv_cq);
@@ -226,6 +258,15 @@ pub fn createAddressHandle(
     // Global routing is required for RoCE
     ah_attr.is_global = 1;
     ah_attr.port_num = dev.port_num;
+    // Known limitation: sl and traffic_class are fixed at 0 rather than
+    // being configurable. On a production lossless fabric that relies on
+    // PFC/ECN and DSCP-to-TC mappings (RoCEv2 congestion control), probe
+    // traffic sharing traffic_class=0 with best-effort/background traffic
+    // may land in an unintended priority queue, skewing latency
+    // measurements relative to the application traffic the probes are
+    // meant to represent. Left as-is here (no behavior change); a future
+    // fix would thread a configurable DSCP/traffic_class value through
+    // from the agent configuration.
     ah_attr.sl = 0; // Service Level
 
     // GRH settings
@@ -326,7 +367,10 @@ fn createExtendedCqs(dev: *types.RdmaDevice) ?ExtendedCqResult {
 fn destroyCqEx(cq_ex: *c.ibv_cq_ex) void {
     const base_cq = c.ibv_cq_ex_to_cq(cq_ex);
     if (base_cq != null) {
-        _ = c.ibv_destroy_cq(base_cq);
+        const ret = c.ibv_destroy_cq(base_cq);
+        if (ret != 0) {
+            std.log.scoped(.rdma_queue).err("ibv_destroy_cq() failed with errno={d}", .{ret});
+        }
     }
 }
 

--- a/rebuild/zig/src/types.zig
+++ b/rebuild/zig/src/types.zig
@@ -119,9 +119,6 @@ pub const RdmaDevice = struct {
     /// Human-readable device information matching rdma_device_info_t in the
     /// C header. This is filled during device open and returned to Go.
     device_info: DeviceInfo,
-
-    /// Whether this device supports hardware completion timestamps.
-    has_hw_timestamps: bool,
 };
 
 /// Device information struct, matching rdma_device_info_t in rdma_bridge.h.
@@ -201,6 +198,19 @@ pub const UdQueue = struct {
     running: std.atomic.Value(bool),
 
     // ----- Send completion signaling (synchronous send path) -----
+    //
+    // IMPORTANT invariant: these three fields form a single-slot mailbox,
+    // not a queue. They implicitly assume "one UdQueue is driven by at most
+    // one sender goroutine/thread at a time" -- i.e. a caller posts a send
+    // WR, then immediately waits on send_completion_ready before posting
+    // another. If this queue is ever shared by multiple concurrent senders
+    // (e.g. a future change that parallelizes probing across goroutines
+    // using the same UdQueue), a second sendPacketInternal() call could
+    // overwrite send_completion_ready/timestamp/status while a first call
+    // is still spinning on waitSendCompletion(), causing one sender to read
+    // the other's completion (wrong timestamp) or to hang. Do not remove
+    // the "1 Queue = 1 sender at a time" contract without replacing this
+    // mailbox with a per-request completion slot (e.g. keyed by wr_id).
 
     /// Atomic flag set by the CQ poller when a send completion is ready.
     /// The sender thread spins on this after posting a send WR.


### PR DESCRIPTION
## Overview

This PR addresses the findings of a full 5-area audit of `rebuild/`: the 6-timestamp
measurement protocol, the agent control plane, the controller/config layer, the Zig
RDMA data path, and CI/build. Each area had correctness or reliability gaps that are
fixed here; deliberately out-of-scope items are documented as new README Limitations
instead of silently deferred.

## Key fixes

### Critical

- **T6 clock-domain bug**: `ProberDelay` mixed a wall-clock timestamp with
  `CLOCK_MONOTONIC` timestamps, silently corrupting RTT/delay computation for every
  probe. Fixed to use a consistent monotonic clock domain, with sanity checks added
  on `ProberDelay`.
- **No agent heartbeat**: the controller registry assumed an active-window
  registration model, but the agent never re-registered after startup, so agents
  would silently age out. Added a 60s `RegisterAgent` heartbeat and `resp.Success`
  checking, plus exponential backoff retry on initial registration instead of
  failing startup outright.
- **Controller registry non-atomicity**: batch RNIC registration could partially
  apply with no error surfaced to the caller. Wrapped it in a transaction and
  return a gRPC error on failure.
- **Dead CLI flags**: `BindPFlags` was wired incorrectly, so command-line flags on
  both `agent` and `controller` were silently overridden by config defaults.
- **OTel metrics collector always failing**: a semconv schema mismatch made
  `NewMetricsCollector` fail unconditionally, so no metrics were ever exported.
- **Zig UAF risk**: `ibv_dereg_mr`/`destroy` error paths freed memory regardless of
  whether the underlying dereg/destroy actually succeeded, risking use-after-free.
  Now skips the free on failure.

### High

- Interruptible `Stop()` for `Prober`/`Responder`, an out-of-order ACK state
  machine, time-based stale-probe cleanup that emits failed results instead of
  leaking state, a per-target rate limiter, wire-format dedup, and recv-buffer
  length validation.
- Per-RPC 10s timeouts on all agent→controller calls, and per-type pinglist
  caching so a partial fetch failure doesn't wipe out previously-working targets.
- Context-aware rqlite calls, `ORDER BY RANDOM()` inter-ToR sampling with
  configurable sample size/thresholds (previously deterministic), and config
  validation.
- Sysfs GID type detection with RoCE v2 advisory logging, and a GRH presence check
  on the extended-CQ (HW timestamp) path in the Zig data path.
- New `rebuild-test` CI workflow (unit tests, `go vet`, full build, controller e2e,
  best-effort soft-RoCE e2e) — `rebuild/` had no CI coverage before this. Docker
  layer caching fixed via `go mod download` before source copy with BuildKit cache
  mounts.
- Docs (`README.md`, `CLAUDE.md`) brought in line with the implementation: unified
  Zig version (0.15.2, docs previously claimed 0.16+), corrected wire-format file
  references, documented the T6 clock source.

## Deliberately deferred (documented as README Limitations)

- Analyzer / Service Tracing (out of scope for this audit)
- Derivation of paper Eq.(1) ECMP coverage
- 5-tuple rotation
- Per-type probe rates
- mTLS
- Agent self-protection caps
- Multi-RNIC prober support
- systemd packaging

## Test Plan

- [x] Docker full build + `go vet` + all unit tests PASS
- [x] soft-RoCE RDMA e2e PASS (`TestProbeToOTelMetrics`, `TestRDMAE2ETwoDevices`)
- [x] Controller e2e PASS
- [x] macOS-local pure-Go tests PASS
