### PR TITLE
fix(rebuild): replace agent RNIC set on re-registration

### DIFF
--- a/rebuild/internal/controller/registry/registry.go
+++ b/rebuild/internal/controller/registry/registry.go
@@ -152,24 +152,23 @@ func (r *RnicRegistry) initializeSchema() error {
 // RNICs no longer reported by the agent (e.g. a NIC removed, an allowlist
 // change, or a QP recreated with a new QPN) are removed immediately instead
 // of lingering in the registry - and therefore in pinglists - until the
-// stale-threshold window expires. This is safe for the agent's periodic
-// heartbeat re-registration too, since the agent always sends its complete
-// current RNIC set on every registration and heartbeat call (see
-// buildRegistrationRequest in internal/agent/agent.go), never a partial
-// delta. The whole operation still runs in a single transaction, so a
-// partial failure (e.g. a constraint violation on one RNIC) never leaves the
-// agent with some RNICs deleted and none re-inserted. The last_updated_epoch
-// field is set to the current Unix timestamp (seconds) for every row.
+// stale-threshold window expires. This holds even when rnics is empty (the
+// agent currently has no RNICs at all): the DELETE still runs, on its own,
+// so the agent's previously-registered rows don't linger either. This is
+// safe for the agent's periodic heartbeat re-registration too, since the
+// agent always sends its complete current RNIC set on every registration
+// and heartbeat call (see buildRegistrationRequest in
+// internal/agent/agent.go), never a partial delta. The whole operation
+// still runs in a single transaction, so a partial failure (e.g. a
+// constraint violation on one RNIC) never leaves the agent with some RNICs
+// deleted and none re-inserted. The last_updated_epoch field is set to the
+// current Unix timestamp (seconds) for every row.
 func (r *RnicRegistry) RegisterRNICs(
 	ctx context.Context,
 	agentID string,
 	agentIP string,
 	rnics []*controller_agent.RnicInfo,
 ) error {
-	if len(rnics) == 0 {
-		return nil
-	}
-
 	log.Info().
 		Str("agentID", agentID).
 		Int("rnicCount", len(rnics)).

--- a/rebuild/internal/controller/registry/registry.go
+++ b/rebuild/internal/controller/registry/registry.go
@@ -29,9 +29,21 @@ const (
 	DefaultInterTorSampleSize = 5
 )
 
+// dbConn is the subset of gorqlite.Connection's API used by RnicRegistry. It
+// is declared here, at the point of use, so that RnicRegistry's methods can
+// be unit tested against a fake connection instead of a real rqlite-backed
+// one.
+type dbConn interface {
+	Close()
+	WriteOneContext(ctx context.Context, sqlStatement string) (gorqlite.WriteResult, error)
+	WriteOneParameterizedContext(ctx context.Context, statement gorqlite.ParameterizedStatement) (gorqlite.WriteResult, error)
+	WriteParameterizedContext(ctx context.Context, sqlStatements []gorqlite.ParameterizedStatement) ([]gorqlite.WriteResult, error)
+	QueryOneParameterizedContext(ctx context.Context, statement gorqlite.ParameterizedStatement) (gorqlite.QueryResult, error)
+}
+
 // RnicRegistry manages RNIC information stored in rqlite.
 type RnicRegistry struct {
-	conn *gorqlite.Connection
+	conn dbConn
 
 	// activeThresholdSec is the "active" window (seconds) used by queries
 	// that only consider recently-updated RNIC entries.
@@ -132,13 +144,22 @@ func (r *RnicRegistry) initializeSchema() error {
 	return nil
 }
 
-// RegisterRNICs upserts all of the given RNIC entries for a single agent as
-// one atomic rqlite transaction (WriteParameterizedContext executes all
-// statements as a single transaction). This guarantees that a partial
-// failure (e.g. a constraint violation on one RNIC) never leaves some of the
-// agent's RNICs registered while others are silently dropped. The
-// last_updated_epoch field is set to the current Unix timestamp (seconds)
-// for every row.
+// RegisterRNICs replaces the full set of RNIC entries registered for a
+// single agent as one atomic rqlite transaction (WriteParameterizedContext
+// executes all statements as a single transaction): it first deletes every
+// existing row for agentID, then inserts one row per entry in rnics. This
+// set-replacement semantics (rather than a per-RNIC upsert) ensures that
+// RNICs no longer reported by the agent (e.g. a NIC removed, an allowlist
+// change, or a QP recreated with a new QPN) are removed immediately instead
+// of lingering in the registry - and therefore in pinglists - until the
+// stale-threshold window expires. This is safe for the agent's periodic
+// heartbeat re-registration too, since the agent always sends its complete
+// current RNIC set on every registration and heartbeat call (see
+// buildRegistrationRequest in internal/agent/agent.go), never a partial
+// delta. The whole operation still runs in a single transaction, so a
+// partial failure (e.g. a constraint violation on one RNIC) never leaves the
+// agent with some RNICs deleted and none re-inserted. The last_updated_epoch
+// field is set to the current Unix timestamp (seconds) for every row.
 func (r *RnicRegistry) RegisterRNICs(
 	ctx context.Context,
 	agentID string,
@@ -154,17 +175,23 @@ func (r *RnicRegistry) RegisterRNICs(
 		Int("rnicCount", len(rnics)).
 		Msg("Registering RNICs")
 
-	upsertSQL := `
+	deleteSQL := `DELETE FROM rnics WHERE agent_id = ?;`
+
+	insertSQL := `
 	INSERT OR REPLACE INTO rnics
 	(rnic_gid, qpn, agent_id, agent_ip, rnic_ip, tor_id, hostname, device_name, last_updated_epoch)
 	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	now := time.Now().Unix()
 
-	statements := make([]gorqlite.ParameterizedStatement, 0, len(rnics))
+	statements := make([]gorqlite.ParameterizedStatement, 0, len(rnics)+1)
+	statements = append(statements, gorqlite.ParameterizedStatement{
+		Query:     deleteSQL,
+		Arguments: []interface{}{agentID},
+	})
 	for _, rnic := range rnics {
 		statements = append(statements, gorqlite.ParameterizedStatement{
-			Query: upsertSQL,
+			Query: insertSQL,
 			Arguments: []interface{}{
 				rnic.GetGid(),
 				rnic.GetQpn(),
@@ -181,10 +208,14 @@ func (r *RnicRegistry) RegisterRNICs(
 
 	results, err := r.conn.WriteParameterizedContext(ctx, statements)
 	if err != nil {
-		return fmt.Errorf("failed to register RNICs: %w", err)
+		return fmt.Errorf("failed to replace RNICs: %w", err)
 	}
 
-	for i, res := range results {
+	if results[0].Err != nil {
+		return fmt.Errorf("failed to delete stale RNICs for agent %s: %w", agentID, results[0].Err)
+	}
+
+	for i, res := range results[1:] {
 		if res.Err != nil {
 			return fmt.Errorf("failed to register RNIC %s: %w", rnics[i].GetGid(), res.Err)
 		}

--- a/rebuild/internal/controller/registry/registry_test.go
+++ b/rebuild/internal/controller/registry/registry_test.go
@@ -233,15 +233,68 @@ func TestRegisterRNICs_TransactionErrorPropagates(t *testing.T) {
 	}
 }
 
-func TestRegisterRNICs_EmptyRNICsIsNoOp(t *testing.T) {
+func TestRegisterRNICs_EmptyRNICsStillDeletesAgentRows(t *testing.T) {
 	fake := &fakeConn{}
 	reg := newTestRegistry(fake)
 
+	// An agent whose current RNIC set became empty (all NICs lost, or all
+	// removed by an allowlist change) must still have its previously
+	// registered rows deleted - the empty set is itself the agent's current
+	// state, and set-replacement semantics apply just as much as when the
+	// set shrinks but isn't empty.
 	if err := reg.RegisterRNICs(context.Background(), "agent-1", "10.0.0.1", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(fake.writeParameterizedCalls) != 0 {
-		t.Errorf("WriteParameterizedContext called %d times, want 0 for an empty RNIC set", len(fake.writeParameterizedCalls))
+
+	if len(fake.writeParameterizedCalls) != 1 {
+		t.Fatalf("WriteParameterizedContext called %d times, want 1 (a delete-only batch)", len(fake.writeParameterizedCalls))
+	}
+	batch := fake.writeParameterizedCalls[0]
+	if len(batch) != 1 {
+		t.Fatalf("got %d statements, want 1 (just the DELETE, no RNICs to insert)", len(batch))
+	}
+	if !strings.Contains(batch[0].Query, "DELETE FROM rnics") {
+		t.Errorf("statement 0 query = %q, want a DELETE FROM rnics", batch[0].Query)
+	}
+	if len(batch[0].Arguments) != 1 || batch[0].Arguments[0] != "agent-1" {
+		t.Errorf("delete arguments = %v, want [agent-1]", batch[0].Arguments)
+	}
+}
+
+func TestRegisterRNICs_ReRegistrationWithEmptySetRemovesAllPreviousRows(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+	ctx := context.Background()
+
+	// Register two different agents, each with their own RNICs.
+	if err := reg.RegisterRNICs(ctx, "agent-1", "10.0.0.1", []*controller_agent.RnicInfo{testRnic("gid-1"), testRnic("gid-2")}); err != nil {
+		t.Fatalf("agent-1 registration: unexpected error: %v", err)
+	}
+	if err := reg.RegisterRNICs(ctx, "agent-2", "10.0.0.2", []*controller_agent.RnicInfo{testRnic("gid-3")}); err != nil {
+		t.Fatalf("agent-2 registration: unexpected error: %v", err)
+	}
+
+	// agent-1 re-registers reporting no RNICs at all (e.g. every NIC was
+	// lost or removed from the allowlist). This must still delete agent-1's
+	// rows so they don't linger, scoped only to agent-1 - agent-2's rows
+	// must be untouched.
+	if err := reg.RegisterRNICs(ctx, "agent-1", "10.0.0.1", nil); err != nil {
+		t.Fatalf("agent-1 empty re-registration: unexpected error: %v", err)
+	}
+
+	if len(fake.writeParameterizedCalls) != 3 {
+		t.Fatalf("WriteParameterizedContext called %d times, want 3", len(fake.writeParameterizedCalls))
+	}
+
+	thirdBatch := fake.writeParameterizedCalls[2]
+	if len(thirdBatch) != 1 {
+		t.Fatalf("third batch has %d statements, want 1 (a delete-only batch)", len(thirdBatch))
+	}
+	if !strings.Contains(thirdBatch[0].Query, "DELETE FROM rnics") {
+		t.Fatalf("third batch statement 0 = %q, want a DELETE FROM rnics", thirdBatch[0].Query)
+	}
+	if got := thirdBatch[0].Arguments[0]; got != "agent-1" {
+		t.Errorf("third batch delete agent_id = %v, want agent-1 (must not touch agent-2's rows)", got)
 	}
 }
 

--- a/rebuild/internal/controller/registry/registry_test.go
+++ b/rebuild/internal/controller/registry/registry_test.go
@@ -1,0 +1,434 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rqlite/gorqlite"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// fakeConn implements dbConn without any real rqlite backend, so that
+// RnicRegistry's SQL-generation and error-handling logic can be unit tested
+// in isolation, the same way ControllerService's registryClient interface
+// (internal/controller/service_test.go) is faked at its point of use.
+type fakeConn struct {
+	// writeParameterizedCalls captures every batch of statements passed to
+	// WriteParameterizedContext, in call order, so tests can assert on the
+	// exact statements/arguments sent for each RegisterRNICs call.
+	writeParameterizedCalls [][]gorqlite.ParameterizedStatement
+	// writeParameterizedErr, if set, is returned as the call-level error
+	// from WriteParameterizedContext (simulating a transport/HTTP failure).
+	writeParameterizedErr error
+	// writeParameterizedResults, if set, is returned verbatim as the
+	// per-statement results from WriteParameterizedContext. If nil, a
+	// slice of zero-value (no-error) results matching the statement count
+	// is returned instead.
+	writeParameterizedResults []gorqlite.WriteResult
+
+	// queryOneParameterizedCalls captures every statement passed to
+	// QueryOneParameterizedContext, in call order.
+	queryOneParameterizedCalls []gorqlite.ParameterizedStatement
+	queryOneParameterizedErr   error
+
+	// writeOneParameterizedCalls captures every statement passed to
+	// WriteOneParameterizedContext, in call order.
+	writeOneParameterizedCalls []gorqlite.ParameterizedStatement
+	writeOneParameterizedErr   error
+}
+
+func (f *fakeConn) Close() {}
+
+func (f *fakeConn) WriteOneContext(_ context.Context, _ string) (gorqlite.WriteResult, error) {
+	return gorqlite.WriteResult{}, nil
+}
+
+func (f *fakeConn) WriteOneParameterizedContext(_ context.Context, statement gorqlite.ParameterizedStatement) (gorqlite.WriteResult, error) {
+	f.writeOneParameterizedCalls = append(f.writeOneParameterizedCalls, statement)
+	if f.writeOneParameterizedErr != nil {
+		return gorqlite.WriteResult{}, f.writeOneParameterizedErr
+	}
+	return gorqlite.WriteResult{}, nil
+}
+
+func (f *fakeConn) QueryOneParameterizedContext(_ context.Context, statement gorqlite.ParameterizedStatement) (gorqlite.QueryResult, error) {
+	f.queryOneParameterizedCalls = append(f.queryOneParameterizedCalls, statement)
+	if f.queryOneParameterizedErr != nil {
+		return gorqlite.QueryResult{}, f.queryOneParameterizedErr
+	}
+	// A zero-value QueryResult behaves like an empty result set: Next()
+	// returns false immediately. gorqlite.QueryResult's fields backing
+	// actual rows are unexported, so populating real rows from outside the
+	// gorqlite package isn't possible; the row-scanning path is exercised
+	// by the e2e tests against a real rqlite server instead.
+	return gorqlite.QueryResult{}, nil
+}
+
+func (f *fakeConn) WriteParameterizedContext(_ context.Context, statements []gorqlite.ParameterizedStatement) ([]gorqlite.WriteResult, error) {
+	f.writeParameterizedCalls = append(f.writeParameterizedCalls, statements)
+	if f.writeParameterizedErr != nil {
+		return nil, f.writeParameterizedErr
+	}
+	if f.writeParameterizedResults != nil {
+		return f.writeParameterizedResults, nil
+	}
+	return make([]gorqlite.WriteResult, len(statements)), nil
+}
+
+// newTestRegistry builds an RnicRegistry backed by conn, with the same
+// default thresholds NewRnicRegistry would apply, but without touching a
+// real rqlite server (no Open/initializeSchema call).
+func newTestRegistry(conn dbConn) *RnicRegistry {
+	return &RnicRegistry{
+		conn:               conn,
+		activeThresholdSec: DefaultActiveThresholdSec,
+		staleThresholdSec:  DefaultStaleThresholdSec,
+		interTorSampleSize: DefaultInterTorSampleSize,
+	}
+}
+
+func testRnic(gid string) *controller_agent.RnicInfo {
+	return &controller_agent.RnicInfo{
+		Gid:        gid,
+		Qpn:        7,
+		IpAddress:  "10.0.0.1",
+		HostName:   "host-1",
+		TorId:      "tor-1",
+		DeviceName: "mlx5_0",
+	}
+}
+
+func TestRegisterRNICs_FreshRegistrationInsertsAll(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	rnics := []*controller_agent.RnicInfo{testRnic("gid-1"), testRnic("gid-2")}
+	if err := reg.RegisterRNICs(context.Background(), "agent-1", "10.0.0.1", rnics); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.writeParameterizedCalls) != 1 {
+		t.Fatalf("WriteParameterizedContext called %d times, want 1", len(fake.writeParameterizedCalls))
+	}
+
+	statements := fake.writeParameterizedCalls[0]
+	if len(statements) != 3 { // 1 DELETE + 2 INSERT
+		t.Fatalf("got %d statements, want 3 (1 delete + 2 insert)", len(statements))
+	}
+
+	// The DELETE must run first, scoped to the registering agent, so that a
+	// re-registration with a different RNIC set (tested below) always
+	// starts from a clean slate for that agent.
+	del := statements[0]
+	if !strings.Contains(del.Query, "DELETE FROM rnics") {
+		t.Errorf("statement 0 query = %q, want a DELETE FROM rnics", del.Query)
+	}
+	if len(del.Arguments) != 1 || del.Arguments[0] != "agent-1" {
+		t.Errorf("delete arguments = %v, want [agent-1]", del.Arguments)
+	}
+
+	// Every reported RNIC must be inserted after the delete, in order.
+	for i, rn := range rnics {
+		ins := statements[i+1]
+		if !strings.Contains(ins.Query, "INSERT") {
+			t.Errorf("statement %d query = %q, want an INSERT", i+1, ins.Query)
+		}
+		if len(ins.Arguments) < 3 {
+			t.Fatalf("statement %d has %d arguments, want at least 3", i+1, len(ins.Arguments))
+		}
+		if got := ins.Arguments[0]; got != rn.GetGid() {
+			t.Errorf("insert %d gid = %v, want %v", i, got, rn.GetGid())
+		}
+		if got := ins.Arguments[2]; got != "agent-1" {
+			t.Errorf("insert %d agent_id = %v, want agent-1", i, got)
+		}
+	}
+}
+
+func TestRegisterRNICs_ReRegistrationWithSmallerSetReplacesRows(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+	ctx := context.Background()
+
+	// Initial registration reports three RNICs for the agent.
+	first := []*controller_agent.RnicInfo{testRnic("gid-1"), testRnic("gid-2"), testRnic("gid-3")}
+	if err := reg.RegisterRNICs(ctx, "agent-1", "10.0.0.1", first); err != nil {
+		t.Fatalf("first registration: unexpected error: %v", err)
+	}
+
+	// Re-registration (e.g. a heartbeat after a NIC was removed) reports
+	// only one of those RNICs.
+	second := []*controller_agent.RnicInfo{testRnic("gid-1")}
+	if err := reg.RegisterRNICs(ctx, "agent-1", "10.0.0.1", second); err != nil {
+		t.Fatalf("second registration: unexpected error: %v", err)
+	}
+
+	if len(fake.writeParameterizedCalls) != 2 {
+		t.Fatalf("WriteParameterizedContext called %d times, want 2", len(fake.writeParameterizedCalls))
+	}
+
+	secondBatch := fake.writeParameterizedCalls[1]
+	// A DELETE for agent-1 followed by exactly one INSERT: gid-2 and gid-3
+	// are not part of this batch at all, so against a real rqlite backend
+	// the preceding DELETE removes them instead of leaving them stale.
+	if len(secondBatch) != 2 {
+		t.Fatalf("second batch has %d statements, want 2 (1 delete + 1 insert)", len(secondBatch))
+	}
+	if !strings.Contains(secondBatch[0].Query, "DELETE FROM rnics") {
+		t.Fatalf("second batch statement 0 = %q, want a DELETE FROM rnics", secondBatch[0].Query)
+	}
+	if secondBatch[0].Arguments[0] != "agent-1" {
+		t.Errorf("second batch delete agent_id = %v, want agent-1", secondBatch[0].Arguments[0])
+	}
+	if got := secondBatch[1].Arguments[0]; got != "gid-1" {
+		t.Errorf("second batch insert gid = %v, want gid-1", got)
+	}
+}
+
+func TestRegisterRNICs_DeleteStatementErrorPropagates(t *testing.T) {
+	wantErr := errors.New("db locked")
+	fake := &fakeConn{
+		writeParameterizedResults: []gorqlite.WriteResult{
+			{Err: wantErr}, // the DELETE statement fails
+			{},
+		},
+	}
+	reg := newTestRegistry(fake)
+
+	err := reg.RegisterRNICs(context.Background(), "agent-1", "10.0.0.1", []*controller_agent.RnicInfo{testRnic("gid-1")})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestRegisterRNICs_InsertStatementErrorPropagates(t *testing.T) {
+	wantErr := errors.New("constraint violation")
+	fake := &fakeConn{
+		writeParameterizedResults: []gorqlite.WriteResult{
+			{}, // the DELETE statement succeeds
+			{Err: wantErr},
+		},
+	}
+	reg := newTestRegistry(fake)
+
+	err := reg.RegisterRNICs(context.Background(), "agent-1", "10.0.0.1", []*controller_agent.RnicInfo{testRnic("gid-1")})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+	if !strings.Contains(err.Error(), "gid-1") {
+		t.Errorf("error = %q, want it to identify the failing RNIC gid-1", err.Error())
+	}
+}
+
+func TestRegisterRNICs_TransactionErrorPropagates(t *testing.T) {
+	wantErr := errors.New("connection refused")
+	fake := &fakeConn{writeParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	err := reg.RegisterRNICs(context.Background(), "agent-1", "10.0.0.1", []*controller_agent.RnicInfo{testRnic("gid-1")})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestRegisterRNICs_EmptyRNICsIsNoOp(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	if err := reg.RegisterRNICs(context.Background(), "agent-1", "10.0.0.1", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.writeParameterizedCalls) != 0 {
+		t.Errorf("WriteParameterizedContext called %d times, want 0 for an empty RNIC set", len(fake.writeParameterizedCalls))
+	}
+}
+
+func TestGetRNICsByToR_UsesActiveThresholdAndTorID(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	rnics, err := reg.GetRNICsByToR(context.Background(), "tor-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rnics) != 0 {
+		t.Errorf("got %d rnics, want 0 from a fake with no rows", len(rnics))
+	}
+
+	if len(fake.queryOneParameterizedCalls) != 1 {
+		t.Fatalf("QueryOneParameterizedContext called %d times, want 1", len(fake.queryOneParameterizedCalls))
+	}
+	args := fake.queryOneParameterizedCalls[0].Arguments
+	if args[0] != "tor-42" || args[1] != DefaultActiveThresholdSec {
+		t.Errorf("arguments = %v, want [tor-42 %d]", args, DefaultActiveThresholdSec)
+	}
+}
+
+func TestGetRNICsByToR_QueryErrorPropagates(t *testing.T) {
+	wantErr := errors.New("query failed")
+	fake := &fakeConn{queryOneParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	_, err := reg.GetRNICsByToR(context.Background(), "tor-1")
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestGetSampleRNICsFromOtherToRs_UsesActiveThresholdAndExcludesToR(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	if _, err := reg.GetSampleRNICsFromOtherToRs(context.Background(), "tor-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.queryOneParameterizedCalls) != 1 {
+		t.Fatalf("QueryOneParameterizedContext called %d times, want 1", len(fake.queryOneParameterizedCalls))
+	}
+	args := fake.queryOneParameterizedCalls[0].Arguments
+	if args[0] != "tor-1" || args[1] != DefaultActiveThresholdSec {
+		t.Errorf("arguments = %v, want [tor-1 %d]", args, DefaultActiveThresholdSec)
+	}
+}
+
+func TestGetSampleRNICsFromOtherToRs_QueryErrorPropagates(t *testing.T) {
+	wantErr := errors.New("query failed")
+	fake := &fakeConn{queryOneParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	_, err := reg.GetSampleRNICsFromOtherToRs(context.Background(), "tor-1")
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestGetRNICInfo_RequiresIPOrGID(t *testing.T) {
+	reg := newTestRegistry(&fakeConn{})
+
+	_, err := reg.GetRNICInfo(context.Background(), "", "")
+	if err == nil {
+		t.Fatal("expected an error when neither targetIP nor targetGID is provided")
+	}
+}
+
+func TestGetRNICInfo_QueriesByGIDWhenProvided(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	rnic, err := reg.GetRNICInfo(context.Background(), "10.0.0.9", "gid-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rnic != nil {
+		t.Errorf("got %v, want nil for a fake with no matching row", rnic)
+	}
+
+	if len(fake.queryOneParameterizedCalls) != 1 {
+		t.Fatalf("QueryOneParameterizedContext called %d times, want 1", len(fake.queryOneParameterizedCalls))
+	}
+	stmt := fake.queryOneParameterizedCalls[0]
+	if !strings.Contains(stmt.Query, "rnic_gid = ?") {
+		t.Errorf("query = %q, want lookup by rnic_gid since targetGID was provided", stmt.Query)
+	}
+	if stmt.Arguments[0] != "gid-1" {
+		t.Errorf("arguments = %v, want first argument gid-1", stmt.Arguments)
+	}
+}
+
+func TestGetRNICInfo_FallsBackToIPWhenGIDMissing(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	if _, err := reg.GetRNICInfo(context.Background(), "10.0.0.9", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stmt := fake.queryOneParameterizedCalls[0]
+	if !strings.Contains(stmt.Query, "rnic_ip = ?") {
+		t.Errorf("query = %q, want lookup by rnic_ip since targetGID was empty", stmt.Query)
+	}
+	if stmt.Arguments[0] != "10.0.0.9" {
+		t.Errorf("arguments = %v, want first argument 10.0.0.9", stmt.Arguments)
+	}
+}
+
+func TestGetRNICInfo_QueryErrorPropagates(t *testing.T) {
+	wantErr := errors.New("query failed")
+	fake := &fakeConn{queryOneParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	_, err := reg.GetRNICInfo(context.Background(), "", "gid-1")
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestCleanupStaleEntries_UsesStaleThreshold(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	if err := reg.CleanupStaleEntries(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.writeOneParameterizedCalls) != 1 {
+		t.Fatalf("WriteOneParameterizedContext called %d times, want 1", len(fake.writeOneParameterizedCalls))
+	}
+	args := fake.writeOneParameterizedCalls[0].Arguments
+	if len(args) != 1 || args[0] != DefaultStaleThresholdSec {
+		t.Errorf("arguments = %v, want [%d]", args, DefaultStaleThresholdSec)
+	}
+}
+
+func TestCleanupStaleEntries_WriteErrorPropagates(t *testing.T) {
+	wantErr := errors.New("write failed")
+	fake := &fakeConn{writeOneParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	err := reg.CleanupStaleEntries(context.Background())
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestListAllRNICs_UsesStaleThreshold(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	rnics, err := reg.ListAllRNICs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rnics) != 0 {
+		t.Errorf("got %d rnics, want 0 from a fake with no rows", len(rnics))
+	}
+
+	if len(fake.queryOneParameterizedCalls) != 1 {
+		t.Fatalf("QueryOneParameterizedContext called %d times, want 1", len(fake.queryOneParameterizedCalls))
+	}
+	args := fake.queryOneParameterizedCalls[0].Arguments
+	if len(args) != 1 || args[0] != DefaultStaleThresholdSec {
+		t.Errorf("arguments = %v, want [%d]", args, DefaultStaleThresholdSec)
+	}
+}
+
+func TestListAllRNICs_QueryErrorPropagates(t *testing.T) {
+	wantErr := errors.New("query failed")
+	fake := &fakeConn{queryOneParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	_, err := reg.ListAllRNICs(context.Background())
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+func TestClose_ClosesUnderlyingConnection(t *testing.T) {
+	reg := newTestRegistry(&fakeConn{})
+	if err := reg.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`RnicRegistry.RegisterRNICs` (`rebuild/internal/controller/registry/registry.go`) used a per-RNIC `INSERT OR REPLACE` upsert inside a single rqlite transaction. If an agent re-registered with a different RNIC set - a NIC removed, an allowlist change, or a UD QP recreated with a new QPN - the rows from the *previous* set were never deleted. Those stale rows stayed in the `rnics` table, and therefore in pinglists, until the 900s stale-threshold window (`DefaultStaleThresholdSec`) expired.

## Fix

`RegisterRNICs` now performs a full set replacement per agent, in the same `WriteParameterizedContext` batch (rqlite still runs the whole batch as one atomic transaction):

1. `DELETE FROM rnics WHERE agent_id = ?`
2. `INSERT OR REPLACE INTO rnics (...) VALUES (...)` for every RNIC in the current registration request

The delete statement's result is checked before the insert results, so a partial failure (e.g. a constraint violation on one RNIC) never leaves the agent with rows deleted and nothing re-inserted - the whole call still fails atomically, same guarantee as before.

## Heartbeat safety analysis

The agent's heartbeat re-registration reuses the exact same `RegisterAgent` RPC as the initial registration (`internal/agent/agent.go`: `startHeartbeat` → `heartbeatLoop` → `grpcClient.RegisterAgent(ctx, req)`), and the request is built by `buildRegistrationRequest`, which rebuilds the RNIC list from the agent's *live* `a.responders`/`a.devices` slices on every call - never an incremental delta computed against some previously-sent set. So every registration and every heartbeat always carries the agent's complete, current RNIC set.

**Conclusion:** delete-then-insert semantics are safe here. A heartbeat can never cause data loss for RNICs that are still active, because the RNIC will always be present in the same batch's insert statements right after its own delete.

## Tests

Registry package was previously at 0% coverage. Introduced a minimal `dbConn` interface (the `gorqlite.Connection` methods `RnicRegistry` actually calls: `Close`, `WriteOneContext`, `WriteOneParameterizedContext`, `WriteParameterizedContext`, `QueryOneParameterizedContext`) as a seam, following the same pattern already used for `ControllerService`'s `registryClient` interface in `internal/controller/service_test.go`. Added `rebuild/internal/controller/registry/registry_test.go` with a fake `dbConn` and cases including:

- fresh registration emits one DELETE (scoped to `agent_id`) followed by one INSERT per RNIC, in that order, in the same batch
- re-registering with a smaller RNIC set: the second call's batch is independently `DELETE + <current set only>` - no leftovers from the previous, larger set carry over
- statement-level errors (delete fails, insert fails) and call-level transport errors all propagate with the right wrapping
- error-path and argument-passing coverage for `GetRNICsByToR`, `GetSampleRNICsFromOtherToRs`, `GetRNICInfo`, `CleanupStaleEntries`, `ListAllRNICs`

(`gorqlite.QueryResult`'s row-backing fields are unexported, so populated-row scanning isn't unit-testable from outside the `gorqlite` package; that path is covered by the e2e controller test instead.)

Registry package coverage: 0% → 64.0%.

## Verification

- `go vet ./...` - clean
- `go test ./internal/controller/... ./internal/config/...` - all pass
- Docker (`Dockerfile.e2e`, Colima): `go vet ./...`, `go test $(go list ./... | grep -v /e2e)`, `make build` - all pass
- `make test-e2e-controller` - all pass, including `TestAgentRegistration`, which re-registers the same agent twice and confirms registration/pinglist flows still work end-to-end against a real rqlite server with the new delete-then-insert path