### PR TITLE
feat(rebuild): ECMP path coverage via multi-flow-label probing

### DIFF
--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -208,8 +208,9 @@ via Cgo (`CGO_ENABLED=1`).
 | `tor_id` | *(required)* | Top-of-Rack switch identifier |
 | `controller_addr` | `localhost:50051` | Controller gRPC address |
 | `probe_interval_ms` | `500` | Milliseconds between probe rounds |
-| `target_probe_rate_per_second` | `10` | Max probes per second |
+| `target_probe_rate_per_second` | `10` | Max probes per second **per target** (a target's ECMP flow labels share this budget) |
 | `pinglist_update_interval_sec` | `300` | Seconds between pinglist refreshes |
+| `flow_label_rotation_period_sec` | `3600` | Period over which the rotating ~20% of each target's ECMP flow-label set is refreshed |
 | `gid_index` | `0` | GID table index on RDMA devices |
 | `allowed_device_names` | `[]` | Device filter (empty = all devices) |
 | `metrics_enabled` | `true` | Enable OpenTelemetry export |
@@ -222,6 +223,10 @@ via Cgo (`CGO_ENABLED=1`).
 |-------|---------|-------------|
 | `listen_addr` | `:50051` | gRPC listen address |
 | `database_uri` | `http://localhost:4001` | rqlite connection URI |
+| `inter_tor_sample_size` | `5` | Distinct ToRs sampled per inter-ToR pinglist |
+| `ecmp_paths_assumed` | `16` | Assumed ECMP fabric width (m) for Eq.(1) flow-label coverage sizing |
+| `ecmp_coverage_probability` | `0.9` | Target probability (p, in (0,1)) that generated flow labels cover all ECMP paths |
+| `ecmp_max_flow_labels` | `64` | Hard cap on flow labels per target (bounds probe amplification) |
 | `log_level` | `info` | Log level |
 
 ### Environment Variable Overrides
@@ -329,15 +334,58 @@ The latter requires a Connection Manager context that is unnecessary for UD
 (Unreliable Datagram) operations. `librdmacm` is linked only for its utility
 functions.
 
-### `flow_label` for ECMP Path Diversity
+### `flow_label` for ECMP Path Coverage
 
 RoCEv2 UD mode does not allow control over the UDP source port (it is
 driver-generated). Instead, the IPv6 flow label field in `ibv_ah_attr.grh` is
 used for ECMP path selection. The `source_port` field in `PingTarget` is
-metadata only and is not enforced at the RDMA layer.
+metadata only and is not enforced at the RDMA layer. The flow label reaches the
+NIC per send via a fresh `ibv_create_ah()` in the Zig bridge, so it can vary
+from one probe to the next with no per-QP state.
 
-Flow labels are generated deterministically using FNV-1a hashing of
-`(requester_gid, target_gid)`, masked to 20 bits.
+Rather than probing each `(source, target)` pair with a single deterministic
+flow label — which always pins the same ECMP path and leaves silent drops on
+other links invisible — the controller sizes a **set** of distinct flow labels
+per target so the target's ECMP paths are covered with a configured
+probability, and the agent rotates through that set.
+
+**Coverage sizing (R-Pingmesh Eq.(1), coupon-collector).** To cover all `m`
+equal-probability ECMP paths with probability at least `p`, model each probe as
+drawing one of `m` paths uniformly. Let `q = (m-1)/m` be the per-probe miss
+probability for a given path; after `n` draws that path is uncovered with
+probability `q^n`. Treating the `m` paths' coverage as independent (a standard,
+slightly conservative closed form) gives `P(cover all) ≈ (1 - q^n)^m ≥ p`,
+which solves to:
+
+```
+n = ceil( ln(1 - p^(1/m)) / ln((m-1)/m) )
+```
+
+This agrees to within one probe with the strict union bound
+`P(cover all) ≥ 1 - m·q^n`. The controller computes `n` once from
+`ecmp_paths_assumed` (m), `ecmp_coverage_probability` (p), and the
+`ecmp_max_flow_labels` cap (which bounds probe amplification), and stamps
+`flow_label_count = n` and a full 32-bit `flow_label_seed` into every
+`PingTarget` (seed + count is far smaller than a repeated label list). The
+legacy `flow_label` field remains populated (the low 20 bits of the seed) and
+is used verbatim when `flow_label_count ≤ 1`, preserving backward compatibility.
+
+**Agent expansion and rotation.** The agent derives label `i` deterministically
+from `hash(seed, i, rotationEpoch)` masked to 20 bits, and sends probes
+**round-robin** across the set (successive probes to a target use successive
+labels). The set of labels shares the target's probe budget:
+`target_probe_rate_per_second` is a per-**target** cap and is *not* multiplied
+by `n`, so enabling coverage bounds probe amplification rather than accelerating
+it. Every `flow_label_rotation_period_sec` (default 1h), the rotating subset
+(~20%, every 5th label index) folds in `rotationEpoch = floor(unixTime /
+period)` and shifts, catching a wider set of paths over time while the other
+~80% stay stable for time-series continuity. (Wall-clock time here only selects
+labels; it never enters a measurement timestamp.)
+
+The actual flow label used for each probe is reported in `ProbeResult` and in
+debug logs, but deliberately **not** as an OTel metric attribute — per-label
+cardinality would explode the metric space, so aggregate metrics stay
+ToR-level.
 
 ### ToR-Level Metric Cardinality
 
@@ -471,16 +519,12 @@ sudo rdma link add rxe0 type rxe netdev eth0
   rates (e.g. ToR-mesh probes at 10pps, with a separate rate for inter-ToR
   probes) are not implemented.
 
-- **Inter-ToR pinglist coverage is a simplified random sample, not a
-  probabilistic ECMP coverage guarantee.** The paper's Eq. (1) derives the
-  number of samples needed to cover ECMP paths with a target probability;
-  this rebuild instead picks a fixed, configurable number of random ToRs
-  (`N`) without that coverage-probability derivation.
-
-- **No periodic 5-tuple rotation.** The paper rotates ~20% of probe 5-tuples
-  every hour to shift ECMP path selection over time and catch a wider set of
-  paths. This rebuild's `flow_label` is derived deterministically from
-  `(requester_gid, target_gid)` and does not rotate.
+- **Inter-ToR *ToR selection* is a fixed-size random sample.** ECMP *path*
+  coverage per target is now sized probabilistically via Eq.(1) (see
+  [`flow_label` for ECMP Path Coverage](#flow_label-for-ecmp-path-coverage)),
+  but the choice of *which* remote ToRs an agent probes for its inter-ToR
+  pinglist is still a fixed, configurable random sample of `inter_tor_sample_size`
+  ToRs, not itself derived from a coverage-probability target.
 
 - **Analyzer and Service Tracing remain out of scope.** As noted above, the
   data-aggregation/anomaly-detection Analyzer (switch/link fault

--- a/rebuild/cmd/controller/main.go
+++ b/rebuild/cmd/controller/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/yuuki/rpingmesh/rebuild/internal/config"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller"
+	"github.com/yuuki/rpingmesh/rebuild/internal/controller/pinglist"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller/registry"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 )
@@ -66,6 +67,9 @@ func run(cmd *cobra.Command, args []string) error {
 		Int("activeThresholdSec", cfg.ActiveThresholdSec).
 		Int("staleThresholdSec", cfg.StaleThresholdSec).
 		Int("interTorSampleSize", cfg.InterTorSampleSize).
+		Int("ecmpPathsAssumed", cfg.EcmpPathsAssumed).
+		Float64("ecmpCoverageProbability", cfg.EcmpCoverageProbability).
+		Int("ecmpMaxFlowLabels", cfg.EcmpMaxFlowLabels).
 		Msg("Starting rpingmesh-controller")
 
 	// Initialize RNIC registry backed by rqlite.
@@ -84,8 +88,13 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// Create the controller gRPC service.
-	svc := controller.NewControllerService(reg)
+	// Create the controller gRPC service. The ECMP config sizes the per-target
+	// flow-label set (Eq.(1) coverage) each pinglist entry carries.
+	svc := controller.NewControllerService(reg, pinglist.ECMPConfig{
+		PathsAssumed:        cfg.EcmpPathsAssumed,
+		CoverageProbability: cfg.EcmpCoverageProbability,
+		MaxFlowLabels:       cfg.EcmpMaxFlowLabels,
+	})
 
 	// Create and configure the gRPC server.
 	grpcServer := grpc.NewServer()

--- a/rebuild/configs/agent.yaml
+++ b/rebuild/configs/agent.yaml
@@ -10,8 +10,15 @@ controller_addr: "localhost:50051"
 
 # Probing settings
 probe_interval_ms: 500           # Probe interval in milliseconds
-target_probe_rate_per_second: 10 # Max probes per second
+target_probe_rate_per_second: 10 # Max probes per second PER TARGET (shared across a target's flow labels)
 pinglist_update_interval_sec: 300 # Pinglist refresh interval
+
+# ECMP flow-label rotation
+# Period over which the rotating ~20% of each target's flow-label set is
+# refreshed, shifting a fraction of probed ECMP paths over time while the rest
+# stay stable for time-series continuity. The label COUNT is sized by the
+# controller (see controller.yaml ecmp_* settings).
+flow_label_rotation_period_sec: 3600
 
 # RDMA settings
 gid_index: 0                     # GID table index to use

--- a/rebuild/configs/controller.yaml
+++ b/rebuild/configs/controller.yaml
@@ -6,5 +6,13 @@ listen_addr: ":50051"
 # Database
 database_uri: "http://localhost:4001"  # rqlite address
 
+# ECMP path coverage (R-Pingmesh Eq.(1))
+# The controller sizes each target's flow-label set so that its ECMP paths are
+# covered with probability >= ecmp_coverage_probability, assuming
+# ecmp_paths_assumed equal-cost paths, capped at ecmp_max_flow_labels.
+ecmp_paths_assumed: 16            # Assumed ECMP fabric width (m)
+ecmp_coverage_probability: 0.9    # Target coverage probability (p, in (0,1))
+ecmp_max_flow_labels: 64          # Hard cap on labels per target (bounds amplification)
+
 # Logging
 log_level: "info"                       # debug, info, warn, error

--- a/rebuild/e2e/controller/agent_controller_e2e_test.go
+++ b/rebuild/e2e/controller/agent_controller_e2e_test.go
@@ -241,6 +241,14 @@ func TestPinglistTorMesh(t *testing.T) {
 		if tgt.GetTargetIp() == "" {
 			t.Errorf("PingTarget %s has empty IP", tgt.GetTargetGid())
 		}
+		// ECMP path coverage sizing must be carried so the agent can expand a
+		// multi-flow-label set (Eq.(1)).
+		if tgt.GetFlowLabelCount() == 0 {
+			t.Errorf("PingTarget %s has zero flow_label_count", tgt.GetTargetGid())
+		}
+		if tgt.GetFlowLabelSeed() == 0 {
+			t.Errorf("PingTarget %s has zero flow_label_seed", tgt.GetTargetGid())
+		}
 	}
 }
 

--- a/rebuild/e2e/ecmp_flow_label_e2e_test.go
+++ b/rebuild/e2e/ecmp_flow_label_e2e_test.go
@@ -1,0 +1,193 @@
+// Package e2e — TestECMPMultiFlowLabel validates the multi-flow-label probing
+// MECHANISM end to end on soft-RoCE.
+//
+// Soft-RoCE over a veth pair has no real ECMP fabric, so this test does not (and
+// cannot) assert that different flow labels take different physical paths.
+// Instead it verifies the observable mechanism the feature adds:
+//
+//  1. A target carrying FlowLabelSeed + FlowLabelCount > 1 causes the Prober to
+//     rotate through a set of DISTINCT flow labels (round-robin), rather than
+//     always using one deterministic label.
+//  2. Every probe still completes the 6-timestamp round trip (the ACK-matching
+//     path is unaffected by varying the flow label per send).
+//
+// It shares the soft-RoCE devices (rxe0/rxe1) and RDMA_E2E_ENABLED gate with
+// the other RDMA e2e tests, and is exercised via `make test-e2e`.
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yuuki/rpingmesh/rebuild/internal/agent"
+	"github.com/yuuki/rpingmesh/rebuild/internal/rdmabridge"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+func TestECMPMultiFlowLabel(t *testing.T) {
+	if os.Getenv("RDMA_E2E_ENABLED") != "1" {
+		t.Skip("RDMA_E2E_ENABLED not set; run via 'make test-e2e' or set RDMA_E2E_ENABLED=1")
+	}
+
+	const (
+		sourceTorID     = "tor-ecmp-source"
+		targetTorID     = "tor-ecmp-target"
+		probeIntervalMS = uint32(150)
+		flowLabelCount  = uint32(4)
+		flowLabelSeed   = uint32(0x0BADF00D)
+		collectTimeout  = 20 * time.Second
+		drainTimeout    = 2 * time.Second
+	)
+
+	// --- RDMA context and devices ---
+	rdmaCtx, err := rdmabridge.Init()
+	if err != nil {
+		t.Fatalf("rdmabridge.Init: %v", err)
+	}
+	defer rdmaCtx.Destroy()
+
+	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	if err != nil {
+		t.Fatalf("open prober device %q: %v", proberDeviceName, err)
+	}
+	defer proberDev.Close()
+
+	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	if err != nil {
+		t.Fatalf("open responder device %q: %v", responderDeviceName, err)
+	}
+	defer responderDev.Close()
+
+	// --- Event rings (before queues) ---
+	proberRing, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create prober ring: %v", err)
+	}
+	defer proberRing.Destroy()
+
+	responderRing, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create responder ring: %v", err)
+	}
+	defer responderRing.Destroy()
+
+	// --- Prober and Responder ---
+	prober, err := agent.NewProber(proberDev, proberRing, probeIntervalMS)
+	if err != nil {
+		t.Fatalf("NewProber: %v", err)
+	}
+	responder, err := agent.NewResponder(responderDev, responderRing)
+	if err != nil {
+		t.Fatalf("NewResponder: %v", err)
+	}
+
+	// --- Mock controller: one target with a multi-label ECMP set ---
+	responderQueueInfo := responder.GetQueueInfo()
+	mockClient := &mockControllerClient{
+		targets: []*controller_agent.PingTarget{
+			{
+				TargetGid:        responderDev.Info.GID,
+				TargetQpn:        responderQueueInfo.QPN,
+				TargetIp:         responderDev.Info.IPAddr,
+				TargetHostname:   "e2e-ecmp-responder",
+				TargetTorId:      targetTorID,
+				TargetDeviceName: responderDev.Info.DeviceName,
+				// The base (legacy) flow label; ignored when count > 1.
+				FlowLabel:      flowLabelSeed & 0xFFFFF,
+				FlowLabelSeed:  flowLabelSeed,
+				FlowLabelCount: flowLabelCount,
+			},
+		},
+	}
+	t.Logf("mock target: GID=%s QPN=%d flow_label_count=%d seed=%#x",
+		responderDev.Info.GID, responderQueueInfo.QPN, flowLabelCount, flowLabelSeed)
+
+	monitor := agent.NewClusterMonitor(
+		mockClient, prober, "e2e-ecmp-agent", sourceTorID, proberDev.Info.GID, 3600,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), collectTimeout+10*time.Second)
+	defer cancel()
+
+	if err := responder.Start(ctx); err != nil {
+		t.Fatalf("responder.Start: %v", err)
+	}
+	if err := prober.Start(ctx); err != nil {
+		t.Fatalf("prober.Start: %v", err)
+	}
+	if err := monitor.Start(ctx); err != nil {
+		t.Fatalf("monitor.Start: %v", err)
+	}
+
+	// --- Consume results, tracking distinct flow labels and timeouts ---
+	var (
+		mu             sync.Mutex
+		distinctLabels = map[uint32]struct{}{}
+		completed      int
+		timeouts       int
+	)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		for result := range prober.Results() {
+			mu.Lock()
+			if result.Success {
+				completed++
+				distinctLabels[result.FlowLabel] = struct{}{}
+			} else if strings.Contains(result.ErrorMessage, "timed out") {
+				timeouts++
+			}
+			mu.Unlock()
+		}
+	}()
+
+	// Wait until we have observed the full label set completing, or time out.
+	// With round-robin over flowLabelCount labels at ~1 probe / probeInterval,
+	// this needs only a few hundred ms; the generous deadline absorbs jitter.
+	deadline := time.Now().Add(collectTimeout)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		enough := len(distinctLabels) >= int(flowLabelCount) && completed >= int(flowLabelCount)
+		mu.Unlock()
+		if enough {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// --- Controlled shutdown before assertions ---
+	monitor.Stop()
+	prober.Destroy() // closes Results(), so the consumer's range loop ends
+	responder.Destroy()
+
+	select {
+	case <-consumerDone:
+	case <-time.After(drainTimeout):
+		t.Log("WARNING: result consumer did not drain within drainTimeout")
+	}
+
+	// --- Assertions ---
+	mu.Lock()
+	defer mu.Unlock()
+	t.Logf("completed=%d distinct_flow_labels=%d timeouts=%d", completed, len(distinctLabels), timeouts)
+
+	if completed == 0 {
+		t.Fatal("no probes completed the 6-timestamp round trip")
+	}
+	// The ACK-matching path must be unaffected by per-send flow-label variation.
+	if timeouts != 0 {
+		t.Fatalf("%d probes timed out waiting for ACKs: multi-flow-label send broke the ACK path", timeouts)
+	}
+	// The mechanism: probes to a single target used MULTIPLE distinct flow
+	// labels. index 0 of the set folds in the wall-clock rotation epoch and the
+	// other three are seed-fixed, so with count=4 we expect 4 distinct labels;
+	// tolerate at most one hash collision to stay non-flaky.
+	if got := len(distinctLabels); got < int(flowLabelCount)-1 {
+		t.Fatalf("observed %d distinct flow labels, want ~%d: round-robin over the "+
+			"ECMP label set is not taking effect", got, flowLabelCount)
+	}
+}

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -160,9 +160,14 @@ func (a *Agent) Initialize(ctx context.Context) error {
 		if a.cfg.TargetProbeRatePerSecond > 0 {
 			// Per-target rate cap; the prober scales the aggregate limit with the
 			// pinglist size. Differentiated per-pinglist-type rates are a
-			// documented limitation (see README Limitations).
+			// documented limitation (see README Limitations). Note the cap is
+			// per TARGET, not per flow label: a target's ECMP label set shares
+			// this budget, bounding probe amplification.
 			prober.SetPerTargetRateLimit(float64(a.cfg.TargetProbeRatePerSecond))
 		}
+		// Configure the ECMP flow-label rotation period (time-based rotation of
+		// the rotating ~20% of each target's label set).
+		prober.SetFlowLabelRotationPeriod(a.cfg.FlowLabelRotationPeriodSec)
 		a.probers = append(a.probers, prober)
 		a.logger.Info().
 			Str("device", dev.Info.DeviceName).

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -59,15 +59,19 @@ const (
 	flowLabelMask = 0xFFFFF
 )
 
-// flowLabelAt deterministically derives the ECMP flow label for label index
-// within a target's set, from the controller-provided seed and (for the
+// flowLabelAt deterministically derives a candidate ECMP flow label for label
+// index within a target's set, from the controller-provided seed and (for the
 // rotating subset of indices) the current rotationEpoch. It is pure: the same
-// (seed, index, rotationEpoch) always yields the same 20-bit label, which is
-// what makes the set reproducible across agents and testable.
+// (seed, index, rotationEpoch, attempt) always yields the same 20-bit label,
+// which is what makes the set reproducible across agents and testable.
 //
 // Only indices that are multiples of flowLabelRotateStride fold in the epoch;
-// all other indices ignore it and are therefore stable across epochs.
-func flowLabelAt(seed, index uint32, rotationEpoch uint64) uint32 {
+// all other indices ignore it and are therefore stable across epochs. The
+// attempt parameter is a collision-resolution nonce: attempt 0 is the primary
+// candidate (its bytes are omitted so the value is unchanged from a plain
+// hash), and generateFlowLabels advances it only when a candidate collides
+// with an already-chosen label.
+func flowLabelAt(seed, index uint32, rotationEpoch uint64, attempt uint32) uint32 {
 	h := fnv.New32a()
 	var buf [16]byte
 	binary.BigEndian.PutUint32(buf[0:4], seed)
@@ -78,19 +82,62 @@ func flowLabelAt(seed, index uint32, rotationEpoch uint64) uint32 {
 		n = 16
 	}
 	_, _ = h.Write(buf[:n])
+	if attempt > 0 {
+		var a [4]byte
+		binary.BigEndian.PutUint32(a[:], attempt)
+		_, _ = h.Write(a[:])
+	}
 	return h.Sum32() & flowLabelMask
 }
 
-// generateFlowLabels expands a (seed, count) pair into count deterministic
-// 20-bit flow labels for the given rotationEpoch. A count of 0 is treated as 1
-// so every target yields at least one label.
+// generateFlowLabels expands a (seed, count) pair into exactly count DISTINCT
+// deterministic 20-bit flow labels for the given rotationEpoch. A count of 0 is
+// treated as 1 so every target yields at least one label.
+//
+// Distinctness matters: the controller sizes count via Eq.(1) assuming n
+// distinct labels, so a duplicate would silently explore fewer ECMP 5-tuples
+// than the configured coverage probability requires. Masking a 32-bit hash to
+// 20 bits can collide, so each label is chosen by a set-guarded loop that
+// advances a collision nonce (flowLabelAt's attempt) until the candidate is
+// new. Termination is fast and guaranteed: the controller caps count well
+// below the 2^20 label space (default cap 64), so collisions are rare and each
+// slot resolves in ~1 attempt.
+//
+// Slots are resolved in two passes -- stable slots (index % stride != 0)
+// first, then rotating slots -- so a stable slot's dedup never depends on the
+// epoch-varying rotating slots. This keeps the ~80% stable subset byte-for-byte
+// identical across epochs (exact time-series continuity, not merely likely)
+// while the rotating subset still shifts each epoch. Dedup is applied after the
+// epoch is mixed in, so the final set is distinct for every epoch.
 func generateFlowLabels(seed, count uint32, rotationEpoch uint64) []uint32 {
 	if count == 0 {
 		count = 1
 	}
 	labels := make([]uint32, count)
+	used := make(map[uint32]struct{}, count)
+
+	assign := func(i uint32) {
+		for attempt := uint32(0); ; attempt++ {
+			v := flowLabelAt(seed, i, rotationEpoch, attempt)
+			if _, dup := used[v]; !dup {
+				used[v] = struct{}{}
+				labels[i] = v
+				return
+			}
+		}
+	}
+
+	// Pass 1: stable slots (epoch-independent dedup domain).
 	for i := uint32(0); i < count; i++ {
-		labels[i] = flowLabelAt(seed, i, rotationEpoch)
+		if i%flowLabelRotateStride != 0 {
+			assign(i)
+		}
+	}
+	// Pass 2: rotating slots (epoch-mixed, dedup against the full set).
+	for i := uint32(0); i < count; i++ {
+		if i%flowLabelRotateStride == 0 {
+			assign(i)
+		}
 	}
 	return labels
 }

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -57,7 +57,25 @@ const (
 	// flowLabelMask is the 20-bit IPv6 flow-label field width; generated labels
 	// are masked to it before reaching ibv_ah_attr.grh.flow_label.
 	flowLabelMask = 0xFFFFF
+
+	// maxDistinctFlowLabels is the hard upper bound on how many DISTINCT flow
+	// labels can exist: the field is 20 bits, so at most 2^20 distinct values.
+	// generateFlowLabels clamps FlowLabelCount to this so a bad or malicious
+	// controller value can never make the dedup loop spin forever hunting for
+	// more distinct 20-bit labels than the space contains. The controller also
+	// validates ecmp_max_flow_labels against this bound (defense in depth).
+	maxDistinctFlowLabels = 1 << 20
 )
+
+// clampDistinctFlowLabelCount bounds a requested flow-label count to the number
+// of distinct 20-bit labels that can exist (maxDistinctFlowLabels). Extracted
+// so the clamp decision is unit-testable without generating a huge label set.
+func clampDistinctFlowLabelCount(count uint32) uint32 {
+	if count > maxDistinctFlowLabels {
+		return maxDistinctFlowLabels
+	}
+	return count
+}
 
 // flowLabelAt deterministically derives a candidate ECMP flow label for label
 // index within a target's set, from the controller-provided seed and (for the
@@ -113,6 +131,9 @@ func generateFlowLabels(seed, count uint32, rotationEpoch uint64) []uint32 {
 	if count == 0 {
 		count = 1
 	}
+	// Never ask for more distinct labels than the 20-bit space can hold, or the
+	// dedup loop below could never satisfy the request and would spin forever.
+	count = clampDistinctFlowLabelCount(count)
 	labels := make([]uint32, count)
 	used := make(map[uint32]struct{}, count)
 

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -5,7 +5,9 @@ package agent
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"hash/fnv"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -37,7 +39,72 @@ const (
 	// cadence from the probe interval, so the sweep runs at a predictable rate
 	// regardless of how frequently probes are sent.
 	stalePendingCleanupPeriod = 10 * time.Second
+
+	// defaultFlowLabelRotationPeriodSec is the fallback rotation period used
+	// when SetFlowLabelRotationPeriod has not been called (or is set to 0). It
+	// mirrors config.DefaultFlowLabelRotationPeriodSec without importing the
+	// config package.
+	defaultFlowLabelRotationPeriodSec = 3600
+
+	// flowLabelRotateStride controls which flow-label indices rotate with the
+	// epoch: every flowLabelRotateStride-th label (indices 0, 5, 10, ...) mixes
+	// the rotation epoch into its hash, so ~1/5 (20%) of a target's label set
+	// shifts each rotation period while the remaining ~80% stay stable for
+	// time-series continuity. This matches the R-Pingmesh paper's ~20%
+	// 5-tuple rotation.
+	flowLabelRotateStride = 5
+
+	// flowLabelMask is the 20-bit IPv6 flow-label field width; generated labels
+	// are masked to it before reaching ibv_ah_attr.grh.flow_label.
+	flowLabelMask = 0xFFFFF
 )
+
+// flowLabelAt deterministically derives the ECMP flow label for label index
+// within a target's set, from the controller-provided seed and (for the
+// rotating subset of indices) the current rotationEpoch. It is pure: the same
+// (seed, index, rotationEpoch) always yields the same 20-bit label, which is
+// what makes the set reproducible across agents and testable.
+//
+// Only indices that are multiples of flowLabelRotateStride fold in the epoch;
+// all other indices ignore it and are therefore stable across epochs.
+func flowLabelAt(seed, index uint32, rotationEpoch uint64) uint32 {
+	h := fnv.New32a()
+	var buf [16]byte
+	binary.BigEndian.PutUint32(buf[0:4], seed)
+	binary.BigEndian.PutUint32(buf[4:8], index)
+	n := 8
+	if index%flowLabelRotateStride == 0 {
+		binary.BigEndian.PutUint64(buf[8:16], rotationEpoch)
+		n = 16
+	}
+	_, _ = h.Write(buf[:n])
+	return h.Sum32() & flowLabelMask
+}
+
+// generateFlowLabels expands a (seed, count) pair into count deterministic
+// 20-bit flow labels for the given rotationEpoch. A count of 0 is treated as 1
+// so every target yields at least one label.
+func generateFlowLabels(seed, count uint32, rotationEpoch uint64) []uint32 {
+	if count == 0 {
+		count = 1
+	}
+	labels := make([]uint32, count)
+	for i := uint32(0); i < count; i++ {
+		labels[i] = flowLabelAt(seed, i, rotationEpoch)
+	}
+	return labels
+}
+
+// labelsForTarget returns the flow-label set the prober cycles through for a
+// target. When FlowLabelCount <= 1 it preserves exact legacy behavior by
+// returning the single controller-provided FlowLabel; otherwise it expands
+// FlowLabelSeed + FlowLabelCount for the given epoch.
+func labelsForTarget(target *controller_agent.PingTarget, rotationEpoch uint64) []uint32 {
+	if target.GetFlowLabelCount() <= 1 {
+		return []uint32{target.GetFlowLabel()}
+	}
+	return generateFlowLabels(target.GetFlowLabelSeed(), target.GetFlowLabelCount(), rotationEpoch)
+}
 
 // pendingProbe holds the in-flight state for a single probe awaiting ACKs.
 // The 6-timestamp bookkeeping lives in the embedded PendingMeasurement, which
@@ -46,6 +113,11 @@ type pendingProbe struct {
 	target    *controller_agent.PingTarget
 	meas      *probe.PendingMeasurement
 	createdAt time.Time
+	// flowLabel is the concrete ECMP flow label this probe was actually sent
+	// with (one of the target's rotating set), recorded so the resulting
+	// ProbeResult and debug logs report the path actually exercised rather
+	// than the target's base label.
+	flowLabel uint32
 }
 
 // Prober sends probe packets to targets on a configurable interval,
@@ -85,6 +157,18 @@ type Prober struct {
 	limiter      probe.RateLimiter
 	perTargetPPS float64
 
+	// flowLabelRotationPeriodSec is the period over which the rotating subset
+	// of each target's flow-label set is refreshed. Read only by the probe-loop
+	// goroutine via flowLabelRotationEpoch; set once at construction and
+	// optionally via SetFlowLabelRotationPeriod before Start.
+	flowLabelRotationPeriodSec uint32
+
+	// labelRotation tracks the next flow-label index for each target, keyed by
+	// target GID string, so successive probes to a target use successive labels
+	// (round-robin over its set). It is accessed ONLY from the probe-loop
+	// goroutine (sendProbes), so it needs no lock; stale keys are pruned there.
+	labelRotation map[string]uint32
+
 	logger zerolog.Logger
 }
 
@@ -109,16 +193,18 @@ func NewProber(device *rdmabridge.Device, ring *rdmabridge.EventRing, probeInter
 	}
 
 	p := &Prober{
-		queue:         queue,
-		ring:          ring,
-		device:        device,
-		pending:       make(map[uint64]*pendingProbe),
-		agentEpoch:    rand.Uint32(),
-		resultChan:    make(chan *probe.ProbeResult, resultChanSize),
-		stopCh:        make(chan struct{}),
-		probeInterval: time.Duration(probeIntervalMS) * time.Millisecond,
-		probeTimeout:  probeSendTimeoutMS,
-		logger:        log.With().Str("component", "prober").Logger(),
+		queue:                      queue,
+		ring:                       ring,
+		device:                     device,
+		pending:                    make(map[uint64]*pendingProbe),
+		agentEpoch:                 rand.Uint32(),
+		resultChan:                 make(chan *probe.ProbeResult, resultChanSize),
+		stopCh:                     make(chan struct{}),
+		probeInterval:              time.Duration(probeIntervalMS) * time.Millisecond,
+		probeTimeout:               probeSendTimeoutMS,
+		flowLabelRotationPeriodSec: defaultFlowLabelRotationPeriodSec,
+		labelRotation:              make(map[string]uint32),
+		logger:                     log.With().Str("component", "prober").Logger(),
 	}
 
 	p.logger.Info().
@@ -196,6 +282,31 @@ func (p *Prober) SetPerTargetRateLimit(pps float64) {
 		Float64("per_target_pps", pps).
 		Int("targets", n).
 		Msg("Probe send rate limit updated")
+}
+
+// SetFlowLabelRotationPeriod sets the period over which the rotating subset of
+// each target's ECMP flow-label set is refreshed. A non-positive value keeps
+// the default (defaultFlowLabelRotationPeriodSec). It should be called before
+// Start; the field is read only by the single probe-loop goroutine.
+func (p *Prober) SetFlowLabelRotationPeriod(sec uint32) {
+	if sec == 0 {
+		sec = defaultFlowLabelRotationPeriodSec
+	}
+	p.flowLabelRotationPeriodSec = sec
+	p.logger.Info().
+		Uint32("rotation_period_sec", sec).
+		Msg("Flow-label rotation period updated")
+}
+
+// flowLabelRotationEpoch maps a wall-clock instant to the current rotation
+// epoch = floor(unixTime / period). Wall-clock is acceptable here because the
+// epoch only selects which flow labels are used, never a measurement timestamp.
+func (p *Prober) flowLabelRotationEpoch(now time.Time) uint64 {
+	period := p.flowLabelRotationPeriodSec
+	if period == 0 {
+		period = defaultFlowLabelRotationPeriodSec
+	}
+	return uint64(now.Unix()) / uint64(period)
 }
 
 // nowMonotonicNS returns the current CLOCK_MONOTONIC time in nanoseconds. It
@@ -302,6 +413,14 @@ func (p *Prober) sendProbes(ctx context.Context) {
 		return
 	}
 
+	// The rotation epoch selects which of each target's rotating labels are in
+	// effect this round; computed once per round so all targets share it.
+	rotationEpoch := p.flowLabelRotationEpoch(time.Now())
+
+	// Prune round-robin state for targets no longer in the pinglist so the map
+	// cannot grow without bound as targets churn. Confined to this goroutine.
+	p.pruneLabelRotation(targets)
+
 	for _, target := range targets {
 		// Abort the batch promptly on shutdown instead of walking the entire
 		// target list while blocking on SendProbe for each one.
@@ -340,6 +459,13 @@ func (p *Prober) sendProbes(ctx context.Context) {
 			continue
 		}
 
+		// Pick the flow label for this probe: round-robin across the target's
+		// ECMP label set so successive probes to a target exercise successive
+		// paths. Labels share the target's probe budget (the rate limiter is
+		// per-target, unaffected by the set size), trading coverage speed for
+		// bounded probe amplification.
+		flowLabel := p.nextFlowLabel(target, rotationEpoch)
+
 		// Register the pending entry BEFORE sending. SendProbe blocks until the
 		// send completion (T2), and on a low-latency RNIC an ACK can reach
 		// ackProcessLoop before SendProbe returns. Registering first guarantees
@@ -352,18 +478,21 @@ func (p *Prober) sendProbes(ctx context.Context) {
 			target:    target,
 			meas:      probe.NewPendingMeasurement(),
 			createdAt: time.Now(),
+			flowLabel: flowLabel,
 		}
 		p.pendingMu.Lock()
 		p.pending[seqNum] = pp
 		p.pendingMu.Unlock()
 
 		// Send the probe packet. SendProbe is synchronous: it posts the
-		// packet and waits for the send completion within the timeout.
+		// packet and waits for the send completion within the timeout. The
+		// per-send flow label reaches ibv_ah_attr.grh.flow_label via a fresh
+		// AH created in the Zig bridge, so no per-QP/AH state needs updating.
 		result := p.queue.SendProbe(
 			targetGID,
 			target.GetTargetQpn(),
 			seqNum,
-			target.GetFlowLabel(),
+			flowLabel,
 			p.probeTimeout,
 		)
 
@@ -379,8 +508,9 @@ func (p *Prober) sendProbes(ctx context.Context) {
 				Str("target_gid", target.GetTargetGid()).
 				Uint32("target_qpn", target.GetTargetQpn()).
 				Uint64("seq", seqNum).
+				Uint32("flow_label", flowLabel).
 				Msg("Failed to send probe packet")
-			p.emitResult(newFailedResult(seqNum, target, fmt.Sprintf("probe send failed: %v", result.Error)))
+			p.emitResult(newFailedResult(seqNum, target, flowLabel, fmt.Sprintf("probe send failed: %v", result.Error)))
 			continue
 		}
 
@@ -403,9 +533,47 @@ func (p *Prober) sendProbes(ctx context.Context) {
 			Str("target_gid", target.GetTargetGid()).
 			Uint32("target_qpn", target.GetTargetQpn()).
 			Uint64("seq", seqNum).
+			Uint32("flow_label", flowLabel).
 			Uint64("t1_ns", result.T1NS).
 			Uint64("t2_ns", result.T2NS).
 			Msg("Probe sent, awaiting ACKs")
+	}
+}
+
+// nextFlowLabel returns the flow label to use for the next probe to target and
+// advances that target's round-robin index. It is called only from the
+// probe-loop goroutine, so the unsynchronized labelRotation map access is safe.
+func (p *Prober) nextFlowLabel(target *controller_agent.PingTarget, rotationEpoch uint64) uint32 {
+	labels := labelsForTarget(target, rotationEpoch)
+	if p.labelRotation == nil {
+		// Defensive: a Prober built via a struct literal (test helpers) rather
+		// than NewProber may have a nil map. Lazily initialize so the single
+		// probe-loop goroutine never panics writing to it.
+		p.labelRotation = make(map[string]uint32)
+	}
+	gid := target.GetTargetGid()
+	idx := p.labelRotation[gid]
+	p.labelRotation[gid] = idx + 1
+	return labels[idx%uint32(len(labels))]
+}
+
+// pruneLabelRotation drops round-robin entries for targets absent from the
+// current pinglist, bounding labelRotation's size as targets churn. Called
+// only from the probe-loop goroutine.
+func (p *Prober) pruneLabelRotation(targets []*controller_agent.PingTarget) {
+	if len(p.labelRotation) == 0 {
+		return
+	}
+	live := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		if t != nil {
+			live[t.GetTargetGid()] = struct{}{}
+		}
+	}
+	for gid := range p.labelRotation {
+		if _, ok := live[gid]; !ok {
+			delete(p.labelRotation, gid)
+		}
 	}
 }
 
@@ -615,20 +783,23 @@ func (p *Prober) finalizeIfCompleteLocked(seqNum uint64, pp *pendingProbe) *prob
 	}
 
 	result := pp.meas.Result()
-	fillTargetMetadata(&result, seqNum, pp.target)
+	fillTargetMetadata(&result, seqNum, pp.flowLabel, pp.target)
 	result.Success = true
 
 	delete(p.pending, seqNum)
 	return &result
 }
 
-// fillTargetMetadata copies the sequence number and per-target metadata into a
-// ProbeResult. Shared by the success, send-failure, and stale-timeout paths so
-// they cannot diverge on which fields a result carries.
-func fillTargetMetadata(result *probe.ProbeResult, seqNum uint64, target *controller_agent.PingTarget) {
+// fillTargetMetadata copies the sequence number, the flow label actually used
+// for the probe, and per-target metadata into a ProbeResult. Shared by the
+// success, send-failure, and stale-timeout paths so they cannot diverge on
+// which fields a result carries. The flow label is passed explicitly (rather
+// than read from target.GetFlowLabel()) so the result reports the specific
+// ECMP path this probe exercised out of the target's rotating set.
+func fillTargetMetadata(result *probe.ProbeResult, seqNum uint64, flowLabel uint32, target *controller_agent.PingTarget) {
 	result.SequenceNum = seqNum
 	result.TargetQPN = target.GetTargetQpn()
-	result.FlowLabel = target.GetFlowLabel()
+	result.FlowLabel = flowLabel
 	result.TargetIP = target.GetTargetIp()
 	result.TargetHostname = target.GetTargetHostname()
 	result.TargetTorID = target.GetTargetTorId()
@@ -638,10 +809,11 @@ func fillTargetMetadata(result *probe.ProbeResult, seqNum uint64, target *contro
 }
 
 // newFailedResult builds a Success=false ProbeResult carrying the target
-// metadata and an error message, used when a probe send fails outright.
-func newFailedResult(seqNum uint64, target *controller_agent.PingTarget, errMsg string) *probe.ProbeResult {
+// metadata, the flow label the failed send used, and an error message, used
+// when a probe send fails outright.
+func newFailedResult(seqNum uint64, target *controller_agent.PingTarget, flowLabel uint32, errMsg string) *probe.ProbeResult {
 	result := &probe.ProbeResult{}
-	fillTargetMetadata(result, seqNum, target)
+	fillTargetMetadata(result, seqNum, flowLabel, target)
 	result.Success = false
 	result.ErrorMessage = errMsg
 	return result
@@ -700,7 +872,7 @@ func (p *Prober) cleanupStalePending() {
 			// Preserve any partial timestamps the measurement collected, then
 			// overlay the target metadata and failure state.
 			result := pp.meas.Result()
-			fillTargetMetadata(&result, seqNum, pp.target)
+			fillTargetMetadata(&result, seqNum, pp.flowLabel, pp.target)
 			result.Success = false
 			result.ErrorMessage = "timed out waiting for ACKs"
 			stale = append(stale, &result)

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -58,13 +58,15 @@ const (
 	// are masked to it before reaching ibv_ah_attr.grh.flow_label.
 	flowLabelMask = 0xFFFFF
 
-	// maxDistinctFlowLabels is the hard upper bound on how many DISTINCT flow
-	// labels can exist: the field is 20 bits, so at most 2^20 distinct values.
-	// generateFlowLabels clamps FlowLabelCount to this so a bad or malicious
-	// controller value can never make the dedup loop spin forever hunting for
-	// more distinct 20-bit labels than the space contains. The controller also
-	// validates ecmp_max_flow_labels against this bound (defense in depth).
-	maxDistinctFlowLabels = 1 << 20
+	// maxDistinctFlowLabels is the operational hard clamp on how many labels a
+	// target's set may contain. generateFlowLabels clamps FlowLabelCount to it
+	// so a bad or malicious controller value can never make the agent build a
+	// huge label set/map (stalling the send loop or OOMing) nor spin the dedup
+	// loop forever. 4096 is ~16KB per target and covers even extreme Eq.(1)
+	// configs; it mirrors config.MaxEcmpFlowLabels (defense in depth). The
+	// 20-bit flow-label field's 2^20 distinct-value ceiling is the secondary,
+	// far higher bound this stays well under.
+	maxDistinctFlowLabels = 4096
 )
 
 // clampDistinctFlowLabelCount bounds a requested flow-label count to the number
@@ -237,7 +239,22 @@ type Prober struct {
 	// goroutine (sendProbes), so it needs no lock; stale keys are pruned there.
 	labelRotation map[string]uint32
 
+	// labelCache memoizes each target's generated flow-label set so it is built
+	// once per (epoch, seed, count) rather than on every probe tick. Same GID
+	// key, same goroutine confinement, and pruned alongside labelRotation.
+	labelCache map[string]*labelSet
+
 	logger zerolog.Logger
+}
+
+// labelSet is a cached flow-label set plus the inputs that produced it, so the
+// prober can detect when a rotation-epoch or target seed/count change makes the
+// cached labels stale and must be regenerated.
+type labelSet struct {
+	epoch  uint64
+	seed   uint32
+	count  uint32
+	labels []uint32
 }
 
 // NewProber creates a new Prober with a sender-type RDMA queue bound to the
@@ -272,6 +289,7 @@ func NewProber(device *rdmabridge.Device, ring *rdmabridge.EventRing, probeInter
 		probeTimeout:               probeSendTimeoutMS,
 		flowLabelRotationPeriodSec: defaultFlowLabelRotationPeriodSec,
 		labelRotation:              make(map[string]uint32),
+		labelCache:                 make(map[string]*labelSet),
 		logger:                     log.With().Str("component", "prober").Logger(),
 	}
 
@@ -610,26 +628,53 @@ func (p *Prober) sendProbes(ctx context.Context) {
 
 // nextFlowLabel returns the flow label to use for the next probe to target and
 // advances that target's round-robin index. It is called only from the
-// probe-loop goroutine, so the unsynchronized labelRotation map access is safe.
+// probe-loop goroutine, so the unsynchronized map accesses are safe.
 func (p *Prober) nextFlowLabel(target *controller_agent.PingTarget, rotationEpoch uint64) uint32 {
-	labels := labelsForTarget(target, rotationEpoch)
 	if p.labelRotation == nil {
 		// Defensive: a Prober built via a struct literal (test helpers) rather
-		// than NewProber may have a nil map. Lazily initialize so the single
-		// probe-loop goroutine never panics writing to it.
+		// than NewProber may have nil maps. Lazily initialize so the single
+		// probe-loop goroutine never panics writing to them.
 		p.labelRotation = make(map[string]uint32)
 	}
+	labels := p.cachedLabelsForTarget(target, rotationEpoch)
 	gid := target.GetTargetGid()
 	idx := p.labelRotation[gid]
 	p.labelRotation[gid] = idx + 1
 	return labels[idx%uint32(len(labels))]
 }
 
-// pruneLabelRotation drops round-robin entries for targets absent from the
-// current pinglist, bounding labelRotation's size as targets churn. Called
-// only from the probe-loop goroutine.
+// cachedLabelsForTarget returns the target's flow-label set, regenerating it
+// only when the rotation epoch or the target's seed/count changes. Without this
+// cache, generateFlowLabels would rebuild a (potentially thousands-entry) set
+// on every probe tick for every target, stalling the send loop. The multi-label
+// set is expensive to build; the legacy single-label case is trivial and
+// bypasses the cache. Called only from the probe-loop goroutine, so the
+// unsynchronized map access is safe.
+func (p *Prober) cachedLabelsForTarget(target *controller_agent.PingTarget, rotationEpoch uint64) []uint32 {
+	count := target.GetFlowLabelCount()
+	if count <= 1 {
+		// Trivial single-label (legacy) path; no set to cache.
+		return labelsForTarget(target, rotationEpoch)
+	}
+
+	gid := target.GetTargetGid()
+	seed := target.GetFlowLabelSeed()
+	if p.labelCache == nil {
+		p.labelCache = make(map[string]*labelSet)
+	}
+	if e, ok := p.labelCache[gid]; ok && e.epoch == rotationEpoch && e.seed == seed && e.count == count {
+		return e.labels
+	}
+	labels := generateFlowLabels(seed, count, rotationEpoch)
+	p.labelCache[gid] = &labelSet{epoch: rotationEpoch, seed: seed, count: count, labels: labels}
+	return labels
+}
+
+// pruneLabelRotation drops per-target round-robin and label-cache entries for
+// targets absent from the current pinglist, bounding both maps' sizes as
+// targets churn. Called only from the probe-loop goroutine.
 func (p *Prober) pruneLabelRotation(targets []*controller_agent.PingTarget) {
-	if len(p.labelRotation) == 0 {
+	if len(p.labelRotation) == 0 && len(p.labelCache) == 0 {
 		return
 	}
 	live := make(map[string]struct{}, len(targets))
@@ -641,6 +686,11 @@ func (p *Prober) pruneLabelRotation(targets []*controller_agent.PingTarget) {
 	for gid := range p.labelRotation {
 		if _, ok := live[gid]; !ok {
 			delete(p.labelRotation, gid)
+		}
+	}
+	for gid := range p.labelCache {
+		if _, ok := live[gid]; !ok {
+			delete(p.labelCache, gid)
 		}
 	}
 }

--- a/rebuild/internal/agent/prober_flowlabel_test.go
+++ b/rebuild/internal/agent/prober_flowlabel_test.go
@@ -181,6 +181,43 @@ func TestNextFlowLabel_RoundRobin(t *testing.T) {
 	}
 }
 
+// TestCachedLabelsForTarget verifies the per-target label-set cache: within one
+// rotation epoch (and unchanged seed/count) the identical set is returned
+// without regenerating, while an epoch change or a seed/count change forces
+// regeneration. This keeps generateFlowLabels off the per-probe-tick hot path.
+func TestCachedLabelsForTarget(t *testing.T) {
+	target := &controller_agent.PingTarget{
+		TargetGid:      "fe80::cafe",
+		FlowLabelSeed:  0x1234,
+		FlowLabelCount: 8,
+	}
+	p := &Prober{logger: zerolog.Nop()}
+
+	a := p.cachedLabelsForTarget(target, 100)
+	b := p.cachedLabelsForTarget(target, 100)
+	// Same epoch/seed/count: the cache must return the SAME backing slice, not
+	// a freshly generated one.
+	if &a[0] != &b[0] {
+		t.Errorf("same epoch returned a regenerated set; cache not hit")
+	}
+	if len(a) != 8 {
+		t.Fatalf("cached set length = %d, want 8", len(a))
+	}
+
+	// Epoch change: must regenerate (new backing slice).
+	c := p.cachedLabelsForTarget(target, 101)
+	if &a[0] == &c[0] {
+		t.Errorf("epoch change did not regenerate the label set")
+	}
+
+	// Count change at the same epoch: must regenerate with the new size.
+	target.FlowLabelCount = 16
+	d := p.cachedLabelsForTarget(target, 101)
+	if &c[0] == &d[0] || len(d) != 16 {
+		t.Errorf("count change did not regenerate (len=%d, want 16)", len(d))
+	}
+}
+
 // TestLabelsForTarget_LegacySingleLabel verifies that FlowLabelCount <= 1
 // preserves exact legacy behavior: the single controller-provided FlowLabel is
 // used verbatim, ignoring seed and epoch.

--- a/rebuild/internal/agent/prober_flowlabel_test.go
+++ b/rebuild/internal/agent/prober_flowlabel_test.go
@@ -58,6 +58,41 @@ func TestGenerateFlowLabels_ZeroCount(t *testing.T) {
 	}
 }
 
+// TestGenerateFlowLabels_DistinctUnderCollision verifies that a (seed, count)
+// pair whose raw 20-bit hashes collide still yields exactly count distinct
+// labels. seed=593, count=64, epoch=0 is a known collision (indices 5 and 37
+// both hash to 0xfda4b without dedup); Eq.(1) sizing assumes distinct labels,
+// so the set-guarded loop must resolve the collision. A broad sweep guards the
+// invariant across many seeds at the controller's maximum cap (64).
+func TestGenerateFlowLabels_DistinctUnderCollision(t *testing.T) {
+	got := generateFlowLabels(593, 64, 0)
+	seen := make(map[uint32]struct{}, len(got))
+	for i, v := range got {
+		if v > 0xFFFFF {
+			t.Errorf("label[%d] = %#x exceeds 20-bit width", i, v)
+		}
+		if _, dup := seen[v]; dup {
+			t.Errorf("label[%d] = %#x is a duplicate; collision not resolved", i, v)
+		}
+		seen[v] = struct{}{}
+	}
+	if len(seen) != 64 {
+		t.Fatalf("seed=593 count=64: got %d distinct labels, want 64", len(seen))
+	}
+
+	// The dedup must hold for every seed at the maximum label count.
+	for seed := uint32(0); seed < 4096; seed++ {
+		labels := generateFlowLabels(seed, 64, 0)
+		u := make(map[uint32]struct{}, 64)
+		for _, v := range labels {
+			u[v] = struct{}{}
+		}
+		if len(u) != 64 {
+			t.Fatalf("seed=%d count=64: got %d distinct labels, want 64", seed, len(u))
+		}
+	}
+}
+
 // TestFlowLabelRotation_FractionAcrossEpoch verifies that exactly the rotating
 // subset (~20%, every flowLabelRotateStride-th index) changes across an epoch
 // boundary while the rest stay stable for time-series continuity.

--- a/rebuild/internal/agent/prober_flowlabel_test.go
+++ b/rebuild/internal/agent/prober_flowlabel_test.go
@@ -1,0 +1,178 @@
+// Tests for the prober's ECMP multi-flow-label probing: deterministic
+// label-set expansion, round-robin advance across a target's set, time-based
+// rotation of the ~20% rotating subset, and the invariant that the per-target
+// rate limit is independent of the label-set size (probe amplification is
+// bounded, not multiplied by n).
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// TestGenerateFlowLabels_Deterministic verifies that the same (seed, count,
+// epoch) always yields the same set and that the set is distinct and within
+// the 20-bit flow-label field.
+func TestGenerateFlowLabels_Deterministic(t *testing.T) {
+	const (
+		seed  = uint32(0x12345678)
+		count = uint32(16)
+		epoch = uint64(42)
+	)
+
+	a := generateFlowLabels(seed, count, epoch)
+	b := generateFlowLabels(seed, count, epoch)
+
+	if len(a) != int(count) {
+		t.Fatalf("len = %d, want %d", len(a), count)
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("non-deterministic at %d: %d != %d", i, a[i], b[i])
+		}
+	}
+
+	seen := make(map[uint32]struct{}, count)
+	for i, v := range a {
+		if v > 0xFFFFF {
+			t.Errorf("label[%d] = %#x exceeds 20-bit flow-label width", i, v)
+		}
+		if _, dup := seen[v]; dup {
+			t.Errorf("label[%d] = %#x is a duplicate; set is not distinct", i, v)
+		}
+		seen[v] = struct{}{}
+	}
+	if len(seen) != int(count) {
+		t.Errorf("distinct labels = %d, want %d", len(seen), count)
+	}
+}
+
+// TestGenerateFlowLabels_ZeroCount ensures a count of 0 still yields one label,
+// so every target is probed at least once.
+func TestGenerateFlowLabels_ZeroCount(t *testing.T) {
+	if got := generateFlowLabels(1, 0, 0); len(got) != 1 {
+		t.Errorf("count=0 produced %d labels, want 1", len(got))
+	}
+}
+
+// TestFlowLabelRotation_FractionAcrossEpoch verifies that exactly the rotating
+// subset (~20%, every flowLabelRotateStride-th index) changes across an epoch
+// boundary while the rest stay stable for time-series continuity.
+func TestFlowLabelRotation_FractionAcrossEpoch(t *testing.T) {
+	const (
+		seed  = uint32(0xABCDEF01)
+		count = uint32(20)
+	)
+	before := generateFlowLabels(seed, count, 1000)
+	after := generateFlowLabels(seed, count, 1001)
+
+	rotating := 0
+	changed := 0
+	for i := uint32(0); i < count; i++ {
+		if i%flowLabelRotateStride == 0 {
+			rotating++
+		} else if before[i] != after[i] {
+			t.Errorf("stable index %d changed across epoch: %d -> %d", i, before[i], after[i])
+		}
+		if before[i] != after[i] {
+			changed++
+		}
+	}
+
+	// With stride 5 over 20 labels, indices 0,5,10,15 rotate -> 20%.
+	if wantRotating := int(count) / flowLabelRotateStride; rotating != wantRotating {
+		t.Errorf("rotating index count = %d, want %d (~20%%)", rotating, wantRotating)
+	}
+	// Changed labels can never exceed the rotating count, and (barring an
+	// astronomically unlikely hash collision) at least one must actually move.
+	if changed > rotating {
+		t.Errorf("changed %d > rotating %d: a stable label moved", changed, rotating)
+	}
+	if changed == 0 {
+		t.Error("no labels changed across the epoch boundary; rotation is not taking effect")
+	}
+}
+
+// TestNextFlowLabel_RoundRobin verifies that successive probes to a target walk
+// its flow-label set in order and wrap around (round-robin), so all paths are
+// exercised over time.
+func TestNextFlowLabel_RoundRobin(t *testing.T) {
+	const (
+		seed  = uint32(0xABCDEF)
+		count = uint32(4)
+		epoch = uint64(1000)
+	)
+	target := &controller_agent.PingTarget{
+		TargetGid:      "fe80::abcd",
+		FlowLabelSeed:  seed,
+		FlowLabelCount: count,
+	}
+	want := generateFlowLabels(seed, count, epoch)
+
+	p := &Prober{logger: zerolog.Nop()}
+	for i := 0; i < 3*int(count); i++ {
+		got := p.nextFlowLabel(target, epoch)
+		exp := want[uint32(i)%count]
+		if got != exp {
+			t.Fatalf("probe %d: flow label = %d, want %d (round-robin index %d)",
+				i, got, exp, uint32(i)%count)
+		}
+	}
+}
+
+// TestLabelsForTarget_LegacySingleLabel verifies that FlowLabelCount <= 1
+// preserves exact legacy behavior: the single controller-provided FlowLabel is
+// used verbatim, ignoring seed and epoch.
+func TestLabelsForTarget_LegacySingleLabel(t *testing.T) {
+	target := &controller_agent.PingTarget{
+		FlowLabel:      0xBEEF,
+		FlowLabelSeed:  0x9999,
+		FlowLabelCount: 1,
+	}
+	got := labelsForTarget(target, 12345)
+	if len(got) != 1 || got[0] != 0xBEEF {
+		t.Errorf("legacy path = %v, want [0xBEEF]", got)
+	}
+
+	// Count 0 (unset by an older controller) is also legacy single-label.
+	target.FlowLabelCount = 0
+	got = labelsForTarget(target, 999)
+	if len(got) != 1 || got[0] != 0xBEEF {
+		t.Errorf("count=0 path = %v, want [0xBEEF]", got)
+	}
+}
+
+// TestPerTargetRateLimit_IndependentOfFlowLabelCount verifies that the
+// aggregate send-rate limit is per TARGET (pps * number of targets) and does
+// not scale with each target's flow-label count. This guards the deliberate
+// choice that a target's labels share its probe budget (bounded amplification).
+func TestPerTargetRateLimit_IndependentOfFlowLabelCount(t *testing.T) {
+	const pps = 10.0
+
+	// Two targets, each with a large flow-label set.
+	targets := []*controller_agent.PingTarget{
+		{TargetGid: "fe80::1", FlowLabelSeed: 1, FlowLabelCount: 64},
+		{TargetGid: "fe80::2", FlowLabelSeed: 2, FlowLabelCount: 64},
+	}
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(targets)
+	p.SetPerTargetRateLimit(pps)
+
+	// Aggregate rate must be pps * len(targets) = 20 pps regardless of the
+	// per-target flow-label count, i.e. a 50ms minimum spacing.
+	wantInterval := time.Duration(float64(time.Second) / (pps * float64(len(targets))))
+
+	base := time.Now()
+	if w := p.limiter.Reserve(base); w != 0 {
+		t.Fatalf("first Reserve wait = %v, want 0", w)
+	}
+	// The next send, requested at the same instant, must wait exactly one
+	// aggregate interval -- proving n (=64) did not inflate the rate.
+	if w := p.limiter.Reserve(base); w != wantInterval {
+		t.Fatalf("second Reserve wait = %v, want %v (rate independent of flow_label_count)", w, wantInterval)
+	}
+}

--- a/rebuild/internal/agent/prober_flowlabel_test.go
+++ b/rebuild/internal/agent/prober_flowlabel_test.go
@@ -93,6 +93,29 @@ func TestGenerateFlowLabels_DistinctUnderCollision(t *testing.T) {
 	}
 }
 
+// TestClampDistinctFlowLabelCount verifies the agent never asks for more
+// distinct labels than the 20-bit space holds, so a bad/malicious controller
+// FlowLabelCount cannot make generateFlowLabels spin forever. The clamp
+// decision is tested directly (not by generating 2^20 labels) to stay fast.
+func TestClampDistinctFlowLabelCount(t *testing.T) {
+	tests := []struct {
+		in   uint32
+		want uint32
+	}{
+		{0, 0},
+		{5, 5},
+		{maxDistinctFlowLabels - 1, maxDistinctFlowLabels - 1},
+		{maxDistinctFlowLabels, maxDistinctFlowLabels},
+		{maxDistinctFlowLabels + 1, maxDistinctFlowLabels},
+		{^uint32(0), maxDistinctFlowLabels}, // 2^32-1, worst case
+	}
+	for _, tc := range tests {
+		if got := clampDistinctFlowLabelCount(tc.in); got != tc.want {
+			t.Errorf("clampDistinctFlowLabelCount(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestFlowLabelRotation_FractionAcrossEpoch verifies that exactly the rotating
 // subset (~20%, every flowLabelRotateStride-th index) changes across an epoch
 // boundary while the rest stay stable for time-series continuity.

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -12,6 +12,12 @@ import (
 // DefaultTargetProbeRatePerSecond is the default number of probes per second per target.
 const DefaultTargetProbeRatePerSecond = 10
 
+// DefaultFlowLabelRotationPeriodSec is the default period (seconds) over which
+// the rotating subset (~20%) of a target's ECMP flow-label set is refreshed,
+// shifting a fraction of probed paths over time while most labels stay stable
+// for time-series continuity. 3600s (1h) matches the R-Pingmesh paper.
+const DefaultFlowLabelRotationPeriodSec = 3600
+
 // AgentConfig holds all configuration for the agent.
 type AgentConfig struct {
 	AgentID                   string   `mapstructure:"agent_id"`
@@ -26,6 +32,10 @@ type AgentConfig struct {
 	GIDIndex                  int      `mapstructure:"gid_index"`
 	PinglistUpdateIntervalSec uint32   `mapstructure:"pinglist_update_interval_sec"`
 	TargetProbeRatePerSecond  int      `mapstructure:"target_probe_rate_per_second"`
+	// FlowLabelRotationPeriodSec is the period over which the rotating subset
+	// of each target's ECMP flow-label set is refreshed (time-based ECMP path
+	// rotation). See DefaultFlowLabelRotationPeriodSec.
+	FlowLabelRotationPeriodSec uint32 `mapstructure:"flow_label_rotation_period_sec"`
 }
 
 // LoadAgentConfig loads agent configuration from a YAML file, environment
@@ -51,6 +61,7 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	v.SetDefault("gid_index", 0)
 	v.SetDefault("pinglist_update_interval_sec", 300)
 	v.SetDefault("target_probe_rate_per_second", DefaultTargetProbeRatePerSecond)
+	v.SetDefault("flow_label_rotation_period_sec", DefaultFlowLabelRotationPeriodSec)
 
 	// Enable environment variable override with RPINGMESH_ prefix.
 	// Underscores in env var names map to underscores in config keys.
@@ -104,18 +115,19 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	}
 
 	config := &AgentConfig{
-		AgentID:                   agentID,
-		HostName:                  hostname,
-		TorID:                     v.GetString("tor_id"),
-		ControllerAddr:            v.GetString("controller_addr"),
-		LogLevel:                  v.GetString("log_level"),
-		ProbeIntervalMS:           v.GetUint32("probe_interval_ms"),
-		OtelCollectorAddr:         v.GetString("otel_collector_addr"),
-		MetricsEnabled:            v.GetBool("metrics_enabled"),
-		AllowedDeviceNames:        v.GetStringSlice("allowed_device_names"),
-		GIDIndex:                  v.GetInt("gid_index"),
-		PinglistUpdateIntervalSec: v.GetUint32("pinglist_update_interval_sec"),
-		TargetProbeRatePerSecond:  v.GetInt("target_probe_rate_per_second"),
+		AgentID:                    agentID,
+		HostName:                   hostname,
+		TorID:                      v.GetString("tor_id"),
+		ControllerAddr:             v.GetString("controller_addr"),
+		LogLevel:                   v.GetString("log_level"),
+		ProbeIntervalMS:            v.GetUint32("probe_interval_ms"),
+		OtelCollectorAddr:          v.GetString("otel_collector_addr"),
+		MetricsEnabled:             v.GetBool("metrics_enabled"),
+		AllowedDeviceNames:         v.GetStringSlice("allowed_device_names"),
+		GIDIndex:                   v.GetInt("gid_index"),
+		PinglistUpdateIntervalSec:  v.GetUint32("pinglist_update_interval_sec"),
+		TargetProbeRatePerSecond:   v.GetInt("target_probe_rate_per_second"),
+		FlowLabelRotationPeriodSec: v.GetUint32("flow_label_rotation_period_sec"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -139,6 +151,11 @@ func (c *AgentConfig) Validate() error {
 		return fmt.Errorf("probe_interval_ms must be > 0, got: %d", c.ProbeIntervalMS)
 	}
 
+	// A zero rotation period would make the epoch computation divide by zero.
+	if c.FlowLabelRotationPeriodSec == 0 {
+		return fmt.Errorf("flow_label_rotation_period_sec must be > 0, got: %d", c.FlowLabelRotationPeriodSec)
+	}
+
 	return nil
 }
 
@@ -156,4 +173,5 @@ func BindAgentFlags(flags *pflag.FlagSet) {
 	flags.Int("gid-index", 0, "GID index to use for RDMA devices (must be >= 0)")
 	flags.Uint32("pinglist-update-interval-sec", 300, "Pinglist update interval in seconds")
 	flags.Int("target-probe-rate-per-second", DefaultTargetProbeRatePerSecond, "Probe rate per second per target")
+	flags.Uint32("flow-label-rotation-period-sec", DefaultFlowLabelRotationPeriodSec, "Period (seconds) over which the rotating ~20% of each target's ECMP flow-label set is refreshed")
 }

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -183,6 +183,26 @@ func TestControllerConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// A cap above the 20-bit flow-label space (2^20) could reach a
+			// PingTarget and hang the agent's distinct-label generation.
+			name: "ecmp max flow labels exceeds 20-bit space",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: MaxEcmpFlowLabels + 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ecmp max flow labels at 20-bit boundary",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: MaxEcmpFlowLabels,
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid listen addr",
 			cfg: ControllerConfig{
 				ListenAddr: "not-a-valid-addr-no-colon", DatabaseURI: "http://localhost:4001", LogLevel: "info",

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -151,8 +151,36 @@ func TestControllerConfig_Validate(t *testing.T) {
 			cfg: ControllerConfig{
 				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
 				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 64,
 			},
 			wantErr: false,
+		},
+		{
+			name: "zero ecmp paths assumed",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 0, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 64,
+			},
+			wantErr: true,
+		},
+		{
+			name: "coverage probability out of range",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 1.0, EcmpMaxFlowLabels: 64,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero ecmp max flow labels",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 0,
+			},
+			wantErr: true,
 		},
 		{
 			name: "invalid listen addr",
@@ -286,17 +314,22 @@ func TestAgentConfig_Validate(t *testing.T) {
 	}{
 		{
 			name:    "valid",
-			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 500},
+			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600},
 			wantErr: false,
 		},
 		{
 			name:    "negative gid index",
-			cfg:     AgentConfig{GIDIndex: -1, ProbeIntervalMS: 500},
+			cfg:     AgentConfig{GIDIndex: -1, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600},
 			wantErr: true,
 		},
 		{
 			name:    "zero probe interval",
-			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 0},
+			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 0, FlowLabelRotationPeriodSec: 3600},
+			wantErr: true,
+		},
+		{
+			name:    "zero flow label rotation period",
+			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 0},
 			wantErr: true,
 		},
 	}

--- a/rebuild/internal/config/controller_config.go
+++ b/rebuild/internal/config/controller_config.go
@@ -26,6 +26,17 @@ const (
 	// DefaultInterTorSampleSize is the default number of distinct ToRs
 	// sampled for inter-ToR pinglist generation.
 	DefaultInterTorSampleSize = 5
+
+	// DefaultEcmpPathsAssumed is the assumed ECMP fabric width (m) used by
+	// Eq.(1) to size the per-target flow-label set. It cannot be measured
+	// from the agent, so it is an operator assumption.
+	DefaultEcmpPathsAssumed = 16
+	// DefaultEcmpCoverageProbability is the target probability (p) that the
+	// generated flow-label set exercises all m ECMP paths.
+	DefaultEcmpCoverageProbability = 0.9
+	// DefaultEcmpMaxFlowLabels caps the computed label count (n) to bound
+	// probe amplification.
+	DefaultEcmpMaxFlowLabels = 64
 )
 
 // ControllerConfig holds all configuration for the controller.
@@ -36,6 +47,12 @@ type ControllerConfig struct {
 	ActiveThresholdSec int    `mapstructure:"active_threshold_sec"`
 	StaleThresholdSec  int    `mapstructure:"stale_threshold_sec"`
 	InterTorSampleSize int    `mapstructure:"inter_tor_sample_size"`
+	// EcmpPathsAssumed (m), EcmpCoverageProbability (p), and EcmpMaxFlowLabels
+	// (cap on n) drive R-Pingmesh Eq.(1) sizing of the per-target flow-label
+	// set for probabilistic ECMP path coverage.
+	EcmpPathsAssumed        int     `mapstructure:"ecmp_paths_assumed"`
+	EcmpCoverageProbability float64 `mapstructure:"ecmp_coverage_probability"`
+	EcmpMaxFlowLabels       int     `mapstructure:"ecmp_max_flow_labels"`
 }
 
 // LoadControllerConfig loads controller configuration from a YAML file,
@@ -55,6 +72,9 @@ func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerC
 	v.SetDefault("active_threshold_sec", DefaultActiveThresholdSec)
 	v.SetDefault("stale_threshold_sec", DefaultStaleThresholdSec)
 	v.SetDefault("inter_tor_sample_size", DefaultInterTorSampleSize)
+	v.SetDefault("ecmp_paths_assumed", DefaultEcmpPathsAssumed)
+	v.SetDefault("ecmp_coverage_probability", DefaultEcmpCoverageProbability)
+	v.SetDefault("ecmp_max_flow_labels", DefaultEcmpMaxFlowLabels)
 
 	// Enable environment variable override with RPINGMESH_ prefix
 	v.SetEnvPrefix("RPINGMESH")
@@ -91,12 +111,15 @@ func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerC
 	}
 
 	config := &ControllerConfig{
-		ListenAddr:         v.GetString("listen_addr"),
-		DatabaseURI:        v.GetString("database_uri"),
-		LogLevel:           v.GetString("log_level"),
-		ActiveThresholdSec: v.GetInt("active_threshold_sec"),
-		StaleThresholdSec:  v.GetInt("stale_threshold_sec"),
-		InterTorSampleSize: v.GetInt("inter_tor_sample_size"),
+		ListenAddr:              v.GetString("listen_addr"),
+		DatabaseURI:             v.GetString("database_uri"),
+		LogLevel:                v.GetString("log_level"),
+		ActiveThresholdSec:      v.GetInt("active_threshold_sec"),
+		StaleThresholdSec:       v.GetInt("stale_threshold_sec"),
+		InterTorSampleSize:      v.GetInt("inter_tor_sample_size"),
+		EcmpPathsAssumed:        v.GetInt("ecmp_paths_assumed"),
+		EcmpCoverageProbability: v.GetFloat64("ecmp_coverage_probability"),
+		EcmpMaxFlowLabels:       v.GetInt("ecmp_max_flow_labels"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -159,6 +182,18 @@ func (c *ControllerConfig) Validate() error {
 		return fmt.Errorf("inter_tor_sample_size must be > 0, got: %d", c.InterTorSampleSize)
 	}
 
+	if c.EcmpPathsAssumed < 1 {
+		return fmt.Errorf("ecmp_paths_assumed must be >= 1, got: %d", c.EcmpPathsAssumed)
+	}
+	// p must be a strict probability: 0 and 1 are degenerate for Eq.(1)
+	// (0 needs no coverage; 1 is unreachable by random sampling).
+	if c.EcmpCoverageProbability <= 0 || c.EcmpCoverageProbability >= 1 {
+		return fmt.Errorf("ecmp_coverage_probability must be in (0, 1), got: %v", c.EcmpCoverageProbability)
+	}
+	if c.EcmpMaxFlowLabels < 1 {
+		return fmt.Errorf("ecmp_max_flow_labels must be >= 1, got: %d", c.EcmpMaxFlowLabels)
+	}
+
 	return nil
 }
 
@@ -171,4 +206,7 @@ func BindControllerFlags(flags *pflag.FlagSet) {
 	flags.Int("active-threshold-sec", DefaultActiveThresholdSec, "Window (seconds) within which an RNIC is considered active")
 	flags.Int("stale-threshold-sec", DefaultStaleThresholdSec, "Window (seconds) after which an inactive RNIC is removed")
 	flags.Int("inter-tor-sample-size", DefaultInterTorSampleSize, "Number of distinct ToRs sampled for inter-ToR pinglists")
+	flags.Int("ecmp-paths-assumed", DefaultEcmpPathsAssumed, "Assumed ECMP fabric width (m) for Eq.(1) flow-label coverage sizing")
+	flags.Float64("ecmp-coverage-probability", DefaultEcmpCoverageProbability, "Target probability (p, in (0,1)) that generated flow labels cover all ECMP paths")
+	flags.Int("ecmp-max-flow-labels", DefaultEcmpMaxFlowLabels, "Hard cap on the number of flow labels per target (bounds probe amplification)")
 }

--- a/rebuild/internal/config/controller_config.go
+++ b/rebuild/internal/config/controller_config.go
@@ -37,6 +37,13 @@ const (
 	// DefaultEcmpMaxFlowLabels caps the computed label count (n) to bound
 	// probe amplification.
 	DefaultEcmpMaxFlowLabels = 64
+
+	// MaxEcmpFlowLabels is the absolute ceiling on ecmp_max_flow_labels: the
+	// IPv6 flow-label field is 20 bits, so at most 2^20 DISTINCT labels can
+	// exist. A larger cap could reach a PingTarget and make the agent's
+	// distinct-label generation unable to ever collect that many, so it is
+	// rejected here.
+	MaxEcmpFlowLabels = 1 << 20
 )
 
 // ControllerConfig holds all configuration for the controller.
@@ -192,6 +199,11 @@ func (c *ControllerConfig) Validate() error {
 	}
 	if c.EcmpMaxFlowLabels < 1 {
 		return fmt.Errorf("ecmp_max_flow_labels must be >= 1, got: %d", c.EcmpMaxFlowLabels)
+	}
+	// The 20-bit flow-label field holds at most 2^20 distinct values; a larger
+	// cap could hang the agent's distinct-label generation.
+	if c.EcmpMaxFlowLabels > MaxEcmpFlowLabels {
+		return fmt.Errorf("ecmp_max_flow_labels must be <= %d (20-bit flow-label space), got: %d", MaxEcmpFlowLabels, c.EcmpMaxFlowLabels)
 	}
 
 	return nil

--- a/rebuild/internal/config/controller_config.go
+++ b/rebuild/internal/config/controller_config.go
@@ -38,12 +38,13 @@ const (
 	// probe amplification.
 	DefaultEcmpMaxFlowLabels = 64
 
-	// MaxEcmpFlowLabels is the absolute ceiling on ecmp_max_flow_labels: the
-	// IPv6 flow-label field is 20 bits, so at most 2^20 DISTINCT labels can
-	// exist. A larger cap could reach a PingTarget and make the agent's
-	// distinct-label generation unable to ever collect that many, so it is
-	// rejected here.
-	MaxEcmpFlowLabels = 1 << 20
+	// MaxEcmpFlowLabels is the operational ceiling on ecmp_max_flow_labels.
+	// 4096 labels is ~16KB per target ([]uint32) and covers even extreme Eq.(1)
+	// configs (e.g. m=256, p=0.99 needs ~2600 labels). It is deliberately far
+	// below the 20-bit field's theoretical 2^20 maximum, which would make each
+	// target carry a ~1M-entry label set/map and stall or OOM the agent. The
+	// agent enforces the same 4096 clamp as defense in depth.
+	MaxEcmpFlowLabels = 4096
 )
 
 // ControllerConfig holds all configuration for the controller.
@@ -200,10 +201,10 @@ func (c *ControllerConfig) Validate() error {
 	if c.EcmpMaxFlowLabels < 1 {
 		return fmt.Errorf("ecmp_max_flow_labels must be >= 1, got: %d", c.EcmpMaxFlowLabels)
 	}
-	// The 20-bit flow-label field holds at most 2^20 distinct values; a larger
-	// cap could hang the agent's distinct-label generation.
+	// Bound per-target probe amplification and agent memory: an operational cap
+	// far below the 20-bit flow-label space (see MaxEcmpFlowLabels).
 	if c.EcmpMaxFlowLabels > MaxEcmpFlowLabels {
-		return fmt.Errorf("ecmp_max_flow_labels must be <= %d (20-bit flow-label space), got: %d", MaxEcmpFlowLabels, c.EcmpMaxFlowLabels)
+		return fmt.Errorf("ecmp_max_flow_labels must be <= %d, got: %d", MaxEcmpFlowLabels, c.EcmpMaxFlowLabels)
 	}
 
 	return nil

--- a/rebuild/internal/controller/pinglist/ecmp.go
+++ b/rebuild/internal/controller/pinglist/ecmp.go
@@ -1,0 +1,106 @@
+package pinglist
+
+import "math"
+
+// ECMPConfig parameterizes how many distinct flow labels the controller asks
+// an agent to probe each target with, so that the target's set of
+// equal-cost (ECMP) paths is covered with a target probability.
+//
+// These come from controller configuration:
+//   - PathsAssumed          -> ecmp_paths_assumed        (m)
+//   - CoverageProbability    -> ecmp_coverage_probability (p)
+//   - MaxFlowLabels          -> ecmp_max_flow_labels      (hard cap on n)
+type ECMPConfig struct {
+	// PathsAssumed is the assumed number of equal-probability ECMP paths (m)
+	// between any prober and target. It cannot be measured from the agent, so
+	// it is an operator-supplied fabric-width assumption.
+	PathsAssumed int
+	// CoverageProbability is the desired probability p (0 < p < 1) that all m
+	// paths are exercised by the generated flow-label set.
+	CoverageProbability float64
+	// MaxFlowLabels caps n to bound probe amplification: n distinct labels
+	// share one target's probe budget, but a large n still costs memory and
+	// slows per-label revisit cadence, so we never exceed this ceiling.
+	MaxFlowLabels int
+}
+
+// DefaultECMP* mirror the controller config defaults so the two stay in sync
+// without the config package importing this one.
+const (
+	DefaultECMPPathsAssumed        = 16
+	DefaultECMPCoverageProbability = 0.9
+	DefaultECMPMaxFlowLabels       = 64
+)
+
+// ComputeFlowLabelCount returns n, the number of distinct random flow labels
+// required to cover all m equal-probability ECMP paths with probability at
+// least p, capped at maxLabels. It implements R-Pingmesh (SIGCOMM 2024)
+// Eq.(1), a coupon-collector coverage sizing.
+//
+// Derivation (coupon-collector, per-path independence closed form):
+//
+//	Model each probe as drawing one of m paths uniformly at random. Let
+//	q = (m-1)/m be the probability a probe MISSES a given path. After n
+//	independent draws, that path is still uncovered with probability q^n, so
+//	it is covered with probability (1 - q^n). Treating the m paths' coverage
+//	events as independent (a standard, slightly conservative closed form —
+//	the true events are negatively correlated, so this never underestimates
+//	the labels needed), the probability that ALL m paths are covered is
+//	approximately:
+//
+//	    P(cover all) ≈ (1 - q^n)^m
+//
+//	Requiring P(cover all) >= p and solving for n:
+//
+//	    (1 - q^n)^m >= p
+//	    1 - q^n     >= p^(1/m)
+//	    q^n         <= 1 - p^(1/m)
+//	    n           >= ln(1 - p^(1/m)) / ln(q)          [ln(q) < 0 flips >=]
+//
+//	giving  n = ceil( ln(1 - p^(1/m)) / ln((m-1)/m) ).
+//
+//	This agrees to within one probe with the strict union bound
+//	P(cover all) >= 1 - m*q^n (which yields n = ceil(ln((1-p)/m)/ln(q))); we
+//	use the closed form above as directed. At the defaults (m=16, p=0.9) both
+//	give ~78, so the MaxFlowLabels cap (64) is the binding constraint and the
+//	choice between the two forms is immaterial.
+//
+// Edge cases:
+//   - m <= 1: a single path is covered by any one label -> n = 1.
+//   - p <= 0: coverage is trivially satisfied -> n = 1.
+//   - p >= 1: exact certainty is unreachable by random sampling -> cap.
+//   - result is always clamped to [1, maxLabels].
+func ComputeFlowLabelCount(m int, p float64, maxLabels int) uint32 {
+	if maxLabels < 1 {
+		maxLabels = 1
+	}
+	// With one (or zero) assumed path, a single flow label already covers it.
+	if m <= 1 {
+		return 1
+	}
+	// Non-positive coverage targets are trivially met by one label.
+	if p <= 0 {
+		return 1
+	}
+	// p >= 1 makes 1 - p^(1/m) <= 0 and ln() undefined/-Inf; certainty is not
+	// achievable via random sampling, so fall back to the amplification cap.
+	if p >= 1 {
+		return uint32(maxLabels)
+	}
+
+	mf := float64(m)
+	q := (mf - 1) / mf // per-probe miss probability
+	numerator := math.Log(1 - math.Pow(p, 1/mf))
+	denominator := math.Log(q) // < 0 for m >= 2
+
+	n := math.Ceil(numerator / denominator)
+
+	// Guard against NaN/Inf from floating-point extremes; clamp into range.
+	if math.IsNaN(n) || n < 1 {
+		n = 1
+	}
+	if n > float64(maxLabels) {
+		n = float64(maxLabels)
+	}
+	return uint32(n)
+}

--- a/rebuild/internal/controller/pinglist/ecmp_test.go
+++ b/rebuild/internal/controller/pinglist/ecmp_test.go
@@ -1,0 +1,125 @@
+package pinglist
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// TestComputeFlowLabelCount verifies Eq.(1) sizing for representative (m, p)
+// pairs, plus the hard cap and the degenerate edge cases. Expected values were
+// computed independently from n = ceil(ln(1 - p^(1/m)) / ln((m-1)/m)).
+func TestComputeFlowLabelCount(t *testing.T) {
+	tests := []struct {
+		name string
+		m    int
+		p    float64
+		maxN int
+		want uint32
+	}{
+		{"m2_p0.9", 2, 0.9, 64, 5},
+		{"m4_p0.9", 4, 0.9, 64, 13},
+		{"m8_p0.9", 8, 0.9, 64, 33},
+		{"m16_p0.9_capped", 16, 0.9, 64, 64},    // uncapped 78 -> cap 64
+		{"m16_p0.9_uncapped", 16, 0.9, 256, 78}, // cap high enough to see raw n
+		{"m32_p0.9_capped", 32, 0.9, 64, 64},
+		{"m32_p0.9_uncapped", 32, 0.9, 256, 181},
+		{"m16_p0.5", 16, 0.5, 64, 49},
+		{"m16_p0.99_capped", 16, 0.99, 64, 64},
+		// Degenerate / boundary cases.
+		{"single_path", 1, 0.9, 64, 1},
+		{"cap_dominates", 16, 0.9, 1, 1},
+		{"zero_probability", 16, 0.0, 64, 1},
+		{"certainty_falls_back_to_cap", 16, 1.0, 64, 64},
+		{"zero_cap_clamped_to_one", 16, 0.9, 0, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeFlowLabelCount(tc.m, tc.p, tc.maxN)
+			if got != tc.want {
+				t.Errorf("ComputeFlowLabelCount(%d, %v, %d) = %d, want %d",
+					tc.m, tc.p, tc.maxN, got, tc.want)
+			}
+			// The result must always be a usable, capped label count.
+			if got < 1 {
+				t.Errorf("result %d < 1", got)
+			}
+			if tc.maxN >= 1 && got > uint32(tc.maxN) {
+				t.Errorf("result %d exceeds cap %d", got, tc.maxN)
+			}
+		})
+	}
+}
+
+// TestComputeFlowLabelCount_MonotonicInProbability checks that requiring higher
+// coverage never asks for fewer labels (sanity property of Eq.(1)).
+func TestComputeFlowLabelCount_MonotonicInProbability(t *testing.T) {
+	prev := uint32(0)
+	for _, p := range []float64{0.5, 0.7, 0.9, 0.95} {
+		got := ComputeFlowLabelCount(8, p, 1000)
+		if got < prev {
+			t.Errorf("n decreased as p rose: p=%v got %d, previous %d", p, got, prev)
+		}
+		prev = got
+	}
+}
+
+// fakeRnicSource is a minimal RnicSource returning a fixed set of RNICs so the
+// generator's PingTarget construction (seed/count stamping) can be tested
+// without a real registry.
+type fakeRnicSource struct {
+	torMesh []*controller_agent.RnicInfo
+}
+
+func (f *fakeRnicSource) GetRNICsByToR(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+	return f.torMesh, nil
+}
+
+func (f *fakeRnicSource) GetSampleRNICsFromOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+	return nil, nil
+}
+
+// TestPinglistCarriesSeedAndCount verifies that generated PingTargets carry the
+// Eq.(1) flow-label count and a non-zero seed whose low 20 bits equal the
+// legacy flow label, so an agent can expand the label set.
+func TestPinglistCarriesSeedAndCount(t *testing.T) {
+	src := &fakeRnicSource{
+		torMesh: []*controller_agent.RnicInfo{
+			{Gid: "fe80::1"}, // requester (self) -- excluded
+			{Gid: "fe80::2", Qpn: 100, TorId: "tor-1"},
+			{Gid: "fe80::3", Qpn: 101, TorId: "tor-1"},
+		},
+	}
+	wantCount := ComputeFlowLabelCount(16, 0.9, 64)
+	gen := NewPinglistGenerator(src, ECMPConfig{
+		PathsAssumed:        16,
+		CoverageProbability: 0.9,
+		MaxFlowLabels:       64,
+	})
+
+	targets, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateTorMeshPinglist: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets, want 2 (requester excluded)", len(targets))
+	}
+
+	for _, tgt := range targets {
+		if tgt.GetFlowLabelCount() != wantCount {
+			t.Errorf("target %s: FlowLabelCount = %d, want %d",
+				tgt.GetTargetGid(), tgt.GetFlowLabelCount(), wantCount)
+		}
+		if tgt.GetFlowLabelSeed() == 0 {
+			t.Errorf("target %s: FlowLabelSeed = 0, want non-zero", tgt.GetTargetGid())
+		}
+		// The legacy flow label must remain the low 20 bits of the seed for
+		// backward compatibility.
+		if tgt.GetFlowLabel() != tgt.GetFlowLabelSeed()&0xFFFFF {
+			t.Errorf("target %s: FlowLabel %#x != seed&0xFFFFF %#x",
+				tgt.GetTargetGid(), tgt.GetFlowLabel(), tgt.GetFlowLabelSeed()&0xFFFFF)
+		}
+	}
+}

--- a/rebuild/internal/controller/pinglist/pinglist.go
+++ b/rebuild/internal/controller/pinglist/pinglist.go
@@ -20,12 +20,24 @@ type RnicSource interface {
 // PinglistGenerator generates probe target lists for agents.
 type PinglistGenerator struct {
 	registry RnicSource
+	// flowLabelCount is the number of distinct ECMP flow labels each target
+	// should be probed with, computed once from the ECMP config via
+	// ComputeFlowLabelCount (R-Pingmesh Eq.(1)). It is stamped into every
+	// PingTarget; the agent expands seed+count into the concrete label set.
+	flowLabelCount uint32
 }
 
-// NewPinglistGenerator creates a new PinglistGenerator backed by the given RNIC source.
-func NewPinglistGenerator(registry RnicSource) *PinglistGenerator {
+// NewPinglistGenerator creates a new PinglistGenerator backed by the given
+// RNIC source. The ECMP config sizes how many distinct flow labels each
+// target is probed with (Eq.(1) coverage), computed once here.
+func NewPinglistGenerator(registry RnicSource, ecmp ECMPConfig) *PinglistGenerator {
 	return &PinglistGenerator{
 		registry: registry,
+		flowLabelCount: ComputeFlowLabelCount(
+			ecmp.PathsAssumed,
+			ecmp.CoverageProbability,
+			ecmp.MaxFlowLabels,
+		),
 	}
 }
 
@@ -48,7 +60,7 @@ func (g *PinglistGenerator) GenerateTorMeshPinglist(
 			continue
 		}
 
-		targets = append(targets, buildPingTarget(requesterGID, rnic))
+		targets = append(targets, g.buildPingTarget(requesterGID, rnic))
 	}
 
 	log.Info().
@@ -73,7 +85,7 @@ func (g *PinglistGenerator) GenerateInterTorPinglist(
 
 	targets := make([]*controller_agent.PingTarget, 0, len(rnics))
 	for _, rnic := range rnics {
-		targets = append(targets, buildPingTarget(requesterGID, rnic))
+		targets = append(targets, g.buildPingTarget(requesterGID, rnic))
 	}
 
 	log.Info().
@@ -86,9 +98,11 @@ func (g *PinglistGenerator) GenerateInterTorPinglist(
 }
 
 // buildPingTarget creates a PingTarget from an RnicInfo with deterministic
-// 5-tuple values based on the requester-target GID pair.
-func buildPingTarget(requesterGID string, rnic *controller_agent.RnicInfo) *controller_agent.PingTarget {
+// 5-tuple values based on the requester-target GID pair, plus the ECMP
+// flow-label set sizing (seed + count) the agent expands into concrete labels.
+func (g *PinglistGenerator) buildPingTarget(requesterGID string, rnic *controller_agent.RnicInfo) *controller_agent.PingTarget {
 	targetGID := rnic.GetGid()
+	seed := flowLabelSeed(requesterGID, targetGID)
 	return &controller_agent.PingTarget{
 		TargetGid:        targetGID,
 		TargetQpn:        rnic.GetQpn(),
@@ -96,19 +110,33 @@ func buildPingTarget(requesterGID string, rnic *controller_agent.RnicInfo) *cont
 		TargetHostname:   rnic.GetHostName(),
 		TargetTorId:      rnic.GetTorId(),
 		TargetDeviceName: rnic.GetDeviceName(),
-		FlowLabel:        deterministicFlowLabel(requesterGID, targetGID),
-		SourcePort:       deterministicSourcePort(requesterGID, targetGID),
-		Priority:         deterministicPriority(requesterGID, targetGID),
+		// FlowLabel is the legacy base label (low 20 bits of the seed), kept
+		// for backward compatibility and used verbatim when FlowLabelCount<=1.
+		FlowLabel: seed & 0xFFFFF,
+		// FlowLabelSeed/FlowLabelCount let the agent derive FlowLabelCount
+		// distinct 20-bit labels without the controller enumerating them.
+		FlowLabelSeed:  seed,
+		FlowLabelCount: g.flowLabelCount,
+		SourcePort:     deterministicSourcePort(requesterGID, targetGID),
+		Priority:       deterministicPriority(requesterGID, targetGID),
 	}
 }
 
-// deterministicFlowLabel generates a deterministic flow label for ECMP path diversity.
-// Uses FNV-1a 32-bit hash of requesterGID + targetGID, masked to 20 bits (0-0xFFFFF).
-func deterministicFlowLabel(requesterGID, targetGID string) uint32 {
+// flowLabelSeed is the full 32-bit FNV-1a hash of requesterGID+targetGID. It
+// seeds agent-side flow-label expansion; its low 20 bits double as the legacy
+// single flow label (see deterministicFlowLabel).
+func flowLabelSeed(requesterGID, targetGID string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(requesterGID))
 	h.Write([]byte(targetGID))
-	return h.Sum32() & 0xFFFFF // 20-bit mask
+	return h.Sum32()
+}
+
+// deterministicFlowLabel generates a deterministic flow label for ECMP path
+// diversity: the low 20 bits (0-0xFFFFF) of flowLabelSeed. Retained so the
+// legacy single-label semantics and its tests are preserved unchanged.
+func deterministicFlowLabel(requesterGID, targetGID string) uint32 {
+	return flowLabelSeed(requesterGID, targetGID) & 0xFFFFF // 20-bit mask
 }
 
 // deterministicSourcePort generates a deterministic source port (metadata only).

--- a/rebuild/internal/controller/service.go
+++ b/rebuild/internal/controller/service.go
@@ -33,11 +33,12 @@ type ControllerService struct {
 
 // NewControllerService creates a new ControllerService backed by the given
 // RNIC registry. A PinglistGenerator is automatically created from the
-// registry.
-func NewControllerService(reg registryClient) *ControllerService {
+// registry and the ECMP config, which sizes how many distinct flow labels
+// each target is probed with (Eq.(1) coverage).
+func NewControllerService(reg registryClient, ecmp pinglist.ECMPConfig) *ControllerService {
 	return &ControllerService{
 		registry: reg,
-		pinglist: pinglist.NewPinglistGenerator(reg),
+		pinglist: pinglist.NewPinglistGenerator(reg, ecmp),
 	}
 }
 

--- a/rebuild/internal/controller/service_test.go
+++ b/rebuild/internal/controller/service_test.go
@@ -5,10 +5,21 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/yuuki/rpingmesh/rebuild/internal/controller/pinglist"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// newTestService wraps NewControllerService with a fixed, valid ECMP config so
+// the request-handling tests need not care about Eq.(1) flow-label sizing.
+func newTestService(reg registryClient) *ControllerService {
+	return NewControllerService(reg, pinglist.ECMPConfig{
+		PathsAssumed:        16,
+		CoverageProbability: 0.9,
+		MaxFlowLabels:       64,
+	})
+}
 
 // fakeRegistry implements registryClient without any real rqlite backend,
 // so that ControllerService's RegisterAgent/GetPinglist request handling
@@ -52,7 +63,7 @@ func statusCode(t *testing.T, err error) codes.Code {
 }
 
 func TestRegisterAgent_MissingAgentID(t *testing.T) {
-	svc := NewControllerService(&fakeRegistry{})
+	svc := newTestService(&fakeRegistry{})
 
 	_, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
 		TorId: "tor-1",
@@ -66,7 +77,7 @@ func TestRegisterAgent_MissingAgentID(t *testing.T) {
 }
 
 func TestRegisterAgent_MissingTorID(t *testing.T) {
-	svc := NewControllerService(&fakeRegistry{})
+	svc := newTestService(&fakeRegistry{})
 
 	_, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
 		AgentId: "agent-1",
@@ -81,7 +92,7 @@ func TestRegisterAgent_MissingTorID(t *testing.T) {
 
 func TestRegisterAgent_RegistryFailure(t *testing.T) {
 	fake := &fakeRegistry{registerErr: errors.New("write failed")}
-	svc := NewControllerService(fake)
+	svc := newTestService(fake)
 
 	resp, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
 		AgentId: "agent-1",
@@ -111,7 +122,7 @@ func TestRegisterAgent_RegistryFailure(t *testing.T) {
 
 func TestRegisterAgent_Success(t *testing.T) {
 	fake := &fakeRegistry{}
-	svc := NewControllerService(fake)
+	svc := newTestService(fake)
 
 	resp, err := svc.RegisterAgent(context.Background(), &controller_agent.AgentRegistrationRequest{
 		AgentId:  "agent-1",
@@ -146,7 +157,7 @@ func TestRegisterAgent_Success(t *testing.T) {
 }
 
 func TestGetPinglist_MissingAgentID(t *testing.T) {
-	svc := NewControllerService(&fakeRegistry{})
+	svc := newTestService(&fakeRegistry{})
 
 	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
 		RequesterGid: "gid-1",
@@ -160,7 +171,7 @@ func TestGetPinglist_MissingAgentID(t *testing.T) {
 }
 
 func TestGetPinglist_MissingRequesterGID(t *testing.T) {
-	svc := NewControllerService(&fakeRegistry{})
+	svc := newTestService(&fakeRegistry{})
 
 	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
 		AgentId: "agent-1",
@@ -174,7 +185,7 @@ func TestGetPinglist_MissingRequesterGID(t *testing.T) {
 }
 
 func TestGetPinglist_UnknownType(t *testing.T) {
-	svc := NewControllerService(&fakeRegistry{})
+	svc := newTestService(&fakeRegistry{})
 
 	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
 		AgentId:      "agent-1",
@@ -196,7 +207,7 @@ func TestGetPinglist_TorMeshSuccess(t *testing.T) {
 			{Gid: "peer-gid", TorId: "tor-1"},
 		},
 	}
-	svc := NewControllerService(fake)
+	svc := newTestService(fake)
 
 	resp, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
 		AgentId:      "agent-1",
@@ -217,7 +228,7 @@ func TestGetPinglist_TorMeshSuccess(t *testing.T) {
 
 func TestGetPinglist_RegistryFailure(t *testing.T) {
 	fake := &fakeRegistry{torMeshErr: errors.New("query failed")}
-	svc := NewControllerService(fake)
+	svc := newTestService(fake)
 
 	_, err := svc.GetPinglist(context.Background(), &controller_agent.PinglistRequest{
 		AgentId:      "agent-1",

--- a/rebuild/proto/controller_agent/controller_agent.proto
+++ b/rebuild/proto/controller_agent/controller_agent.proto
@@ -62,9 +62,23 @@ message PingTarget {
     string target_device_name = 6;
     // source_port is metadata only (not enforced at the RDMA layer).
     uint32 source_port = 7;
-    // flow_label is used for ECMP path diversity via ibv_ah_attr.grh.flow_label.
+    // flow_label is the base (legacy) ECMP flow label applied via
+    // ibv_ah_attr.grh.flow_label. It remains populated for backward
+    // compatibility and is the sole label the agent uses when
+    // flow_label_count <= 1.
     uint32 flow_label = 8;
     uint32 priority = 9;
+    // flow_label_count is the number of distinct ECMP flow labels the agent
+    // rotates through when probing this target. The controller sizes it via
+    // R-Pingmesh Eq.(1) (coupon-collector coverage) so the target's ECMP paths
+    // are covered with a configured probability. 0 or 1 selects legacy
+    // single-label behavior (use flow_label as-is).
+    uint32 flow_label_count = 10;
+    // flow_label_seed deterministically seeds agent-side generation of the
+    // flow-label set, so the controller need not enumerate every label in the
+    // message (seed + count is far smaller than a repeated list). The agent
+    // derives label i from a hash of (seed, i, rotation_epoch).
+    fixed32 flow_label_seed = 11;
 }
 
 // PinglistResponse contains the list of targets to probe.

--- a/rebuild/scripts/run-e2e.sh
+++ b/rebuild/scripts/run-e2e.sh
@@ -336,7 +336,7 @@ log "Starting RDMA e2e tests..."
 # Temporarily disable exit-on-error so post-test diagnostics always run.
 set +e
 env RDMA_E2E_ENABLED=1 \
-    go test -v -timeout 120s -run "^(TestRDMAE2E|TestProbeToOTelMetrics|TestMultiRNICBothDevicesProbe)" ./e2e/
+    go test -v -timeout 120s -run "^(TestRDMAE2E|TestProbeToOTelMetrics|TestMultiRNICBothDevicesProbe|TestECMPMultiFlowLabel)" ./e2e/
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
## Summary

Each `(source, target)` pair previously probed with a single deterministic flow label, so on an ECMP fabric every probe pinned the same path and silent drops on uncovered links stayed invisible. This implements **R-Pingmesh (SIGCOMM 2024) Eq.(1)**: the controller sizes a set of distinct flow labels per target for probabilistic ECMP coverage, and the agent rotates through them (round-robin + time-based rotation).

## Eq.(1) derivation (coupon-collector)

To cover `m` equal-probability ECMP paths with probability `>= p`, model each probe as drawing one of `m` paths uniformly. With `q = (m-1)/m` the per-probe miss probability, a given path is uncovered after `n` draws with probability `q^n`. Treating the `m` paths' coverage as independent (a standard, slightly conservative closed form — the true events are negatively correlated, so this never underestimates `n`):

```
P(cover all) ≈ (1 - q^n)^m ≥ p
  ⇒  n = ceil( ln(1 - p^(1/m)) / ln((m-1)/m) )
```

This agrees to within one probe with the strict union bound `P(cover all) ≥ 1 - m·q^n`. Computed once in the controller (`internal/controller/pinglist/ecmp.go`), clamped to `[1, cap]`. At the defaults (m=16, p=0.9) the raw n≈78, so the cap (64) binds.

## Config surface

**Controller** (`configs/controller.yaml`): `ecmp_paths_assumed` (m, 16), `ecmp_coverage_probability` (p, 0.9), `ecmp_max_flow_labels` (cap on n, 64).
**Agent** (`configs/agent.yaml`): `flow_label_rotation_period_sec` (3600).

## Distribution

`PingTarget` gains `flow_label_count` (uint32) and `flow_label_seed` (fixed32) — seed+count is far smaller than a repeated label list. The legacy `flow_label` field stays populated (low 20 bits of the seed) and is used verbatim when `flow_label_count <= 1`, so old behavior and clients are unaffected. The agent derives label `i` from `hash(seed, i, rotationEpoch)` masked to 20 bits.

## Rate semantics (deliberate)

`target_probe_rate_per_second` stays a **per-TARGET** cap; a target's labels **share** that budget — the aggregate rate is **not** multiplied by `n`. Bounding probe amplification is preferred over faster coverage.

## Rotation

`rotationEpoch = floor(unixTime / period)` is folded into the hash for ~20% of label indices (every 5th), so a fraction of paths shift each period while ~80% stay stable for time-series continuity. Wall-clock only selects labels, never a measurement timestamp.

## Zig boundary — no change

The C-ABI already takes `flow_label` per send and creates a fresh AH each time (`zig/src/packet.zig` `sendPacketInternal` → `createAddressHandle`), so per-probe label variation needs no bridge change.

## Observability

The actual flow label used is recorded in `ProbeResult` and debug logs, but deliberately **not** an OTel attribute (per-label cardinality would explode the metric space); aggregate metrics stay ToR-level.

## Design deviations from the review direction

- The review labelled Eq.(1) a "union bound" but its formula is the per-path independence closed form; I implemented that exact formula and documented both forms, noting they differ by ≤1 probe and are immaterial at the defaults (cap binds). See the derivation comment in `ecmp.go`.
- Round-robin state is kept in a per-target map confined to the single probe-loop goroutine (no lock), pruned each tick, rather than clearing it on `UpdateTargets` (which would race).
- Skipped the optional per-target distinct-label gauge (cardinality/scope).

## Verification (soft-RoCE via colima, Docker)

- `docker build -f Dockerfile.e2e` ✓ (proto gen, Zig build, full e2e compile)
- `go vet ./...` ✓ · `go test` (non-e2e, all packages) ✓ · `make build` ✓ · `make test-zig` ✓
- `make test-e2e` ✓ **twice** — `TestECMPMultiFlowLabel: completed=4 distinct_flow_labels=4 timeouts=0`
- `make test-e2e-controller` ✓ (seed/count carried over real gRPC)

Note: `.pb.go` is gitignored; only proto source + code are committed.