### PR TITLE
feat(rebuild): probe from every RNIC device, not just devices[0]

### DIFF
--- a/rebuild/e2e/multi_rnic_e2e_test.go
+++ b/rebuild/e2e/multi_rnic_e2e_test.go
@@ -1,0 +1,227 @@
+// Package e2e contains end-to-end tests for the R-Pingmesh system.
+//
+// TestMultiRNICBothDevicesProbe validates the multi-rail fix in
+// internal/agent/agent.go: every opened RDMA device gets its own Prober (not
+// just devices[0]), so on a multi-rail host every RNIC actively probes
+// instead of only being probed BY other agents. This test proves the fix at
+// the Prober/Responder/ClusterMonitor level (the same layer
+// probe_otel_e2e_test.go exercises for a single device) by wiring BOTH
+// rxe0 and rxe1 as prober+responder pairs pointed at each other:
+//
+//	rxe0 prober --probe--> rxe1 responder
+//	rxe1 prober --probe--> rxe0 responder
+//
+// and asserting that both directions independently produce at least one
+// successful (all 6 timestamps collected) ProbeResult.
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/yuuki/rpingmesh/rebuild/internal/agent"
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
+	"github.com/yuuki/rpingmesh/rebuild/internal/rdmabridge"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// TestMultiRNICBothDevicesProbe verifies that when every opened device gets
+// its own Prober and Responder (mirroring what Agent.Initialize now does for
+// every device instead of only devices[0]), both directions of the
+// rxe0<->rxe1 pair independently complete probes. A regression that only
+// wires up devices[0] as a prober would still pass single-device tests like
+// TestRDMAE2ETwoDevices and TestProbeToOTelMetrics but would leave rxe1 (or
+// any non-first device) never sending a single probe -- exactly the blind
+// spot this test is designed to catch.
+func TestMultiRNICBothDevicesProbe(t *testing.T) {
+	if os.Getenv("RDMA_E2E_ENABLED") != "1" {
+		t.Skip("RDMA_E2E_ENABLED not set; run via 'make test-e2e' or set RDMA_E2E_ENABLED=1")
+	}
+
+	const (
+		torA            = "tor-e2e-a"
+		torB            = "tor-e2e-b"
+		probeIntervalMS = uint32(200)
+		resultTimeout   = 20 * time.Second
+	)
+
+	// --- RDMA context ---
+	rdmaCtx, err := rdmabridge.Init()
+	if err != nil {
+		t.Fatalf("rdmabridge.Init: %v", err)
+	}
+	defer rdmaCtx.Destroy()
+
+	// --- Devices: rxe0 and rxe1, each acting as BOTH a prober and a responder ---
+	devA, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	if err != nil {
+		t.Fatalf("open device %q: %v", proberDeviceName, err)
+	}
+	defer devA.Close()
+	t.Logf("device A (%s): GID=%s IP=%s", proberDeviceName, devA.Info.GID, devA.Info.IPAddr)
+
+	devB, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	if err != nil {
+		t.Fatalf("open device %q: %v", responderDeviceName, err)
+	}
+	defer devB.Close()
+	t.Logf("device B (%s): GID=%s IP=%s", responderDeviceName, devB.Info.GID, devB.Info.IPAddr)
+
+	// --- Event rings: one prober ring and one responder ring per device,
+	// matching Agent.createEventRings' one-ring-per-role-per-device layout. ---
+	proberRingA, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create prober ring A: %v", err)
+	}
+	defer proberRingA.Destroy()
+	respRingA, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create responder ring A: %v", err)
+	}
+	defer respRingA.Destroy()
+
+	proberRingB, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create prober ring B: %v", err)
+	}
+	defer proberRingB.Destroy()
+	respRingB, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create responder ring B: %v", err)
+	}
+	defer respRingB.Destroy()
+
+	// --- Responders: one per device, so each device can be probed by the other. ---
+	responderA, err := agent.NewResponder(devA, respRingA)
+	if err != nil {
+		t.Fatalf("NewResponder(A): %v", err)
+	}
+	responderB, err := agent.NewResponder(devB, respRingB)
+	if err != nil {
+		t.Fatalf("NewResponder(B): %v", err)
+	}
+
+	// --- Probers: one per device, each targeting the OTHER device's responder. ---
+	proberA, err := agent.NewProber(devA, proberRingA, probeIntervalMS)
+	if err != nil {
+		t.Fatalf("NewProber(A): %v", err)
+	}
+	proberB, err := agent.NewProber(devB, proberRingB, probeIntervalMS)
+	if err != nil {
+		t.Fatalf("NewProber(B): %v", err)
+	}
+
+	// --- Mock controllers: A's pinglist points at B's responder, and vice versa. ---
+	respAQueueInfo := responderA.GetQueueInfo()
+	respBQueueInfo := responderB.GetQueueInfo()
+
+	clientAToB := &mockControllerClient{
+		targets: []*controller_agent.PingTarget{
+			{
+				TargetGid:        devB.Info.GID,
+				TargetQpn:        respBQueueInfo.QPN,
+				TargetIp:         devB.Info.IPAddr,
+				TargetHostname:   "e2e-device-b",
+				TargetTorId:      torB,
+				TargetDeviceName: devB.Info.DeviceName,
+			},
+		},
+	}
+	clientBToA := &mockControllerClient{
+		targets: []*controller_agent.PingTarget{
+			{
+				TargetGid:        devA.Info.GID,
+				TargetQpn:        respAQueueInfo.QPN,
+				TargetIp:         devA.Info.IPAddr,
+				TargetHostname:   "e2e-device-a",
+				TargetTorId:      torA,
+				TargetDeviceName: devA.Info.DeviceName,
+			},
+		},
+	}
+
+	// updateIntervalSec=3600 so only the initial immediate fetch runs per monitor,
+	// matching NewClusterMonitor's per-device requester GID wiring in
+	// Agent.createClusterMonitors (each device's own GID is its requester_gid).
+	monitorA := agent.NewClusterMonitor(clientAToB, proberA, "e2e-agent", torA, devA.Info.GID, 3600)
+	monitorB := agent.NewClusterMonitor(clientBToA, proberB, "e2e-agent", torB, devB.Info.GID, 3600)
+
+	// --- Start everything: responders first, then probers, then monitors,
+	// matching Agent.Start's ordering. ---
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := responderA.Start(ctx); err != nil {
+		t.Fatalf("responderA.Start: %v", err)
+	}
+	if err := responderB.Start(ctx); err != nil {
+		t.Fatalf("responderB.Start: %v", err)
+	}
+	if err := proberA.Start(ctx); err != nil {
+		t.Fatalf("proberA.Start: %v", err)
+	}
+	if err := proberB.Start(ctx); err != nil {
+		t.Fatalf("proberB.Start: %v", err)
+	}
+	if err := monitorA.Start(ctx); err != nil {
+		t.Fatalf("monitorA.Start: %v", err)
+	}
+	if err := monitorB.Start(ctx); err != nil {
+		t.Fatalf("monitorB.Start: %v", err)
+	}
+
+	// --- Wait for at least one successful (all 6 timestamps collected)
+	// result from EACH direction. result.Success reflects only that the ACK
+	// round trip completed (see Prober.finalizeIfCompleteLocked), independent
+	// of probe.CalculateRTT's Valid verdict, so this assertion is not
+	// sensitive to the small-negative-RTT SW-timestamp jitter documented in
+	// probe_otel_e2e_test.go. ---
+	successA := waitForSuccess(t, "A->B", proberA.Results(), resultTimeout)
+	successB := waitForSuccess(t, "B->A", proberB.Results(), resultTimeout)
+
+	// --- Controlled, symmetric shutdown (mirrors Agent.Stop's ordering:
+	// monitors, then probers, then responders). ---
+	monitorA.Stop()
+	monitorB.Stop()
+	proberA.Destroy()
+	proberB.Destroy()
+	responderA.Destroy()
+	responderB.Destroy()
+
+	if !successA {
+		t.Errorf("device A (%s) never produced a successful probe result targeting device B (%s): "+
+			"this is the multi-rail blind spot this test guards against", proberDeviceName, responderDeviceName)
+	}
+	if !successB {
+		t.Errorf("device B (%s) never produced a successful probe result targeting device A (%s): "+
+			"this is the multi-rail blind spot this test guards against", responderDeviceName, proberDeviceName)
+	}
+}
+
+// waitForSuccess drains resultCh until a Success==true result is observed or
+// timeout elapses, logging every result seen along the way. It returns
+// false (without failing the test itself, letting the caller decide) if no
+// successful result arrives in time.
+func waitForSuccess(t *testing.T, label string, resultCh <-chan *probe.ProbeResult, timeout time.Duration) bool {
+	t.Helper()
+
+	deadline := time.After(timeout)
+	for {
+		select {
+		case result, ok := <-resultCh:
+			if !ok {
+				t.Logf("%s: result channel closed before a successful probe was observed", label)
+				return false
+			}
+			t.Logf("%s: result seq=%d success=%v error=%q", label, result.SequenceNum, result.Success, result.ErrorMessage)
+			if result.Success {
+				return true
+			}
+		case <-deadline:
+			t.Logf("%s: timed out after %s waiting for a successful probe result", label, timeout)
+			return false
+		}
+	}
+}

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -73,6 +73,15 @@ type Agent struct {
 	results   chan *probe.ProbeResult
 	resultsWg sync.WaitGroup
 
+	// resultsDone is closed by stopResultsFanIn (called from Stop) to tell
+	// every fan-in goroutine to stop forwarding immediately, even if it is
+	// currently blocked trying to send on a full results channel. Without
+	// this, a fan-in goroutine has no way to unblock when nothing drains
+	// a.results (e.g. metrics disabled, or MetricsCollector creation
+	// failed), which would leak the goroutine and any buffered results
+	// forever instead of letting Stop complete deterministically.
+	resultsDone chan struct{}
+
 	// agentIP is the host's outbound IP toward the controller, reported in the
 	// registration request's agent_ip field. Best-effort: empty if it cannot be
 	// determined, which never blocks registration.
@@ -447,15 +456,22 @@ func (a *Agent) Stop(ctx context.Context) {
 	a.stopHeartbeat()
 
 	// Stop all probers to cease outgoing probes. Destroy() closes each
-	// prober's own Results() channel; the fan-in goroutines started by
-	// createResultsFanIn notice the close, drain, and exit, and once every
-	// fan-in goroutine has exited the closer goroutine closes a.results,
-	// which in turn lets the metrics result consumer's range loop finish.
+	// prober's own Results() channel, letting each fan-in goroutine's range
+	// loop finish once it has drained any buffered values.
 	for _, prober := range a.probers {
 		if prober != nil {
 			prober.Destroy()
 		}
 	}
+
+	// Deterministically wind down the results fan-in: signal every fan-in
+	// goroutine to stop forwarding, wait for all of them to exit, and close
+	// the shared results channel exactly once. This must happen here in
+	// Stop (not a fire-and-forget background goroutine) so shutdown never
+	// leaves a fan-in goroutine blocked forever on a full a.results with
+	// nothing draining it (e.g. metrics disabled), which in turn lets the
+	// metrics result consumer's range loop finish.
+	a.stopResultsFanIn()
 
 	// Stop all responders.
 	for _, resp := range a.responders {
@@ -688,28 +704,57 @@ func (a *Agent) createEventRings() error {
 // "the" probe result stream as a single channel even though every device now
 // has its own Prober.
 //
-// Shutdown ordering: each fan-in goroutine exits when its prober's Destroy()
-// closes that prober's own resultChan (a range over a closed channel drains
-// then returns). A separate closer goroutine waits for every fan-in
-// goroutine to exit before closing a.results exactly once, so the shared
-// channel is never closed while a producer might still send on it.
+// Each fan-in goroutine selects between sending on a.results and reading
+// from resultsDone, so it can always return promptly once Stop calls
+// stopResultsFanIn -- whether or not anything is (or ever was) draining
+// a.results. Without this, a fan-in goroutine could block forever on a full
+// a.results when metrics are disabled (or MetricsCollector creation
+// failed), leaking the goroutine and every buffered result.
 func (a *Agent) createResultsFanIn() {
 	a.results = make(chan *probe.ProbeResult, resultChanSize)
+	a.resultsDone = make(chan struct{})
 
 	for _, prober := range a.probers {
 		a.resultsWg.Add(1)
 		go func(p *Prober) {
 			defer a.resultsWg.Done()
 			for result := range p.Results() {
-				a.results <- result
+				select {
+				case a.results <- result:
+				case <-a.resultsDone:
+					// Stop is shutting down and nothing is guaranteed to
+					// drain a.results; stop forwarding immediately instead
+					// of risking a permanent block. Any results not yet
+					// forwarded (this one, and anything still buffered in
+					// p.Results()) are dropped.
+					return
+				}
 			}
 		}(prober)
 	}
+}
 
-	go func() {
-		a.resultsWg.Wait()
-		close(a.results)
-	}()
+// stopResultsFanIn signals every fan-in goroutine started by
+// createResultsFanIn to stop forwarding, waits for all of them to exit, and
+// then closes the shared results channel exactly once. It is a no-op if
+// createResultsFanIn was never called (e.g. Initialize failed before
+// reaching it), matching the nil-guard pattern used throughout Stop.
+//
+// Closing resultsDone before waiting is what makes this deterministic: it
+// guarantees every fan-in goroutine can return -- even one currently blocked
+// trying to send on a full a.results -- regardless of whether the metrics
+// result consumer (or anything else) is draining it. Callers must invoke
+// this only after every prober has been destroyed (which closes that
+// prober's own Results() channel), so fan-in goroutines waiting for the
+// *next* value (rather than blocked on the send) also observe closure and
+// exit their range loop.
+func (a *Agent) stopResultsFanIn() {
+	if a.resultsDone == nil {
+		return
+	}
+	close(a.resultsDone)
+	a.resultsWg.Wait()
+	close(a.results)
 }
 
 // proberRingDropCount sums EventRing.DropCount() across every prober ring

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/yuuki/rpingmesh/rebuild/internal/agent/controller_client"
 	"github.com/yuuki/rpingmesh/rebuild/internal/config"
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
 	"github.com/yuuki/rpingmesh/rebuild/internal/rdmabridge"
 	"github.com/yuuki/rpingmesh/rebuild/internal/telemetry"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
@@ -45,20 +46,32 @@ const (
 )
 
 // Agent orchestrates all R-Pingmesh agent components: RDMA context, devices,
-// responders, prober, cluster monitor, and telemetry. It handles initialization,
-// registration with the controller, and graceful shutdown.
+// responders, probers, cluster monitors, and telemetry. It handles
+// initialization, registration with the controller, and graceful shutdown.
+//
+// One Prober, one ClusterMonitor, and one prober EventRing are created per
+// opened RDMA device so that every RNIC on a multi-rail host actively probes
+// (not just the first device), matching the fact that every device is
+// registered with the controller and can be targeted by other agents'
+// pinglists.
 type Agent struct {
-	cfg        *config.AgentConfig
-	rdmaCtx    *rdmabridge.Context
-	devices    []*rdmabridge.Device
-	responders []*Responder
-	prober     *Prober
-	monitor    *ClusterMonitor
-	grpcClient *controller_client.GRPCControllerClient
-	metrics    *telemetry.MetricsCollector
-	proberRing *rdmabridge.EventRing
-	respRings  []*rdmabridge.EventRing
-	logger     zerolog.Logger
+	cfg         *config.AgentConfig
+	rdmaCtx     *rdmabridge.Context
+	devices     []*rdmabridge.Device
+	responders  []*Responder
+	probers     []*Prober
+	monitors    []*ClusterMonitor
+	grpcClient  *controller_client.GRPCControllerClient
+	metrics     *telemetry.MetricsCollector
+	proberRings []*rdmabridge.EventRing
+	respRings   []*rdmabridge.EventRing
+	logger      zerolog.Logger
+
+	// results is the fan-in destination for every prober's Results()
+	// channel (see createResultsFanIn), consumed by the metrics result
+	// consumer as a single stream.
+	results   chan *probe.ProbeResult
+	resultsWg sync.WaitGroup
 
 	// agentIP is the host's outbound IP toward the controller, reported in the
 	// registration request's agent_ip field. Best-effort: empty if it cannot be
@@ -118,28 +131,40 @@ func (a *Agent) Initialize(ctx context.Context) error {
 	}
 	a.grpcClient = grpcClient
 
-	// Step 4: Create event rings (one for the prober, one per responder).
+	// Step 4: Create event rings (one prober ring and one responder ring per device).
 	a.logger.Info().Msg("Creating event rings")
 	if err := a.createEventRings(); err != nil {
 		return fmt.Errorf("failed to create event rings: %w", err)
 	}
 
-	// Step 5: Create prober using the first device.
-	a.logger.Info().
-		Str("device", a.devices[0].Info.DeviceName).
-		Uint32("probe_interval_ms", a.cfg.ProbeIntervalMS).
-		Msg("Creating prober")
-	prober, err := NewProber(a.devices[0], a.proberRing, a.cfg.ProbeIntervalMS)
-	if err != nil {
-		return fmt.Errorf("failed to create prober: %w", err)
+	// Step 5: Create one prober per device, so every RNIC actively probes
+	// instead of only the first one. This closes the multi-rail monitoring
+	// blind spot where every device is registered and probed BY other agents
+	// but only devices[0] ever probed anyone.
+	a.logger.Info().Int("device_count", len(a.devices)).Msg("Creating probers")
+	for i, dev := range a.devices {
+		prober, err := NewProber(dev, a.proberRings[i], a.cfg.ProbeIntervalMS)
+		if err != nil {
+			return fmt.Errorf("failed to create prober for device %s: %w",
+				dev.Info.DeviceName, err)
+		}
+		if a.cfg.TargetProbeRatePerSecond > 0 {
+			// Per-target rate cap; the prober scales the aggregate limit with the
+			// pinglist size. Differentiated per-pinglist-type rates are a
+			// documented limitation (see README Limitations).
+			prober.SetPerTargetRateLimit(float64(a.cfg.TargetProbeRatePerSecond))
+		}
+		a.probers = append(a.probers, prober)
+		a.logger.Info().
+			Str("device", dev.Info.DeviceName).
+			Uint32("qpn", prober.GetQueueInfo().QPN).
+			Msg("Prober created")
 	}
-	a.prober = prober
-	if a.cfg.TargetProbeRatePerSecond > 0 {
-		// Per-target rate cap; the prober scales the aggregate limit with the
-		// pinglist size. Differentiated per-pinglist-type rates are a
-		// documented limitation (see README Limitations).
-		a.prober.SetPerTargetRateLimit(float64(a.cfg.TargetProbeRatePerSecond))
-	}
+
+	// Fan-in every prober's Results() channel into a single stream so the
+	// rest of Initialize/Start can keep treating "the" probe result stream
+	// as one channel, as before.
+	a.createResultsFanIn()
 
 	// Step 6: Create one responder per device.
 	a.logger.Info().Int("device_count", len(a.devices)).Msg("Creating responders")
@@ -171,8 +196,12 @@ func (a *Agent) Initialize(ctx context.Context) error {
 			// above) as an OTel observable counter. A growing count means the
 			// Go poller goroutine is not draining rdma_event_ring_poll fast
 			// enough and completion events are being silently discarded.
+			// Both readers aggregate across all per-device rings under a
+			// single label ("prober"/"responder") to keep metric cardinality
+			// low (matching the source_tor/target_tor-only convention used
+			// elsewhere), rather than reporting one data point per device.
 			if err := a.metrics.RegisterEventRingDropCallback(map[string]func() uint64{
-				"prober":    a.proberRing.DropCount,
+				"prober":    a.proberRingDropCount,
 				"responder": a.responderRingDropCount,
 			}); err != nil {
 				a.logger.Warn().Err(err).
@@ -201,24 +230,42 @@ func (a *Agent) Initialize(ctx context.Context) error {
 		return fmt.Errorf("failed to register with controller: %w", err)
 	}
 
-	// Step 9: Create cluster monitor for periodic pinglist updates.
-	// Use the first device's GID as the requester GID for pinglist requests.
-	requesterGID := a.devices[0].Info.GID
-	a.logger.Info().
-		Str("requester_gid", requesterGID).
-		Uint32("update_interval_sec", a.cfg.PinglistUpdateIntervalSec).
-		Msg("Creating cluster monitor")
-	a.monitor = NewClusterMonitor(
-		a.grpcClient,
-		a.prober,
-		a.cfg.AgentID,
-		a.cfg.TorID,
-		requesterGID,
-		a.cfg.PinglistUpdateIntervalSec,
-	)
+	// Step 9: Create one cluster monitor per device for periodic pinglist
+	// updates, each requesting its pinglist with that device's own GID as
+	// requester_gid and feeding targets to that device's prober.
+	a.createClusterMonitors()
 
 	a.logger.Info().Msg("Agent initialization complete")
 	return nil
+}
+
+// createClusterMonitors creates one ClusterMonitor per device, each
+// requesting its pinglist with that device's own GID as requester_gid and
+// feeding fetched targets to that device's prober (a.probers[i]). This keeps
+// each RNIC's probe targets scoped to requests made on its own behalf,
+// matching how the controller's registry associates pinglists with GIDs, and
+// closes the multi-rail blind spot where only devices[0] ever requested a
+// pinglist. Requires a.probers to already be populated one-to-one with
+// a.devices.
+func (a *Agent) createClusterMonitors() {
+	a.logger.Info().Int("device_count", len(a.devices)).Msg("Creating cluster monitors")
+	for i, dev := range a.devices {
+		requesterGID := dev.Info.GID
+		a.logger.Info().
+			Str("device", dev.Info.DeviceName).
+			Str("requester_gid", requesterGID).
+			Uint32("update_interval_sec", a.cfg.PinglistUpdateIntervalSec).
+			Msg("Creating cluster monitor")
+		monitor := NewClusterMonitor(
+			a.grpcClient,
+			a.probers[i],
+			a.cfg.AgentID,
+			a.cfg.TorID,
+			requesterGID,
+			a.cfg.PinglistUpdateIntervalSec,
+		)
+		a.monitors = append(a.monitors, monitor)
+	}
 }
 
 // buildRegistrationRequest builds a registration request from the agent's
@@ -340,7 +387,7 @@ func (a *Agent) registerWithController(ctx context.Context) error {
 	return fmt.Errorf("agent registration failed after %d attempts: %w", registerRetryMaxAttempts, lastErr)
 }
 
-// Start begins all agent components: responders, prober, cluster monitor,
+// Start begins all agent components: responders, probers, cluster monitors,
 // and the metrics result consumer. All components must be initialized via
 // Initialize() before calling Start().
 func (a *Agent) Start(ctx context.Context) error {
@@ -351,23 +398,29 @@ func (a *Agent) Start(ctx context.Context) error {
 		}
 	}
 
-	// Start the prober.
-	if err := a.prober.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start prober: %w", err)
+	// Start all probers (one per device).
+	for i, prober := range a.probers {
+		if err := prober.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start prober %d: %w", i, err)
+		}
 	}
 
-	// Start the cluster monitor for periodic pinglist updates.
-	if err := a.monitor.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start cluster monitor: %w", err)
+	// Start all cluster monitors for periodic pinglist updates.
+	for i, monitor := range a.monitors {
+		if err := monitor.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start cluster monitor %d: %w", i, err)
+		}
 	}
 
 	// Start the heartbeat goroutine to periodically re-register with the
 	// controller, keeping the agent's registry entry alive.
 	a.startHeartbeat(ctx)
 
-	// Start the metrics result consumer if metrics are enabled.
+	// Start the metrics result consumer if metrics are enabled. It reads from
+	// the fan-in channel that merges every prober's results (see
+	// createResultsFanIn), so results from every device are recorded.
 	if a.metrics != nil {
-		a.metrics.StartResultConsumer(ctx, a.prober.Results(), a.cfg.TorID)
+		a.metrics.StartResultConsumer(ctx, a.results, a.cfg.TorID)
 		a.logger.Info().Msg("Metrics result consumer started")
 	}
 
@@ -376,24 +429,32 @@ func (a *Agent) Start(ctx context.Context) error {
 }
 
 // Stop gracefully shuts down all agent components in reverse order of startup.
-// It stops the cluster monitor, prober, and responders, then tears down
+// It stops the cluster monitors, probers, and responders, then tears down
 // infrastructure resources (metrics, gRPC, queues, devices, RDMA context,
 // and event rings).
 func (a *Agent) Stop(ctx context.Context) {
 	a.logger.Info().Msg("Stopping agent")
 
-	// Stop cluster monitor first to prevent new pinglist updates.
-	if a.monitor != nil {
-		a.monitor.Stop()
+	// Stop all cluster monitors first to prevent new pinglist updates.
+	for _, monitor := range a.monitors {
+		if monitor != nil {
+			monitor.Stop()
+		}
 	}
 
 	// Stop the heartbeat goroutine before closing the gRPC client, since
-	// both it and the cluster monitor depend on grpcClient being open.
+	// both it and the cluster monitors depend on grpcClient being open.
 	a.stopHeartbeat()
 
-	// Stop the prober to cease outgoing probes.
-	if a.prober != nil {
-		a.prober.Destroy()
+	// Stop all probers to cease outgoing probes. Destroy() closes each
+	// prober's own Results() channel; the fan-in goroutines started by
+	// createResultsFanIn notice the close, drain, and exit, and once every
+	// fan-in goroutine has exited the closer goroutine closes a.results,
+	// which in turn lets the metrics result consumer's range loop finish.
+	for _, prober := range a.probers {
+		if prober != nil {
+			prober.Destroy()
+		}
 	}
 
 	// Stop all responders.
@@ -430,10 +491,10 @@ func (a *Agent) Stop(ctx context.Context) {
 	}
 
 	// Destroy event rings.
-	if a.proberRing != nil {
-		a.proberRing.Destroy()
-		a.proberRing = nil
+	for _, ring := range a.proberRings {
+		ring.Destroy()
 	}
+	a.proberRings = nil
 	for _, ring := range a.respRings {
 		ring.Destroy()
 	}
@@ -594,31 +655,74 @@ func (a *Agent) openDevices() error {
 	return nil
 }
 
-// createEventRings creates one event ring for the prober and one per device
-// (for responders). Each ring is a lock-free SPSC buffer used to deliver
-// CQ completion events from the Zig poller thread to Go.
+// createEventRings creates one prober event ring and one responder event
+// ring per device. Each ring is a lock-free SPSC buffer used to deliver CQ
+// completion events from the Zig poller thread to Go.
 func (a *Agent) createEventRings() error {
-	// Prober ring.
-	proberRing, err := rdmabridge.NewEventRing(eventRingCapacity)
-	if err != nil {
-		return fmt.Errorf("failed to create prober event ring: %w", err)
-	}
-	a.proberRing = proberRing
-
-	// One responder ring per device.
 	for i, dev := range a.devices {
-		ring, err := rdmabridge.NewEventRing(eventRingCapacity)
+		proberRing, err := rdmabridge.NewEventRing(eventRingCapacity)
+		if err != nil {
+			return fmt.Errorf("failed to create prober event ring for device %d (%s): %w",
+				i, dev.Info.DeviceName, err)
+		}
+		a.proberRings = append(a.proberRings, proberRing)
+
+		respRing, err := rdmabridge.NewEventRing(eventRingCapacity)
 		if err != nil {
 			return fmt.Errorf("failed to create responder event ring for device %d (%s): %w",
 				i, dev.Info.DeviceName, err)
 		}
-		a.respRings = append(a.respRings, ring)
+		a.respRings = append(a.respRings, respRing)
 	}
 
 	a.logger.Info().
+		Int("prober_rings", len(a.proberRings)).
 		Int("responder_rings", len(a.respRings)).
 		Msg("Event rings created")
 	return nil
+}
+
+// createResultsFanIn creates the shared results channel and starts one
+// fan-in goroutine per prober that forwards its Results() into the shared
+// channel. This lets Start() and the metrics result consumer keep treating
+// "the" probe result stream as a single channel even though every device now
+// has its own Prober.
+//
+// Shutdown ordering: each fan-in goroutine exits when its prober's Destroy()
+// closes that prober's own resultChan (a range over a closed channel drains
+// then returns). A separate closer goroutine waits for every fan-in
+// goroutine to exit before closing a.results exactly once, so the shared
+// channel is never closed while a producer might still send on it.
+func (a *Agent) createResultsFanIn() {
+	a.results = make(chan *probe.ProbeResult, resultChanSize)
+
+	for _, prober := range a.probers {
+		a.resultsWg.Add(1)
+		go func(p *Prober) {
+			defer a.resultsWg.Done()
+			for result := range p.Results() {
+				a.results <- result
+			}
+		}(prober)
+	}
+
+	go func() {
+		a.resultsWg.Wait()
+		close(a.results)
+	}()
+}
+
+// proberRingDropCount sums EventRing.DropCount() across every prober ring
+// (one per device). Used as the "prober" reader for
+// telemetry.MetricsCollector.RegisterEventRingDropCallback; see
+// responderRingDropCount for why this aggregates rather than reporting per
+// device.
+func (a *Agent) proberRingDropCount() uint64 {
+	var total uint64
+	for _, ring := range a.proberRings {
+		total += ring.DropCount()
+	}
+	return total
 }
 
 // responderRingDropCount sums EventRing.DropCount() across every responder

--- a/rebuild/internal/agent/agent_test.go
+++ b/rebuild/internal/agent/agent_test.go
@@ -1,0 +1,144 @@
+// Package agent tests for Agent's multi-device wiring: one Prober and one
+// ClusterMonitor per opened RDMA device (see agent.go's createClusterMonitors
+// and createResultsFanIn), so that every RNIC on a multi-rail host actively
+// probes instead of only the first one.
+//
+// These tests avoid rdmabridge.Init()/OpenDevice()/CreateQueue(), which
+// require real RDMA hardware or soft-RoCE, by constructing bare *Device and
+// *Prober values directly (mirroring newTestProber() in
+// cluster_monitor_test.go) and exercising the pure-Go wiring logic in
+// isolation.
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/yuuki/rpingmesh/rebuild/internal/config"
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
+	"github.com/yuuki/rpingmesh/rebuild/internal/rdmabridge"
+)
+
+// fakeDevice builds a *rdmabridge.Device carrying only the metadata the
+// agent-level wiring logic reads (GID, DeviceName). It never touches the
+// zero-valued Cgo handles, so it is safe to use without a real RDMA context.
+func fakeDevice(deviceName, gid string) *rdmabridge.Device {
+	return &rdmabridge.Device{
+		Info: rdmabridge.DeviceInfo{
+			DeviceName: deviceName,
+			GID:        gid,
+			IPAddr:     "10.200.0." + gid,
+		},
+	}
+}
+
+// fakeProber builds a *Prober with only the fields exercised by the tests
+// below (logger and resultChan) populated, bypassing NewProber (which
+// requires a real RDMA device and queue).
+func fakeProber(resultChanBuf int) *Prober {
+	return &Prober{
+		logger:     zerolog.Nop(),
+		resultChan: make(chan *probe.ProbeResult, resultChanBuf),
+	}
+}
+
+// newTestAgent builds an Agent with the given fake devices and probers
+// wired in, for use by tests that exercise createClusterMonitors and
+// createResultsFanIn without initializing any real RDMA resources.
+func newTestAgent(devices []*rdmabridge.Device, probers []*Prober) *Agent {
+	return &Agent{
+		cfg: &config.AgentConfig{
+			AgentID:                   "agent-1",
+			TorID:                     "tor-1",
+			PinglistUpdateIntervalSec: 3600,
+		},
+		devices: devices,
+		probers: probers,
+		logger:  zerolog.Nop(),
+	}
+}
+
+func TestAgent_CreateClusterMonitors_OnePerDeviceWithMatchingRequesterGID(t *testing.T) {
+	devices := []*rdmabridge.Device{
+		fakeDevice("rxe0", "gid-0"),
+		fakeDevice("rxe1", "gid-1"),
+	}
+	probers := []*Prober{fakeProber(1), fakeProber(1)}
+
+	a := newTestAgent(devices, probers)
+	a.createClusterMonitors()
+
+	if len(a.monitors) != 2 {
+		t.Fatalf("expected 2 cluster monitors (one per device), got %d", len(a.monitors))
+	}
+
+	for i, dev := range devices {
+		monitor := a.monitors[i]
+		if monitor.requesterGID != dev.Info.GID {
+			t.Errorf("monitor[%d].requesterGID = %q, want device GID %q", i, monitor.requesterGID, dev.Info.GID)
+		}
+		if monitor.prober != probers[i] {
+			t.Errorf("monitor[%d].prober is not wired to probers[%d]", i, i)
+		}
+	}
+
+	// The two monitors must use distinct requester GIDs, matching the two
+	// distinct devices -- this is the core multi-rail fix: every RNIC
+	// requests its own pinglist instead of all devices sharing devices[0]'s
+	// GID.
+	if a.monitors[0].requesterGID == a.monitors[1].requesterGID {
+		t.Errorf("expected distinct requester GIDs per device, both monitors use %q", a.monitors[0].requesterGID)
+	}
+}
+
+func TestAgent_CreateResultsFanIn_MergesResultsFromEveryProber(t *testing.T) {
+	probers := []*Prober{fakeProber(4), fakeProber(4)}
+	a := newTestAgent(nil, probers)
+
+	a.createResultsFanIn()
+
+	// Emit one distinguishable result from each prober directly onto its
+	// resultChan (emitResult is unexported but same-package, matching the
+	// production emission path in prober.go).
+	probers[0].emitResult(&probe.ProbeResult{SequenceNum: 100})
+	probers[1].emitResult(&probe.ProbeResult{SequenceNum: 200})
+
+	seen := map[uint64]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case result := <-a.results:
+			seen[result.SequenceNum] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for fan-in result %d", i)
+		}
+	}
+
+	if !seen[100] || !seen[200] {
+		t.Fatalf("expected fan-in to deliver results from both probers, got %v", seen)
+	}
+}
+
+func TestAgent_CreateResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t *testing.T) {
+	probers := []*Prober{fakeProber(1), fakeProber(1)}
+	a := newTestAgent(nil, probers)
+
+	a.createResultsFanIn()
+
+	// Destroy() is safe on a bare fake Prober: Stop() is a no-op because
+	// running was never set true (no goroutines were started), so
+	// destroyOnce only closes resultChan and skips the nil queue teardown --
+	// mirroring what Agent.Stop does to every real prober.
+	for _, p := range probers {
+		p.Destroy()
+	}
+
+	select {
+	case result, ok := <-a.results:
+		if ok {
+			t.Fatalf("expected a.results to be closed with no pending data, got result: %+v", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a.results to close after all probers were destroyed")
+	}
+}

--- a/rebuild/internal/agent/agent_test.go
+++ b/rebuild/internal/agent/agent_test.go
@@ -119,7 +119,7 @@ func TestAgent_CreateResultsFanIn_MergesResultsFromEveryProber(t *testing.T) {
 	}
 }
 
-func TestAgent_CreateResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t *testing.T) {
+func TestAgent_StopResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t *testing.T) {
 	probers := []*Prober{fakeProber(1), fakeProber(1)}
 	a := newTestAgent(nil, probers)
 
@@ -128,9 +128,24 @@ func TestAgent_CreateResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t 
 	// Destroy() is safe on a bare fake Prober: Stop() is a no-op because
 	// running was never set true (no goroutines were started), so
 	// destroyOnce only closes resultChan and skips the nil queue teardown --
-	// mirroring what Agent.Stop does to every real prober.
+	// mirroring what Agent.Stop does to every real prober. Per
+	// stopResultsFanIn's contract, this must happen before calling it so
+	// every fan-in goroutine's range loop can observe the closed source
+	// channel.
 	for _, p := range probers {
 		p.Destroy()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		a.stopResultsFanIn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopResultsFanIn did not return within 2s after all probers were destroyed")
 	}
 
 	select {
@@ -138,7 +153,48 @@ func TestAgent_CreateResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t 
 		if ok {
 			t.Fatalf("expected a.results to be closed with no pending data, got result: %+v", result)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for a.results to close after all probers were destroyed")
+	default:
+		t.Fatal("expected a.results to already be closed once stopResultsFanIn returned")
+	}
+}
+
+// TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock reproduces the
+// scenario a review of PR #31 flagged: when metrics are disabled (or
+// MetricsCollector creation failed), Start never drains a.results. If a
+// fan-in goroutine has no way to abandon a blocked send once a.results
+// fills up, stopResultsFanIn (called from Agent.Stop) would hang forever
+// waiting on resultsWg, leaking the goroutine and every buffered result.
+// createResultsFanIn's select on resultsDone must let it return promptly
+// regardless.
+func TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock(t *testing.T) {
+	// More results than a.results' buffer (resultChanSize) can hold, so at
+	// least one forwarded result is guaranteed to overflow it and block the
+	// fan-in goroutine's send with nothing there to drain it.
+	const overflow = resultChanSize + 8
+
+	prober := fakeProber(overflow)
+	a := newTestAgent(nil, []*Prober{prober})
+
+	a.createResultsFanIn()
+
+	for i := 0; i < overflow; i++ {
+		prober.emitResult(&probe.ProbeResult{SequenceNum: uint64(i)})
+	}
+
+	// Nothing ever reads from a.results in this test: no metrics result
+	// consumer, matching the metrics-disabled/unavailable scenario.
+	prober.Destroy()
+
+	done := make(chan struct{})
+	go func() {
+		a.stopResultsFanIn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stopResultsFanIn deadlocked with no consumer draining a.results: " +
+			"the fan-in goroutine could not abandon a blocked send")
 	}
 }

--- a/rebuild/scripts/run-e2e.sh
+++ b/rebuild/scripts/run-e2e.sh
@@ -336,7 +336,7 @@ log "Starting RDMA e2e tests..."
 # Temporarily disable exit-on-error so post-test diagnostics always run.
 set +e
 env RDMA_E2E_ENABLED=1 \
-    go test -v -timeout 120s -run "^(TestRDMAE2E|TestProbeToOTelMetrics)" ./e2e/
+    go test -v -timeout 120s -run "^(TestRDMAE2E|TestProbeToOTelMetrics|TestMultiRNICBothDevicesProbe)" ./e2e/
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
## Summary

Stacked on #30; auto-retargets to `main` when #30 merges.

On multi-rail GPU/HPC hosts, the agent opened one RDMA device per RNIC and
created a `Responder` for each of them, but only ever created **one**
`Prober`, bound to `devices[0]`, and requested pinglists using only
`devices[0]`'s GID as `requester_gid`. Every other RNIC on the host was
registered with the controller and got probed *by* other agents, but never
probed anyone itself — a monitoring blind spot that grows with the number of
rails per host.

## Design

- `Agent.Initialize` now creates one `Prober`, one prober `EventRing`, and
  one `ClusterMonitor` per opened device (mirroring the existing per-device
  `Responder`/`EventRing` pattern). The singular `prober` / `proberRing` /
  `monitor` fields became `probers` / `proberRings` / `monitors` slices.
- Each `ClusterMonitor` requests its pinglist using **that device's own
  GID** as `requester_gid` and feeds fetched targets to that device's
  `Prober`, so every RNIC's probe targets are scoped to requests made on
  its own behalf.
- The per-target rate limit (`SetPerTargetRateLimit`) is applied to every
  prober, not just one.
- Every prober's `Results()` channel is merged into a single shared channel
  via a small per-prober fan-in goroutine (`Agent.createResultsFanIn`), so
  the existing single-stream metrics result consumer keeps working
  unchanged. Shutdown ordering: `Agent.Stop` destroys every prober (closing
  each prober's own channel first), each fan-in goroutine drains and exits,
  and a closer goroutine closes the shared channel exactly once after every
  producer has stopped — the consumer's range loop still terminates
  cleanly.
- Event-ring drop-count telemetry now aggregates across all per-device
  prober rings under the existing single `ring="prober"` label (mirroring
  the existing responder-ring aggregation), keeping metric cardinality low.
- Controller, proto, and registry needed **no changes**: `GetPinglist`
  already takes a requester GID per call, and heartbeat/registration
  already reports every device's RNIC info (verified while reading).

## Test plan

- [x] `internal/agent/agent_test.go` (new): unit tests for
      `createClusterMonitors` (one monitor per device with a matching,
      distinct requester GID, wired to the matching prober) and
      `createResultsFanIn` (merges results from every prober; closes the
      shared channel exactly once after every prober is destroyed), using
      bare fake `Device`/`Prober` values so no real RDMA hardware is
      needed.
- [x] `e2e/multi_rnic_e2e_test.go` (new): `TestMultiRNICBothDevicesProbe`
      wires both soft-RoCE devices (rxe0, rxe1) as prober+responder pairs
      pointed at each other and asserts both directions independently
      complete a probe — this is the regression class a single-Prober bug
      would slip past `TestRDMAE2ETwoDevices`/`TestProbeToOTelMetrics`
      undetected (those only ever configure devices[0] as a prober).
- [x] `scripts/run-e2e.sh`: added `TestMultiRNICBothDevicesProbe` to the
      `-run` filter so `make test-e2e` exercises it.

### Verification evidence (Docker image built from `Dockerfile.e2e`, colima VM)

- `go vet ./...` → `VET_OK`
- `go test $(go list ./... | grep -v /e2e)` → all packages `ok`, including
  `internal/agent` with the new tests
- `make build` → `BUILD_OK` (zig lib + proto codegen + controller + agent
  binaries)
- `make test-zig` → `ZIGTEST_OK`
- `make test-e2e` (soft-RoCE rxe0+rxe1), run **twice**:
  - Run 1: `--- PASS: TestMultiRNICBothDevicesProbe (0.23s)` /
    `--- PASS: TestProbeToOTelMetrics (0.41s)` /
    `--- PASS: TestRDMAE2ETwoDevices (0.00s)` — `ok`
  - Run 2: `--- PASS: TestMultiRNICBothDevicesProbe (0.23s)` /
    `--- PASS: TestProbeToOTelMetrics (0.42s)` /
    `--- PASS: TestRDMAE2ETwoDevices (0.00s)` — `ok`
- `make test-e2e-controller` → all controller e2e tests `PASS`, container
  exit code 0

Not touched: `mise.toml`, memory files.