### PR TITLE
fix(rebuild): fix prober lifecycle races in send path and control plane

### DIFF
--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -58,6 +59,11 @@ type Agent struct {
 	proberRing *rdmabridge.EventRing
 	respRings  []*rdmabridge.EventRing
 	logger     zerolog.Logger
+
+	// agentIP is the host's outbound IP toward the controller, reported in the
+	// registration request's agent_ip field. Best-effort: empty if it cannot be
+	// determined, which never blocks registration.
+	agentIP string
 
 	// heartbeatStopCh and heartbeatWg control the lifecycle of the
 	// background heartbeat goroutine that periodically re-registers with
@@ -166,6 +172,18 @@ func (a *Agent) Initialize(ctx context.Context) error {
 		a.logger.Info().Msg("Metrics collection is disabled")
 	}
 
+	// Determine the host's outbound IP toward the controller so it can be
+	// reported in the registration. Best-effort: on failure agentIP stays
+	// empty and registration proceeds unaffected.
+	a.agentIP = outboundIP(a.cfg.ControllerAddr)
+	if a.agentIP != "" {
+		a.logger.Info().Str("agent_ip", a.agentIP).Msg("Determined agent outbound IP")
+	} else {
+		a.logger.Warn().
+			Str("controller_addr", a.cfg.ControllerAddr).
+			Msg("Could not determine agent outbound IP; registering without agent_ip")
+	}
+
 	// Step 8: Register with the controller.
 	a.logger.Info().Msg("Registering with controller")
 	if err := a.registerWithController(ctx); err != nil {
@@ -222,10 +240,28 @@ func (a *Agent) buildRegistrationRequest() *controller_agent.AgentRegistrationRe
 
 	return &controller_agent.AgentRegistrationRequest{
 		AgentId:  a.cfg.AgentID,
+		AgentIp:  a.agentIP,
 		Hostname: a.cfg.HostName,
 		TorId:    a.cfg.TorID,
 		Rnics:    rnics,
 	}
+}
+
+// outboundIP returns the local source IP the kernel would use to reach
+// controllerAddr, via the classic connectionless UDP-dial trick: dialing a UDP
+// address performs a route lookup and binds a local address but sends no
+// packets, so LocalAddr() reveals the outbound interface IP. It is best-effort
+// and returns "" on any error (e.g. an addr with no host such as ":50051").
+func outboundIP(controllerAddr string) string {
+	conn, err := net.Dial("udp", controllerAddr)
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+	if udpAddr, ok := conn.LocalAddr().(*net.UDPAddr); ok && udpAddr.IP != nil && !udpAddr.IP.IsUnspecified() {
+		return udpAddr.IP.String()
+	}
+	return ""
 }
 
 // registerAttemptErr builds an error describing why a single registration

--- a/rebuild/internal/agent/cluster_monitor.go
+++ b/rebuild/internal/agent/cluster_monitor.go
@@ -32,6 +32,7 @@ type ClusterMonitor struct {
 	requesterGID   string
 	updateInterval time.Duration
 	running        atomic.Bool
+	stopMu         sync.Mutex // guards stopCh (re)creation across Start/Stop
 	stopCh         chan struct{}
 	wg             sync.WaitGroup
 	logger         zerolog.Logger
@@ -82,6 +83,15 @@ func (m *ClusterMonitor) Start(ctx context.Context) error {
 		return nil // already running
 	}
 
+	// Recreate stopCh so the monitor can be started again after a previous
+	// Stop() closed it. Stop() has already waited for the old goroutine to exit
+	// (running is false here), so nothing references the old channel. Without
+	// this, a Stop->Start cycle would leave monitorLoop reading an
+	// already-closed stopCh and returning immediately, leaving the loop dead.
+	m.stopMu.Lock()
+	m.stopCh = make(chan struct{})
+	m.stopMu.Unlock()
+
 	m.wg.Add(1)
 	go m.monitorLoop(ctx)
 
@@ -102,7 +112,9 @@ func (m *ClusterMonitor) Stop() {
 	if !m.running.CompareAndSwap(true, false) {
 		return // not running
 	}
+	m.stopMu.Lock()
 	close(m.stopCh)
+	m.stopMu.Unlock()
 	m.wg.Wait()
 	m.logger.Info().Msg("ClusterMonitor stopped")
 }

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -73,6 +73,12 @@ type Prober struct {
 	// race with Destroy() setting queue to nil.
 	queueMu sync.RWMutex
 
+	// destroyOnce makes Destroy() idempotent: closing resultChan and tearing
+	// down the queue must happen exactly once even if Destroy is called
+	// multiple times (e.g. Agent.Stop after a partial start), otherwise the
+	// second close(resultChan) panics.
+	destroyOnce sync.Once
+
 	// rateMu guards the send-rate limiter, which SetPerTargetRateLimit may update from
 	// a different goroutine than the probe loop.
 	rateMu       sync.Mutex // guards limiter and perTargetPPS; lock order: targetsMu -> rateMu
@@ -172,14 +178,20 @@ func (p *Prober) Stop() {
 // per-target cadence is preserved as the pinglist grows or shrinks. A
 // non-positive pps disables rate limiting. Safe to call while running.
 func (p *Prober) SetPerTargetRateLimit(pps float64) {
+	// Hold targetsMu across the whole rate update, taking rateMu nested. This
+	// matches UpdateTargets' lock order (targetsMu -> rateMu) and closes a
+	// TOCTOU window: reading len(targets) and recomputing the aggregate rate
+	// must be atomic w.r.t. a concurrent UpdateTargets, otherwise the two could
+	// interleave and leave the limiter with a rate computed from a stale count.
 	p.targetsMu.RLock()
+	defer p.targetsMu.RUnlock()
 	n := len(p.targets)
-	p.targetsMu.RUnlock()
 
 	p.rateMu.Lock()
 	p.perTargetPPS = pps
 	p.limiter.SetRate(pps * float64(n))
 	p.rateMu.Unlock()
+
 	p.logger.Info().
 		Float64("per_target_pps", pps).
 		Int("targets", n).
@@ -316,7 +328,9 @@ func (p *Prober) sendProbes(ctx context.Context) {
 		counter := uint64(p.seqCounter.Add(1))
 		seqNum := (uint64(p.agentEpoch) << 32) | (counter & 0xFFFFFFFF)
 
-		// Parse the target GID string into a [16]byte for the RDMA layer.
+		// Parse the target GID string into a [16]byte for the RDMA layer. Do
+		// this BEFORE registering the pending entry so a malformed target never
+		// leaves an orphaned entry behind.
 		targetGID, err := probe.ParseGID(target.GetTargetGid())
 		if err != nil {
 			p.logger.Error().Err(err).
@@ -325,6 +339,23 @@ func (p *Prober) sendProbes(ctx context.Context) {
 				Msg("Failed to parse target GID, skipping target")
 			continue
 		}
+
+		// Register the pending entry BEFORE sending. SendProbe blocks until the
+		// send completion (T2), and on a low-latency RNIC an ACK can reach
+		// ackProcessLoop before SendProbe returns. Registering first guarantees
+		// the ACK handlers find the entry instead of dropping the ACK as an
+		// "unknown sequence number" and letting the probe falsely time out. The
+		// send-side timestamps are applied after the send via ApplySend, and
+		// Complete() requires them, so the ACK handlers cannot finalize (and
+		// delete) the entry before this send path records T1/T2.
+		pp := &pendingProbe{
+			target:    target,
+			meas:      probe.NewPendingMeasurement(),
+			createdAt: time.Now(),
+		}
+		p.pendingMu.Lock()
+		p.pending[seqNum] = pp
+		p.pendingMu.Unlock()
 
 		// Send the probe packet. SendProbe is synchronous: it posts the
 		// packet and waits for the send completion within the timeout.
@@ -337,24 +368,36 @@ func (p *Prober) sendProbes(ctx context.Context) {
 		)
 
 		if result.Error != nil {
+			// The send failed, so no ACK will ever complete this probe. Remove
+			// the pending entry and emit a failed result so the loss is counted
+			// in probe_failed_total rather than vanishing until the stale sweep.
+			p.pendingMu.Lock()
+			delete(p.pending, seqNum)
+			p.pendingMu.Unlock()
+
 			p.logger.Error().Err(result.Error).
 				Str("target_gid", target.GetTargetGid()).
 				Uint32("target_qpn", target.GetTargetQpn()).
 				Uint64("seq", seqNum).
 				Msg("Failed to send probe packet")
+			p.emitResult(newFailedResult(seqNum, target, fmt.Sprintf("probe send failed: %v", result.Error)))
 			continue
 		}
 
-		// Record the pending probe with T1 and T2 from the send result. The
-		// PendingMeasurement will absorb the two ACKs in whatever order they
-		// arrive.
+		// Apply the send-side timestamps T1/T2 now that the send completed. If
+		// both ACKs already arrived while the send was in progress, this is the
+		// call that finally completes the measurement; finalize it here rather
+		// than losing it.
 		p.pendingMu.Lock()
-		p.pending[seqNum] = &pendingProbe{
-			target:    target,
-			meas:      probe.NewPendingMeasurement(result.T1NS, result.T2NS),
-			createdAt: time.Now(),
+		var finalized *probe.ProbeResult
+		if cur, ok := p.pending[seqNum]; ok {
+			cur.meas.ApplySend(result.T1NS, result.T2NS)
+			finalized = p.finalizeIfCompleteLocked(seqNum, cur)
 		}
 		p.pendingMu.Unlock()
+		if finalized != nil {
+			p.deliverResult(seqNum, target, finalized)
+		}
 
 		p.logger.Debug().
 			Str("target_gid", target.GetTargetGid()).
@@ -571,24 +614,51 @@ func (p *Prober) finalizeIfCompleteLocked(seqNum uint64, pp *pendingProbe) *prob
 		return nil
 	}
 
-	// Build the target GID from the pending probe's target information.
-	var targetGID [16]byte
-	if parsedGID, err := probe.ParseGID(pp.target.GetTargetGid()); err == nil {
-		targetGID = parsedGID
-	}
-
 	result := pp.meas.Result()
-	result.SequenceNum = seqNum
-	result.TargetGID = targetGID
-	result.TargetQPN = pp.target.GetTargetQpn()
-	result.FlowLabel = pp.target.GetFlowLabel()
+	fillTargetMetadata(&result, seqNum, pp.target)
 	result.Success = true
-	result.TargetIP = pp.target.GetTargetIp()
-	result.TargetHostname = pp.target.GetTargetHostname()
-	result.TargetTorID = pp.target.GetTargetTorId()
 
 	delete(p.pending, seqNum)
 	return &result
+}
+
+// fillTargetMetadata copies the sequence number and per-target metadata into a
+// ProbeResult. Shared by the success, send-failure, and stale-timeout paths so
+// they cannot diverge on which fields a result carries.
+func fillTargetMetadata(result *probe.ProbeResult, seqNum uint64, target *controller_agent.PingTarget) {
+	result.SequenceNum = seqNum
+	result.TargetQPN = target.GetTargetQpn()
+	result.FlowLabel = target.GetFlowLabel()
+	result.TargetIP = target.GetTargetIp()
+	result.TargetHostname = target.GetTargetHostname()
+	result.TargetTorID = target.GetTargetTorId()
+	if parsedGID, err := probe.ParseGID(target.GetTargetGid()); err == nil {
+		result.TargetGID = parsedGID
+	}
+}
+
+// newFailedResult builds a Success=false ProbeResult carrying the target
+// metadata and an error message, used when a probe send fails outright.
+func newFailedResult(seqNum uint64, target *controller_agent.PingTarget, errMsg string) *probe.ProbeResult {
+	result := &probe.ProbeResult{}
+	fillTargetMetadata(result, seqNum, target)
+	result.Success = false
+	result.ErrorMessage = errMsg
+	return result
+}
+
+// emitResult delivers a result on resultChan without blocking. A non-blocking
+// send keeps a slow consumer from stalling the probe or ACK loops (which may
+// hold pendingMu at the call site's caller); a full channel drops the result
+// with a warning.
+func (p *Prober) emitResult(result *probe.ProbeResult) {
+	select {
+	case p.resultChan <- result:
+	default:
+		p.logger.Warn().
+			Uint64("seq", result.SequenceNum).
+			Msg("Result channel full, dropping probe result")
+	}
 }
 
 // deliverResult computes RTT metrics for a completed probe and emits it on the
@@ -612,15 +682,7 @@ func (p *Prober) deliverResult(seqNum uint64, target *controller_agent.PingTarge
 		Int64("prober_delay_ns", rtt.ProberDelay).
 		Msg("Probe completed with all 6 timestamps")
 
-	// Send the result to the results channel. Use a non-blocking send
-	// to avoid blocking the ACK processing loop if the consumer is slow.
-	select {
-	case p.resultChan <- result:
-	default:
-		p.logger.Warn().
-			Uint64("seq", seqNum).
-			Msg("Result channel full, dropping probe result")
-	}
+	p.emitResult(result)
 }
 
 // cleanupStalePending removes entries from the pending map that are older
@@ -635,18 +697,12 @@ func (p *Prober) cleanupStalePending() {
 	p.pendingMu.Lock()
 	for seqNum, pp := range p.pending {
 		if now.Sub(pp.createdAt) > stalePendingTimeout {
+			// Preserve any partial timestamps the measurement collected, then
+			// overlay the target metadata and failure state.
 			result := pp.meas.Result()
-			result.SequenceNum = seqNum
-			result.TargetQPN = pp.target.GetTargetQpn()
-			result.FlowLabel = pp.target.GetFlowLabel()
+			fillTargetMetadata(&result, seqNum, pp.target)
 			result.Success = false
 			result.ErrorMessage = "timed out waiting for ACKs"
-			result.TargetIP = pp.target.GetTargetIp()
-			result.TargetHostname = pp.target.GetTargetHostname()
-			result.TargetTorID = pp.target.GetTargetTorId()
-			if parsedGID, err := probe.ParseGID(pp.target.GetTargetGid()); err == nil {
-				result.TargetGID = parsedGID
-			}
 			stale = append(stale, &result)
 			delete(p.pending, seqNum)
 		}
@@ -656,13 +712,7 @@ func (p *Prober) cleanupStalePending() {
 	// Emit outside pendingMu; non-blocking like deliverResult so a slow
 	// consumer cannot stall the probe loop.
 	for _, result := range stale {
-		select {
-		case p.resultChan <- result:
-		default:
-			p.logger.Warn().
-				Uint64("seq", result.SequenceNum).
-				Msg("Result channel full, dropping timed-out probe result")
-		}
+		p.emitResult(result)
 	}
 
 	if len(stale) > 0 {
@@ -693,12 +743,14 @@ func (p *Prober) GetQueueInfo() rdmabridge.QueueInfo {
 // when the channel is closed.
 func (p *Prober) Destroy() {
 	p.Stop()
-	close(p.resultChan)
-	p.queueMu.Lock()
-	if p.queue != nil {
-		p.queue.Destroy()
-		p.queue = nil
-	}
-	p.queueMu.Unlock()
-	p.logger.Info().Msg("Prober destroyed")
+	p.destroyOnce.Do(func() {
+		close(p.resultChan)
+		p.queueMu.Lock()
+		if p.queue != nil {
+			p.queue.Destroy()
+			p.queue = nil
+		}
+		p.queueMu.Unlock()
+		p.logger.Info().Msg("Prober destroyed")
+	})
 }

--- a/rebuild/internal/probe/pending.go
+++ b/rebuild/internal/probe/pending.go
@@ -1,9 +1,17 @@
 package probe
 
-// PendingMeasurement tracks the in-flight 6-timestamp state of a single probe
-// as its two ACKs arrive. The two ACKs may arrive out of order (the second ACK
-// can be delivered before the first), so this state machine records whichever
-// arrives first and only reports completion once both have been seen.
+// PendingMeasurement tracks the in-flight 6-timestamp state of a single probe.
+//
+// The three inputs — the send-side timestamps (T1/T2), the first ACK, and the
+// second ACK — can arrive in ANY order relative to one another. In particular
+// an ACK can arrive before the send-side timestamps are known: SendProbe
+// blocks until its own send completion (T2), and on a low-latency RNIC the ACK
+// can reach the ACK-processing loop before the send call has returned and
+// recorded T1/T2. The pending entry is therefore created (and its sequence
+// number registered) BEFORE the send, and the send-side timestamps are applied
+// afterwards via ApplySend. This state machine buffers whichever inputs arrive
+// first and only reports completion once all three are present. The two ACKs
+// may themselves also arrive out of order (second before first).
 //
 // PendingMeasurement is NOT safe for concurrent use; callers must provide their
 // own synchronization (the prober guards it with its pending-map mutex).
@@ -18,14 +26,28 @@ type PendingMeasurement struct {
 	T5 uint64 // Prober first ACK recv timestamp
 	T6 uint64 // Prober second ACK recv time (CLOCK_MONOTONIC, same domain as T1)
 
+	sendApplied      bool
 	firstAckArrived  bool
 	secondAckArrived bool
 }
 
-// NewPendingMeasurement creates a pending measurement seeded with T1 and T2,
-// which are known at probe-send time.
-func NewPendingMeasurement(t1, t2 uint64) *PendingMeasurement {
-	return &PendingMeasurement{T1: t1, T2: t2}
+// NewPendingMeasurement creates an empty pending measurement. It is registered
+// at probe-send time BEFORE the send so that an ACK arriving before the send
+// completes still finds its pending entry; the send-side timestamps (T1/T2)
+// are filled in afterwards via ApplySend.
+func NewPendingMeasurement() *PendingMeasurement {
+	return &PendingMeasurement{}
+}
+
+// ApplySend records the send-side timestamps T1 (prober send time) and T2
+// (send-completion timestamp), which become known only once SendProbe returns.
+// Until this is called the measurement can never be Complete(), so the ACK
+// handlers cannot finalize (and delete) the entry before the send path has
+// recorded T1/T2 — even if both ACKs have already arrived.
+func (m *PendingMeasurement) ApplySend(t1, t2 uint64) {
+	m.T1 = t1
+	m.T2 = t2
+	m.sendApplied = true
 }
 
 // ApplyFirstAck records the timestamps associated with the first ACK: T3 (the
@@ -52,10 +74,13 @@ func (m *PendingMeasurement) ApplySecondAck(t3, t4, t6 uint64) {
 	m.secondAckArrived = true
 }
 
-// Complete reports whether both ACKs have arrived and the measurement is ready
-// to be finalized into a ProbeResult.
+// Complete reports whether all three inputs — the send-side timestamps and
+// both ACKs — have arrived, so the measurement is ready to be finalized into a
+// ProbeResult. Requiring sendApplied guarantees T1/T2 are present in the
+// result and that an ACK-only arrival (before the send completes) cannot
+// finalize the entry prematurely.
 func (m *PendingMeasurement) Complete() bool {
-	return m.firstAckArrived && m.secondAckArrived
+	return m.sendApplied && m.firstAckArrived && m.secondAckArrived
 }
 
 // Result copies the six timestamps into a ProbeResult. Caller-owned fields

--- a/rebuild/internal/probe/pending_test.go
+++ b/rebuild/internal/probe/pending_test.go
@@ -2,13 +2,18 @@ package probe
 
 import "testing"
 
-// TestPendingMeasurement_InOrder verifies the normal case where the first ACK
-// arrives before the second ACK.
+// TestPendingMeasurement_InOrder verifies the normal case where the send-side
+// timestamps are applied first, then the first ACK, then the second ACK.
 func TestPendingMeasurement_InOrder(t *testing.T) {
-	m := NewPendingMeasurement(100, 101)
+	m := NewPendingMeasurement()
 
 	if m.Complete() {
-		t.Fatal("measurement should not be complete before any ACK")
+		t.Fatal("measurement should not be complete before any input")
+	}
+
+	m.ApplySend(100 /*t1*/, 101 /*t2*/)
+	if m.Complete() {
+		t.Fatal("measurement should not be complete after only the send timestamps")
 	}
 
 	m.ApplyFirstAck(200 /*t3*/, 301 /*t5*/)
@@ -18,7 +23,7 @@ func TestPendingMeasurement_InOrder(t *testing.T) {
 
 	m.ApplySecondAck(200 /*t3*/, 202 /*t4*/, 302 /*t6*/)
 	if !m.Complete() {
-		t.Fatal("measurement should be complete after both ACKs")
+		t.Fatal("measurement should be complete after send timestamps and both ACKs")
 	}
 
 	got := m.Result()
@@ -33,7 +38,8 @@ func TestPendingMeasurement_InOrder(t *testing.T) {
 // timestamps intact. This is the regression guard for the reorder bug where a
 // second-ACK-first arrival orphaned the first ACK and lost the measurement.
 func TestPendingMeasurement_OutOfOrder(t *testing.T) {
-	m := NewPendingMeasurement(100, 101)
+	m := NewPendingMeasurement()
+	m.ApplySend(100, 101)
 
 	// Second ACK arrives first: T3, T4, T6 recorded; T5 still unknown.
 	m.ApplySecondAck(200 /*t3*/, 202 /*t4*/, 302 /*t6*/)
@@ -54,12 +60,65 @@ func TestPendingMeasurement_OutOfOrder(t *testing.T) {
 	}
 }
 
+// TestPendingMeasurement_BothAcksBeforeSend verifies the low-latency race that
+// motivated registering the pending entry before the send: both ACKs can be
+// processed before SendProbe returns and applies T1/T2. The measurement must
+// NOT be considered complete until ApplySend supplies the send-side
+// timestamps, at which point it completes with all six timestamps intact.
+func TestPendingMeasurement_BothAcksBeforeSend(t *testing.T) {
+	m := NewPendingMeasurement()
+
+	// Both ACKs arrive while the send is still in progress (T1/T2 unknown).
+	m.ApplyFirstAck(200 /*t3*/, 301 /*t5*/)
+	m.ApplySecondAck(200 /*t3*/, 202 /*t4*/, 302 /*t6*/)
+	if m.Complete() {
+		t.Fatal("measurement must not complete before the send timestamps are applied")
+	}
+
+	// The send finally completes and records T1/T2, completing the measurement.
+	m.ApplySend(100 /*t1*/, 101 /*t2*/)
+	if !m.Complete() {
+		t.Fatal("measurement should be complete once the send timestamps arrive after both ACKs")
+	}
+
+	got := m.Result()
+	want := ProbeResult{T1: 100, T2: 101, T3: 200, T4: 202, T5: 301, T6: 302}
+	if got != want {
+		t.Errorf("Result = %+v, want %+v", got, want)
+	}
+}
+
+// TestPendingMeasurement_OneAckBeforeSend covers the mixed case where only one
+// ACK beats the send completion.
+func TestPendingMeasurement_OneAckBeforeSend(t *testing.T) {
+	m := NewPendingMeasurement()
+
+	// First ACK beats the send completion.
+	m.ApplyFirstAck(200, 301)
+	m.ApplySend(100, 101)
+	if m.Complete() {
+		t.Fatal("measurement should not be complete with only send timestamps and first ACK")
+	}
+
+	m.ApplySecondAck(200, 202, 302)
+	if !m.Complete() {
+		t.Fatal("measurement should be complete once the second ACK arrives")
+	}
+
+	got := m.Result()
+	want := ProbeResult{T1: 100, T2: 101, T3: 200, T4: 202, T5: 301, T6: 302}
+	if got != want {
+		t.Errorf("Result = %+v, want %+v", got, want)
+	}
+}
+
 // TestPendingMeasurement_FirstAckT3Wins verifies that when the two ACKs carry
 // differing T3 values (e.g., due to a responder-side quirk), the first ACK's
 // T3 is used regardless of arrival order.
 func TestPendingMeasurement_FirstAckT3Wins(t *testing.T) {
 	// First ACK arrives first, then second ACK carries a different T3.
-	m1 := NewPendingMeasurement(100, 101)
+	m1 := NewPendingMeasurement()
+	m1.ApplySend(100, 101)
 	m1.ApplyFirstAck(200, 301)
 	m1.ApplySecondAck(999 /*divergent t3*/, 202, 302)
 	if m1.Result().T3 != 200 {
@@ -68,7 +127,8 @@ func TestPendingMeasurement_FirstAckT3Wins(t *testing.T) {
 
 	// Second ACK arrives first with a divergent T3, then the first ACK
 	// overwrites it with the authoritative value.
-	m2 := NewPendingMeasurement(100, 101)
+	m2 := NewPendingMeasurement()
+	m2.ApplySend(100, 101)
 	m2.ApplySecondAck(999 /*divergent t3*/, 202, 302)
 	if m2.Result().T3 != 999 {
 		t.Errorf("out-of-order interim: T3 = %d, want 999 (only second ACK seen)", m2.Result().T3)
@@ -83,7 +143,8 @@ func TestPendingMeasurement_FirstAckT3Wins(t *testing.T) {
 // measurement produces a ProbeResult that CalculateRTT accepts as valid once
 // the caller-owned Success flag is set.
 func TestPendingMeasurement_ResultFeedsCalculateRTT(t *testing.T) {
-	m := NewPendingMeasurement(100_000, 101_000)
+	m := NewPendingMeasurement()
+	m.ApplySend(100_000, 101_000)
 	m.ApplyFirstAck(200_000, 301_000)
 	m.ApplySecondAck(200_000, 202_000, 302_000)
 

--- a/rebuild/zig/src/cq.zig
+++ b/rebuild/zig/src/cq.zig
@@ -290,11 +290,9 @@ fn dispatchClassicWc(queue: *types.UdQueue, wc: *const c.ibv_wc) void {
     const status_int: i32 = @intCast(wc.status);
     if (wc.opcode == c.IBV_WC_SEND) {
         log.debug("@{x} SEND (classic) status={d}", .{ @intFromPtr(queue), status_int });
-        // Signal the waiting sender thread with a SW timestamp.
-        const ts = swTimestampNs();
-        queue.send_completion_timestamp.store(ts, .release);
-        queue.send_completion_status.store(status_int, .release);
-        queue.send_completion_ready.store(true, .release);
+        // Signal the waiting sender thread with a SW timestamp, matched by
+        // wr_id (see signalSendCompletion / the mailbox invariant in types.zig).
+        signalSendCompletion(queue, wc.wr_id, swTimestampNs(), status_int);
     } else if (wc.opcode == c.IBV_WC_RECV) {
         log.debug("@{x} RECV (classic) status={d}", .{ @intFromPtr(queue), status_int });
         if (wc.status == c.IBV_WC_SUCCESS) {
@@ -504,23 +502,34 @@ pub fn processRecvCompletion(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
 // Send completion processing
 // ---------------------------------------------------------------------------
 
-/// Process a single send completion.
+/// Process a single send completion (extended CQ path).
 ///
-/// Extracts the timestamp from the completion and signals the waiting sender
-/// thread via the atomic variables on the UdQueue struct. The sender thread
-/// spins on send_completion_ready after posting a send WR and reads the
-/// timestamp and status once the flag becomes true.
+/// Extracts the timestamp, status, and wr_id from the completion and hands
+/// them to signalSendCompletion(), which frees the send slot and publishes the
+/// result to the waiting sender.
 pub fn processSendCompletion(queue: *types.UdQueue, cq: *c.ibv_cq_ex) void {
-    // Get timestamp
     const timestamp_ns: u64 = getCompletionTimestamp(queue, cq);
-
-    // Get completion status
     const status: i32 = @intCast(cq.status);
+    signalSendCompletion(queue, cq.wr_id, timestamp_ns, status);
+}
 
-    // Signal the waiting sender with the result
-    queue.send_completion_timestamp.store(timestamp_ns, .release);
-    queue.send_completion_status.store(status, .release);
-    queue.send_completion_ready.store(true, .release);
+/// Free the completed send's slot and publish its result to the waiting sender.
+///
+/// The slot is freed here (not by the sender) so that a late completion for a
+/// timed-out send still returns its slot for reuse. The completed wr_id is
+/// stored LAST with release ordering: the waiter in waitSendCompletion() spins
+/// on send_completion_wr_id with acquire ordering, so it only observes the
+/// timestamp/status once its own wr_id is published. See the mailbox invariant
+/// comment in types.zig.
+fn signalSendCompletion(queue: *types.UdQueue, wr_id: u64, timestamp_ns: u64, status: i32) void {
+    const slot_index: u32 = @intCast(wr_id & 0xFFFFFFFF);
+    queue.freeSendSlot(slot_index);
+
+    queue.send_completion_timestamp.store(timestamp_ns, .monotonic);
+    queue.send_completion_status.store(status, .monotonic);
+    // Publish last: this release pairs with the sender's acquire load and makes
+    // the timestamp/status above visible once the wr_id matches.
+    queue.send_completion_wr_id.store(wr_id, .release);
 }
 
 // ---------------------------------------------------------------------------

--- a/rebuild/zig/src/packet.zig
+++ b/rebuild/zig/src/packet.zig
@@ -223,48 +223,47 @@ pub fn deserializeProbePacket(buf: *const [40]u8) ProbePacket {
 // Send slot management
 // ---------------------------------------------------------------------------
 
-/// Find a free send slot in the queue.
+/// Find a free send slot in the queue, atomically marking it InUse.
 ///
-/// Scans the send_slot_states array for a slot in the Free state.
-/// If found, marks it as InUse and returns the slot index.
-/// Returns null if no free slot is available.
+/// Thin wrapper over UdQueue.allocSendSlot(). Returns the slot index, or null
+/// if no free slot is available.
 pub fn findFreeSendSlot(queue: *types.UdQueue) ?u32 {
-    for (0..types.NUM_SEND_SLOTS) |i| {
-        const idx: u32 = @intCast(i);
-        if (queue.send_slot_states[idx] == .Free) {
-            queue.send_slot_states[idx] = .InUse;
-            return idx;
-        }
-    }
-    return null;
+    return queue.allocSendSlot();
 }
 
-/// Free a send slot, marking it as available for reuse.
+/// Free a send slot, marking it as available for reuse. Thin wrapper over
+/// UdQueue.freeSendSlot().
 pub fn freeSendSlot(queue: *types.UdQueue, slot_index: u32) void {
-    if (slot_index < types.NUM_SEND_SLOTS) {
-        queue.send_slot_states[slot_index] = .Free;
-    }
+    queue.freeSendSlot(slot_index);
 }
 
 // ---------------------------------------------------------------------------
 // Send completion waiting
 // ---------------------------------------------------------------------------
 
-/// Wait for a send completion by spinning on the atomic flag.
+/// Wait for the send completion whose wr_id equals expected_wr_id.
 ///
-/// The CQ poller thread sets send_completion_ready to true after processing
-/// a send completion. This function spins until the flag is set or the
-/// timeout expires.
+/// The CQ poller publishes each completed send by writing timestamp/status and
+/// then storing the completed wr_id LAST (release). This function spins until
+/// the mailbox shows ITS OWN wr_id (acquire) and only then reads the matching
+/// timestamp/status. Completions for OTHER wr_ids (e.g. a late completion from
+/// a previously timed-out send whose slot was intentionally left allocated)
+/// are ignored, which is what prevents send-completion crosstalk: a stale
+/// completion can no longer be misread as this send's T2/status.
+///
+/// Because there is a single sender per queue and a QP reports send completions
+/// in post order, this send's completion is always the last to be published,
+/// so once its wr_id appears it will not be overwritten. The waiter therefore
+/// never needs to reset the mailbox (which could race the poller's next store
+/// and lose a wakeup).
 ///
 /// Returns the send completion timestamp on success, or an error on timeout
 /// or completion failure.
-pub fn waitSendCompletion(queue: *types.UdQueue, timeout_ms: u32) PacketError!u64 {
+pub fn waitSendCompletion(queue: *types.UdQueue, expected_wr_id: u64, timeout_ms: u32) PacketError!u64 {
     const timeout_ns: u64 = @as(u64, timeout_ms) * 1_000_000;
     const start_ns: u64 = getMonotonicNs();
 
-    // Spin-wait on the send_completion_ready atomic flag
-    while (!queue.send_completion_ready.load(.acquire)) {
-        // Check for timeout
+    while (queue.send_completion_wr_id.load(.acquire) != expected_wr_id) {
         const elapsed = getMonotonicNs() - start_ns;
         if (elapsed >= timeout_ns) {
             types.setLastError("timed out waiting for send completion");
@@ -275,15 +274,15 @@ pub fn waitSendCompletion(queue: *types.UdQueue, timeout_ms: u32) PacketError!u6
         std.atomic.spinLoopHint();
     }
 
-    // Check completion status
-    const status = queue.send_completion_status.load(.acquire);
+    // Our wr_id is published; the release/acquire handoff guarantees the
+    // timestamp/status written before it are visible.
+    const status = queue.send_completion_status.load(.monotonic);
     if (status != 0) {
         types.setLastError("send completion reported error status");
         return PacketError.SendCompletionFailed;
     }
 
-    // Read the completion timestamp
-    return queue.send_completion_timestamp.load(.acquire);
+    return queue.send_completion_timestamp.load(.monotonic);
 }
 
 // ---------------------------------------------------------------------------
@@ -321,12 +320,23 @@ fn sendPacketInternal(
     pkt: *const ProbePacket,
     timeout_ms: u32,
 ) PacketError!u64 {
-    // Step 1: Find a free send slot
+    // Step 1: Find a free send slot. Slots are freed by the CQ poller when the
+    // send completes, so a slot is available only if its previous WR has fully
+    // completed -- never one with an outstanding (e.g. timed-out) WR.
     const slot_index = findFreeSendSlot(queue) orelse {
         types.setLastError("no free send slot available");
         return PacketError.NoFreeSendSlot;
     };
-    errdefer freeSendSlot(queue, slot_index);
+    // wr_id == slot index. With no slot reuse while a WR is outstanding, the
+    // slot index uniquely identifies the in-flight send for mailbox matching.
+    const wr_id: u64 = @intCast(slot_index);
+
+    // Slot-freeing ownership below is deliberate: until ibv_post_send succeeds
+    // there is no outstanding WR, so this function must free the slot on every
+    // early-error path. Once the WR is posted, the slot must NOT be freed here
+    // -- the CQ poller frees it when the completion arrives, even if that is a
+    // late completion after a SendTimeout. Freeing (and reusing) an
+    // outstanding WR's slot is exactly what causes send-completion crosstalk.
 
     // Step 2: Get the slot buffer pointer and serialize the packet
     const slot_ptr = memory.getSlotPtr(queue.send_buf, slot_index, types.NUM_SEND_SLOTS) catch {
@@ -345,8 +355,12 @@ fn sendPacketInternal(
     };
     defer queue_module.destroyAddressHandle(ah);
 
-    // Step 4: Reset the send completion flag before posting
-    queue.send_completion_ready.store(false, .release);
+    // Step 4: Reset the completion mailbox before posting so that a reused
+    // slot's previous completion value cannot false-match our wait. Safe under
+    // the single-sender contract: our previous send on this slot already
+    // completed (that is why the slot was free), so no completion carrying
+    // this wr_id is still in flight to be lost by the reset.
+    queue.send_completion_wr_id.store(types.SEND_WR_ID_NONE, .release);
 
     // Step 5: Build and post the send work request
     var sge = c.ibv_sge{
@@ -356,7 +370,7 @@ fn sendPacketInternal(
     };
 
     var wr = std.mem.zeroes(c.ibv_send_wr);
-    wr.wr_id = @intCast(slot_index);
+    wr.wr_id = wr_id;
     wr.sg_list = &sge;
     wr.num_sge = 1;
     wr.opcode = c.IBV_WR_SEND;
@@ -369,20 +383,16 @@ fn sendPacketInternal(
     const ret = c.ibv_post_send(queue.qp, &wr, &bad_wr);
     if (ret != 0) {
         types.setLastError("ibv_post_send() failed");
+        // No WR was accepted by the QP, so no completion will ever arrive to
+        // free this slot; free it here.
         freeSendSlot(queue, slot_index);
         return PacketError.PostSendFailed;
     }
 
-    // Step 6: Wait for send completion
-    const timestamp = waitSendCompletion(queue, timeout_ms) catch |err| {
-        freeSendSlot(queue, slot_index);
-        return err;
-    };
-
-    // Step 7: Free the send slot
-    freeSendSlot(queue, slot_index);
-
-    return timestamp;
+    // Step 6: Wait for this send's completion (matched by wr_id). On timeout we
+    // intentionally leave the slot allocated: the WR is still outstanding and
+    // its (late) completion is the only safe point to reclaim the slot.
+    return try waitSendCompletion(queue, wr_id, timeout_ms);
 }
 
 // ---------------------------------------------------------------------------

--- a/rebuild/zig/src/queue.zig
+++ b/rebuild/zig/src/queue.zig
@@ -156,10 +156,10 @@ pub fn createQueue(
         .event_ring = event_ring,
         .cq_thread = null,
         .device = dev,
-        .send_slot_states = [_]types.SlotState{types.SlotState.Free} ** types.NUM_SEND_SLOTS,
+        .send_slot_states = [_]std.atomic.Value(u8){std.atomic.Value(u8).init(@intFromEnum(types.SlotState.Free))} ** types.NUM_SEND_SLOTS,
         .recv_slot_states = [_]types.SlotState{types.SlotState.Free} ** types.NUM_RECV_SLOTS,
         .running = std.atomic.Value(bool).init(false),
-        .send_completion_ready = std.atomic.Value(bool).init(false),
+        .send_completion_wr_id = std.atomic.Value(u64).init(types.SEND_WR_ID_NONE),
         .send_completion_timestamp = std.atomic.Value(u64).init(0),
         .send_completion_status = std.atomic.Value(i32).init(0),
     };

--- a/rebuild/zig/src/types.zig
+++ b/rebuild/zig/src/types.zig
@@ -45,6 +45,12 @@ pub const NUM_SEND_SLOTS: u32 = 32;
 /// Number of receive slots in the receive memory region.
 pub const NUM_RECV_SLOTS: u32 = 32;
 
+/// Sentinel for `UdQueue.send_completion_wr_id` meaning "no completion has
+/// been published for the current in-flight send yet". A genuine send wr_id
+/// is a slot index (0..NUM_SEND_SLOTS-1), so this all-ones value can never
+/// collide with a real completion.
+pub const SEND_WR_ID_NONE: u64 = std.math.maxInt(u64);
+
 /// Size of each buffer slot: MR_SIZE (payload) + GRH_SIZE (header).
 /// For receive buffers the hardware writes GRH_SIZE bytes of GRH followed
 /// by up to MR_SIZE bytes of payload into each slot.
@@ -187,8 +193,12 @@ pub const UdQueue = struct {
     /// Back-pointer to the parent device.
     device: *RdmaDevice,
 
-    /// Per-slot state tracking for send buffers.
-    send_slot_states: [NUM_SEND_SLOTS]SlotState,
+    /// Per-slot state tracking for send buffers, stored atomically (as the
+    /// SlotState enum's u8 tag). Slots are allocated by the sender thread via
+    /// allocSendSlot() and freed by the CQ poller thread via freeSendSlot()
+    /// once a send completion arrives, so the two threads access this array
+    /// concurrently; the atomic access keeps that race-free.
+    send_slot_states: [NUM_SEND_SLOTS]std.atomic.Value(u8),
 
     /// Per-slot state tracking for receive buffers.
     recv_slot_states: [NUM_RECV_SLOTS]SlotState,
@@ -199,30 +209,73 @@ pub const UdQueue = struct {
 
     // ----- Send completion signaling (synchronous send path) -----
     //
-    // IMPORTANT invariant: these three fields form a single-slot mailbox,
-    // not a queue. They implicitly assume "one UdQueue is driven by at most
-    // one sender goroutine/thread at a time" -- i.e. a caller posts a send
-    // WR, then immediately waits on send_completion_ready before posting
-    // another. If this queue is ever shared by multiple concurrent senders
-    // (e.g. a future change that parallelizes probing across goroutines
-    // using the same UdQueue), a second sendPacketInternal() call could
-    // overwrite send_completion_ready/timestamp/status while a first call
-    // is still spinning on waitSendCompletion(), causing one sender to read
-    // the other's completion (wrong timestamp) or to hang. Do not remove
-    // the "1 Queue = 1 sender at a time" contract without replacing this
-    // mailbox with a per-request completion slot (e.g. keyed by wr_id).
+    // These fields form a single-slot mailbox, not a queue. They assume
+    // "one UdQueue is driven by at most one sender thread at a time" -- a
+    // caller posts a send WR, then waits on waitSendCompletion() before
+    // posting another. The mailbox is matched by wr_id (= the send slot
+    // index): the CQ poller publishes the completed send's wr_id LAST, with
+    // release ordering, after writing timestamp/status; the waiting sender
+    // spins until it observes ITS OWN wr_id (acquire) and only then trusts
+    // timestamp/status.
+    //
+    // wr_id matching is what makes a LATE completion harmless: if a send
+    // times out, its slot is deliberately left allocated (not reused) until
+    // its completion finally arrives, so a stale completion publishes a wr_id
+    // that no current waiter is looking for and is simply ignored -- it can
+    // no longer be misread as the next send's T2/status. Because there is a
+    // single sender and a QP delivers send completions in post order, the
+    // current send's completion is always the last to be published, so the
+    // waiter reliably observes its own wr_id without needing to reset the
+    // mailbox from the consumer side (which would risk a lost wakeup).
+    //
+    // Do not remove the "1 Queue = 1 sender at a time" contract without
+    // replacing this mailbox with a per-request completion slot.
 
-    /// Atomic flag set by the CQ poller when a send completion is ready.
-    /// The sender thread spins on this after posting a send WR.
-    send_completion_ready: std.atomic.Value(bool),
+    /// wr_id (send slot index) of the most recently published send completion,
+    /// or SEND_WR_ID_NONE if none is pending. Written LAST by the CQ poller
+    /// with release ordering; read by the sender with acquire ordering. The
+    /// sender resets it to SEND_WR_ID_NONE just before posting so a reused
+    /// slot's previous completion value cannot false-match.
+    send_completion_wr_id: std.atomic.Value(u64),
 
-    /// Send completion timestamp (nanoseconds). Written by the CQ poller,
-    /// read by the sender after send_completion_ready becomes true.
+    /// Send completion timestamp (nanoseconds). Written by the CQ poller
+    /// before send_completion_wr_id, read by the sender once it matches wr_id.
     send_completion_timestamp: std.atomic.Value(u64),
 
     /// Send completion status. 0 = success, nonzero = RDMA error code.
-    /// Written by the CQ poller alongside the timestamp.
+    /// Written by the CQ poller before send_completion_wr_id.
     send_completion_status: std.atomic.Value(i32),
+
+    /// Atomically allocate a free send slot, transitioning it from Free to
+    /// InUse. Returns the slot index, or null if every slot is currently in
+    /// use. Called from the sender thread. The CAS makes concurrent
+    /// allocation safe and, combined with freeSendSlot() running on the CQ
+    /// poller, keeps the send_slot_states array race-free.
+    pub fn allocSendSlot(self: *UdQueue) ?u32 {
+        for (0..NUM_SEND_SLOTS) |i| {
+            const idx: u32 = @intCast(i);
+            if (self.send_slot_states[idx].cmpxchgStrong(
+                @intFromEnum(SlotState.Free),
+                @intFromEnum(SlotState.InUse),
+                .acq_rel,
+                .monotonic,
+            ) == null) {
+                return idx;
+            }
+        }
+        return null;
+    }
+
+    /// Mark a send slot Free so it can be reused. Called by the CQ poller when
+    /// a send completion arrives (the sole reclaim point for a posted WR's
+    /// slot, so a late post-timeout completion still returns its slot), and by
+    /// the sender only for slots whose WR was never actually posted (early
+    /// error paths).
+    pub fn freeSendSlot(self: *UdQueue, slot_index: u32) void {
+        if (slot_index < NUM_SEND_SLOTS) {
+            self.send_slot_states[slot_index].store(@intFromEnum(SlotState.Free), .release);
+        }
+    }
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a set of confirmed race/lifecycle bugs in the probe send path and agent control plane, found by two independent audits. No behavioral change to the happy-path data flow; each fix closes a concurrency or lifecycle hole.

## Findings addressed

1. **[HIGH] Pending measurement registered after `SendProbe` returns.** `SendProbe` blocks until its own send completion (T2). On a low-latency RNIC the ACK can reach `ackProcessLoop` before `SendProbe` returns, so the ACK was dropped as an "unknown sequence number" and the probe falsely timed out. Now the pending entry is registered at sequence-allocation time (before the send); T1/T2 are applied afterwards via `PendingMeasurement.ApplySend`. A failed send deletes the entry and emits a failed `ProbeResult`.
2. **[MEDIUM] Send-completion crosstalk after timeout.** After a `SendTimeout` the WR stayed outstanding, its slot was freed/reused, and a late completion could hand the next sender a wrong T2/status. Fixed with wr_id matching in the completion mailbox plus poller-owned slot reclamation.
3. **[LOW] `Prober.Destroy()` double-close panic.** `close(resultChan)` guarded with `sync.Once`.
4. **[LOW] `ClusterMonitor.Start()` did not recreate `stopCh`.** A Stop→Start cycle left the loop dead. `stopCh` is now recreated in `Start` under a `stopMu`, mirroring the prober.
5. **[LOW] `SetPerTargetRateLimit` TOCTOU.** Now holds `targetsMu` across the rate update, taking `rateMu` nested (matches `UpdateTargets`' lock order).
6. **[LOW] `agent_ip` never set.** Populated best-effort from the host's outbound IP toward the controller (connectionless UDP-dial trick).

## Key design decisions

### Pending-before-send state machine (`internal/probe/pending.go`)
`PendingMeasurement` now has three independent inputs — send-side timestamps (T1/T2), first ACK, second ACK — that may arrive in **any** order. `Complete()` requires **all three**. Requiring `sendApplied` is load-bearing: it prevents an ACK-only arrival (before the send completes) from finalizing and deleting the entry before the send path has recorded T1/T2. The prober registers the entry under `pendingMu` before the send, applies T1/T2 under the same lock after the send, and finalizes there if both ACKs already landed. Out-of-order first/second-ACK handling and "first ACK's T3 wins" are preserved. New unit tests cover both-ACKs-before-send, one-ACK-before-send, and send-failure paths.

### wr_id completion matching (`zig/src/{types,packet,cq}.zig`)
The single-slot send mailbox is now matched by wr_id (= the send slot index). The CQ poller writes timestamp/status and then publishes the completed wr_id **last** with release ordering; `waitSendCompletion` spins until it observes **its own** wr_id (acquire) and only then trusts timestamp/status. A stale completion from a timed-out send publishes a wr_id no current waiter is looking for and is ignored — eliminating the crosstalk. A posted WR's slot is freed **only by the poller** when the completion arrives (even if late), so a timed-out slot is never reused while outstanding; combined with the single-sender + in-order-completion invariant, the current send's completion is always the last published, so the waiter never needs to reset the mailbox (avoiding a lost-wakeup). Send slot state is now atomic (touched by both sender and poller). The C-ABI is unchanged (`UdQueue` is opaque behind a pointer). The invariant is documented in `types.zig`.

## Verification

Run on macOS host with colima (soft-RoCE), Docker image built from `Dockerfile.e2e`:

- **Local:** `go test ./internal/probe/... ./internal/config/...` pass; `go vet` + build of pure-Go controller packages clean; `gofmt` clean.
- **In container (`Dockerfile.e2e`):** `go vet ./...` clean; `go test $(go list ./... | grep -v /e2e)` — **all packages pass** (incl. `internal/agent`, `internal/probe`); `make build` produces both binaries; `make build-zig` succeeds.
- **`make test-e2e-controller`:** **PASS** (all tests); `agent_ip` now flows through the registration pipeline.
- **`make test-e2e` (RDMA soft-RoCE):** fails **only** on the RTT-sign assertion (`NetworkRTT` negative → `probe_success_total == 0`). This is a **pre-existing, environment-bound** failure of soft-RoCE SW-timestamp poll jitter on this colima/macOS host: the untouched base commit (PR #27 merge) fails **identically** (base `NetworkRTT = -96833 ns`; this branch same jitter range). The probe data path itself is fully healthy on this branch — all 6 timestamps collected, first/second ACKs matched, results recorded, clean shutdown with no double-close panic and no send-completion crosstalk. Not a regression from this PR.
- **Zig unit tests:** all pass except `types.test."setLastError truncates long messages"` (signal 6), which also fails **identically on base** and is unrelated to these changes.

Out of scope (unchanged): seq 32-bit wraparound, recv-slot repost / drop_count, multi-RNIC.

Do not merge.
