### PR TITLE
fix(rebuild): use CLOCK_MONOTONIC for Zig SW timestamps to match Go T6 domain

### DIFF
--- a/rebuild/e2e/probe_otel_e2e_test.go
+++ b/rebuild/e2e/probe_otel_e2e_test.go
@@ -224,28 +224,27 @@ func TestProbeToOTelMetrics(t *testing.T) {
 			probeTotal, probeSuccess, probeFailed)
 	}
 
-	// Soft assertion: at least some probes should succeed. With soft-RoCE
-	// SW timestamps, CQ poll jitter can cause negative NetworkRTT making
-	// all probes "failed" (invalid RTT). This is a known limitation.
+	// Hard assertion: at least some probes must succeed. All 6 timestamps
+	// (T1-T6) are on the same CLOCK_MONOTONIC domain (SW fallback: Zig
+	// types.monotonicNs(); Go: unix.ClockGettime(CLOCK_MONOTONIC)), so a
+	// valid RTT is expected on every run; probe_success_total==0 indicates
+	// a clock-domain regression, not an environmental fluke.
 	if probeSuccess == 0 {
-		t.Logf("WARNING: probe_success_total=0; all probes had invalid RTT (expected with SW timestamps)")
+		t.Fatal("rpingmesh.probe_success_total must be > 0: all probes had invalid RTT")
 	}
 
-	// If any probes succeeded, verify histogram data exists.
-	if probeSuccess > 0 {
-		assertHistogramHasData(t, rm, "rpingmesh.network_rtt_ns")
-		assertHistogramHasData(t, rm, "rpingmesh.prober_delay_ns")
-		assertHistogramHasData(t, rm, "rpingmesh.responder_delay_ns")
+	assertHistogramHasData(t, rm, "rpingmesh.network_rtt_ns")
+	assertHistogramHasData(t, rm, "rpingmesh.prober_delay_ns")
+	assertHistogramHasData(t, rm, "rpingmesh.responder_delay_ns")
 
-		// Log RTT values from histogram.
-		if h := getHistogramData(rm, "rpingmesh.network_rtt_ns"); h != nil {
-			t.Logf("network_rtt_ns: count=%d sum=%d min=%d max=%d",
-				h.Count, h.Sum, extremaVal(h.Min), extremaVal(h.Max))
-		}
-		if h := getHistogramData(rm, "rpingmesh.responder_delay_ns"); h != nil {
-			t.Logf("responder_delay_ns: count=%d sum=%d min=%d max=%d",
-				h.Count, h.Sum, extremaVal(h.Min), extremaVal(h.Max))
-		}
+	// Log RTT values from histogram.
+	if h := getHistogramData(rm, "rpingmesh.network_rtt_ns"); h != nil {
+		t.Logf("network_rtt_ns: count=%d sum=%d min=%d max=%d",
+			h.Count, h.Sum, extremaVal(h.Min), extremaVal(h.Max))
+	}
+	if h := getHistogramData(rm, "rpingmesh.responder_delay_ns"); h != nil {
+		t.Logf("responder_delay_ns: count=%d sum=%d min=%d max=%d",
+			h.Count, h.Sum, extremaVal(h.Min), extremaVal(h.Max))
 	}
 
 	// Verify ToR attributes are present on probe_total.

--- a/rebuild/e2e/rdma_e2e_test.go
+++ b/rebuild/e2e/rdma_e2e_test.go
@@ -271,9 +271,10 @@ func TestRDMAE2ETwoDevices(t *testing.T) {
 // completion, which is only known after the first ACK send WR completes and is
 // therefore only available in the second ACK payload).
 //
-// When usesSWTimestamps is true (soft-RoCE), CQ poll thread scheduling jitter
-// can make T4 appear later than T5, yielding a negative NetworkRTT.  This is
-// expected and logged as a warning instead of a test failure.
+// All SW-fallback timestamps (T1-T5 in Zig, T6 in Go) share the same
+// CLOCK_MONOTONIC domain, so NetworkRTT is expected to be positive even in
+// soft-RoCE (SW timestamp) mode; a non-positive value indicates a real
+// clock-domain or ordering regression, not an environmental fluke.
 func validateRoundTrip(t *testing.T, t1NS, t2NS, t5 uint64, secondAckEv rdmabridge.CompletionEvent, usesSWTimestamps bool) {
 	t.Helper()
 
@@ -302,11 +303,7 @@ func validateRoundTrip(t *testing.T, t1NS, t2NS, t5 uint64, secondAckEv rdmabrid
 		t.Logf("ResponderDelay = %d ns (%.3f ms)", int64(t4-t3), float64(t4-t3)/1e6)
 
 		if networkRTTns <= 0 {
-			if usesSWTimestamps {
-				t.Logf("WARNING: NetworkRTT is non-positive (%d ns); expected with SW timestamps due to CQ poll jitter", networkRTTns)
-			} else {
-				t.Errorf("NetworkRTT should be positive, got %d ns (possible clock skew)", networkRTTns)
-			}
+			t.Errorf("NetworkRTT should be positive, got %d ns (possible clock skew or ordering regression)", networkRTTns)
 		}
 		const maxRTTns = int64(10 * time.Second)
 		if networkRTTns > maxRTTns {

--- a/rebuild/zig/src/cq.zig
+++ b/rebuild/zig/src/cq.zig
@@ -378,9 +378,13 @@ fn pollCqExtended(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
 }
 
 /// Return the current monotonic clock time in nanoseconds (software fallback).
+///
+/// Delegates to the shared `types.monotonicNs()` helper, which uses true
+/// CLOCK_MONOTONIC (not `std.time.nanoTimestamp()`, which is CLOCK_REALTIME
+/// in Zig 0.15.2) so that SW-fallback T2/T3/T4/T5 stay in the same clock
+/// domain as T1 (`packet.zig`) and the Go side's T6.
 fn swTimestampNs() u64 {
-    const ts = std.time.nanoTimestamp();
-    return @intCast(@as(u128, @bitCast(ts)) & 0xFFFFFFFFFFFFFFFF);
+    return types.monotonicNs();
 }
 
 /// Dispatch a single work completion to the appropriate handler.
@@ -526,14 +530,13 @@ pub fn processSendCompletion(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
 /// Get the completion timestamp, using HW or SW source depending on queue config.
 ///
 /// If the queue uses hardware timestamps, reads the wallclock nanosecond
-/// timestamp from the extended CQ. Otherwise falls back to the system
-/// monotonic clock.
+/// timestamp from the extended CQ. Otherwise falls back to the shared
+/// CLOCK_MONOTONIC helper (see `swTimestampNs`).
 fn getCompletionTimestamp(queue: *types.UdQueue, cq: *c.ibv_cq_ex) u64 {
     if (queue.uses_sw_timestamps) {
-        // Software timestamp: use system clock as approximation
-        const ts = std.time.nanoTimestamp();
-        // nanoTimestamp returns i128; truncate to u64
-        return @intCast(@as(u128, @bitCast(ts)) & 0xFFFFFFFFFFFFFFFF);
+        // Software timestamp: use CLOCK_MONOTONIC, same domain as T1 and
+        // the Go side's T6.
+        return swTimestampNs();
     } else {
         // Hardware timestamp: read from extended CQ
         return c.ibv_wc_read_completion_wallclock_ns(cq);

--- a/rebuild/zig/src/packet.zig
+++ b/rebuild/zig/src/packet.zig
@@ -291,10 +291,13 @@ pub fn waitSendCompletion(queue: *types.UdQueue, timeout_ms: u32) PacketError!u6
 // ---------------------------------------------------------------------------
 
 /// Get the current monotonic clock time in nanoseconds.
+///
+/// Delegates to the shared `types.monotonicNs()` helper, which uses true
+/// CLOCK_MONOTONIC (not `std.time.nanoTimestamp()`, which is CLOCK_REALTIME
+/// in Zig 0.15.2) so that T1 stays in the same clock domain as the Go
+/// side's T6.
 fn getMonotonicNs() u64 {
-    const ts = std.time.nanoTimestamp();
-    // nanoTimestamp returns i128; safely convert to u64
-    return @intCast(@as(u128, @bitCast(ts)) & 0xFFFFFFFFFFFFFFFF);
+    return types.monotonicNs();
 }
 
 // ---------------------------------------------------------------------------

--- a/rebuild/zig/src/types.zig
+++ b/rebuild/zig/src/types.zig
@@ -314,8 +314,45 @@ pub fn getLastError() [*:0]const u8 {
 }
 
 // ---------------------------------------------------------------------------
+// Clock helper
+// ---------------------------------------------------------------------------
+
+/// Get the current CLOCK_MONOTONIC time in nanoseconds.
+///
+/// This is the single shared clock source for every software timestamp
+/// (SW-fallback T1/T2/T3/T4/T5) in the 6-timestamp protocol, so that they
+/// stay in the same clock domain as the Go side's T6, which is read via
+/// `unix.ClockGettime(unix.CLOCK_MONOTONIC, ...)` in
+/// `internal/agent/prober.go`. Do NOT use `std.time.nanoTimestamp()` here:
+/// in Zig 0.15.2 it returns CLOCK_REALTIME (wall-clock) time despite the
+/// name, which would mix an epoch-scale value with the Go side's
+/// boot-scale monotonic value and make every ProberDelay/NetworkRTT
+/// calculation nonsensical.
+pub fn monotonicNs() u64 {
+    const ts = std.posix.clock_gettime(.MONOTONIC) catch std.posix.timespec{ .sec = 0, .nsec = 0 };
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+test "monotonicNs returns non-zero value" {
+    const ns = monotonicNs();
+    try std.testing.expect(ns > 0);
+}
+
+test "monotonicNs is monotonic" {
+    const t1 = monotonicNs();
+    // Small busy loop to ensure time advances
+    var sum: u64 = 0;
+    for (0..1000) |i| {
+        sum += i;
+    }
+    if (sum == 0) unreachable; // prevent optimizer from eliminating the loop
+    const t2 = monotonicNs();
+    try std.testing.expect(t2 >= t1);
+}
 
 test "gidToBytes and bytesToGid roundtrip" {
     const original = [16]u8{ 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };


### PR DESCRIPTION
## Problem

In SW-timestamp mode (soft-RoCE, the only environment currently tested end-to-end), every probe was silently counted as failed and no RTT/delay histograms were ever recorded, even though probes and ACKs were completing successfully on the wire.

## Root cause

867d22f fixed a T6 wall-clock vs `CLOCK_MONOTONIC` mismatch on the Go side, but left the Zig SW-fallback timestamp sources unfixed:

- `zig/src/packet.zig` `getMonotonicNs()` (T1)
- `zig/src/cq.zig` `swTimestampNs()` / `getCompletionTimestamp()` (SW-fallback T2/T3/T4/T5)

All three called `std.time.nanoTimestamp()`, which in Zig 0.15.2 returns `CLOCK_REALTIME` (wall-clock) despite its name. Meanwhile the Go side's T6 is read via `unix.ClockGettime(unix.CLOCK_MONOTONIC, ...)` (`internal/agent/prober.go`). This meant T1–T5 were epoch-scale wall-clock values (~1.75e18 ns) while T6 was a boot-scale monotonic value (~1e14 ns), so `ProberDelay = (T6-T1)-(T5-T2)` (`internal/probe/probe.go`) was always a huge negative number, and `CalculateRTT` marked every probe `Valid=false`.

The existing e2e test tolerated this: it only logged a `WARNING` when `probe_success_total == 0` instead of failing, so the regression shipped unnoticed.

## Fix

- Added a single shared `types.monotonicNs()` helper in `zig/src/types.zig`, backed by `std.posix.clock_gettime(.MONOTONIC)` (the correct Zig 0.15.2 API for true `CLOCK_MONOTONIC`).
- `packet.zig`'s `getMonotonicNs()` and `cq.zig`'s `swTimestampNs()` / `getCompletionTimestamp()` now delegate to it instead of each duplicating the broken `nanoTimestamp()` call.
- HW-timestamp mode (NIC wallclock via `ibv_wc_read_completion_wallclock_ns`) is untouched — only the SW-fallback path changed.
- Added unit tests for `types.monotonicNs()` (non-zero, monotonic-increasing) mirroring the existing `getMonotonicNs` tests.

## Test hardening

- `e2e/probe_otel_e2e_test.go`: `probe_success_total == 0` is now a hard `t.Fatal` instead of a logged warning; the histogram assertions (`network_rtt_ns`, `prober_delay_ns`, `responder_delay_ns`) now always run instead of being gated behind `probeSuccess > 0`.
- `e2e/rdma_e2e_test.go`: `validateRoundTrip` no longer tolerates a non-positive `NetworkRTT` in SW-timestamp mode — it's now always a hard failure, since T1–T5 (Zig) and T6 (Go) share one clock domain and a valid RTT is expected on every run.

## Verification

All run via Docker on Colima (macOS has no libibverbs/RDMA hardware):

- `docker build -f Dockerfile.e2e` — builds cleanly, `zig build` (via `make build-zig`) compiles the updated Zig sources.
- `go vet ./...`, `go test $(go list ./... | grep -v /e2e)`, `make build` — all pass.
- `make test-e2e` (soft-RoCE, rxe0+rxe1) — **PASS**, the acid test proving the fix:
  ```
  metrics: probe_total=2 probe_success=2 probe_failed=0
  network_rtt_ns: count=2 sum=1093505 min=454502 max=639003
  responder_delay_ns: count=2 sum=10644538 min=4013014 max=6631524
  --- PASS: TestProbeToOTelMetrics (0.31s)
  ...
  timestamps: T1=7371757714730 T2=7371758190106 T3=7371760243989 T4=7371763151625 T5=7371762888707 (ns)
  NetworkRTT     = 1790965 ns (1.791 ms)
  ResponderDelay = 2907636 ns (2.908 ms)
  --- PASS: TestRDMAE2ETwoDevices (0.01s)
  ```
  All six timestamps are now on the same boot-scale monotonic clock (~7.37e12 ns), and both success count and RTT are as expected.
- `make test-e2e-controller` — **PASS** (all 6 controller e2e tests, unaffected by this change).

Note: `zig build test` has a pre-existing, unrelated failure (`setLastError truncates long messages` panics with an integer overflow in `types.zig`) that reproduces identically on `main` before this change — out of scope for this PR.

## Test plan

- [x] `docker build -f Dockerfile.e2e`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v /e2e)`
- [x] `make build`
- [x] `make test-e2e`
- [x] `make test-e2e-controller`