### PR TITLE
feat(rebuild): wire service_level/traffic_class to RDMA Address Handles

### DIFF
--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -214,6 +214,8 @@ via Cgo (`CGO_ENABLED=1`).
 | `pinglist_update_interval_sec` | `300` | Seconds between pinglist refreshes |
 | `flow_label_rotation_period_sec` | `3600` | Period over which the rotating ~20% of each target's ECMP flow-label set is refreshed |
 | `gid_index` | `0` | GID table index on RDMA devices |
+| `service_level` | `0` | Service Level (SL, PFC priority) applied to every Address Handle (0-7) |
+| `traffic_class` | `0` | GRH traffic class octet applied to every Address Handle (0-255). RoCEv2 DSCP occupies the upper 6 bits of this octet: to use DSCP value `N`, set `traffic_class = N << 2` |
 | `allowed_device_names` | `[]` | Device filter (empty = all devices) |
 | `metrics_enabled` | `true` | Enable OpenTelemetry export |
 | `otel_collector_addr` | `localhost:4317` | OTLP gRPC collector endpoint |
@@ -535,10 +537,17 @@ sudo rdma link add rxe0 type rxe netdev eth0
   agent process and no fail-closed behavior (e.g. backing off or shutting
   down probing) when local resource usage or error rates spike.
 
-- **Address Handle `sl` / `traffic_class` are always 0.** `ibv_ah_attr`
-  fields used for PFC priority (service level) and DSCP (traffic class) are
-  not configurable. Deployments relying on PFC/DSCP-based QoS should be
-  aware probes do not carry the expected markings.
+- **Address Handle `sl` / `traffic_class` are a single agent-wide value, not
+  per-target.** `service_level` and `traffic_class` (see Configuration
+  above) are applied to every Address Handle the agent creates, on every
+  device it opens. There is no way to give individual `PingTarget`s (e.g.
+  by `priority`) a different SL/DSCP; that would require per-send AH
+  parameterization, which is left for future work. Also note: on rxe
+  (soft-RoCE, used by the e2e test suite) the kernel driver does not
+  implement PFC or DSCP-based queuing, so the `sl`/`traffic_class` values
+  are carried on the wire but their real-world effect (priority-queue
+  placement) cannot be verified in that environment — only on real RDMA
+  hardware with a PFC/DSCP-aware fabric.
 
 - **No automatic recovery from RDMA device runtime failures.** If an RDMA
   device fails or is removed after the agent has started, there is no

--- a/rebuild/e2e/ecmp_flow_label_e2e_test.go
+++ b/rebuild/e2e/ecmp_flow_label_e2e_test.go
@@ -50,13 +50,13 @@ func TestECMPMultiFlowLabel(t *testing.T) {
 	}
 	defer rdmaCtx.Destroy()
 
-	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open prober device %q: %v", proberDeviceName, err)
 	}
 	defer proberDev.Close()
 
-	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open responder device %q: %v", responderDeviceName, err)
 	}

--- a/rebuild/e2e/multi_rnic_e2e_test.go
+++ b/rebuild/e2e/multi_rnic_e2e_test.go
@@ -55,14 +55,14 @@ func TestMultiRNICBothDevicesProbe(t *testing.T) {
 	defer rdmaCtx.Destroy()
 
 	// --- Devices: rxe0 and rxe1, each acting as BOTH a prober and a responder ---
-	devA, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	devA, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open device %q: %v", proberDeviceName, err)
 	}
 	defer devA.Close()
 	t.Logf("device A (%s): GID=%s IP=%s", proberDeviceName, devA.Info.GID, devA.Info.IPAddr)
 
-	devB, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	devB, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open device %q: %v", responderDeviceName, err)
 	}

--- a/rebuild/e2e/probe_otel_e2e_test.go
+++ b/rebuild/e2e/probe_otel_e2e_test.go
@@ -107,7 +107,7 @@ func TestProbeToOTelMetrics(t *testing.T) {
 	defer rdmaCtx.Destroy()
 
 	// --- Open devices ---
-	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open prober device %q: %v", proberDeviceName, err)
 	}
@@ -115,7 +115,7 @@ func TestProbeToOTelMetrics(t *testing.T) {
 	t.Logf("prober device: name=%s GID=%s IP=%s",
 		proberDev.Info.DeviceName, proberDev.Info.GID, proberDev.Info.IPAddr)
 
-	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open responder device %q: %v", responderDeviceName, err)
 	}

--- a/rebuild/e2e/rdma_e2e_test.go
+++ b/rebuild/e2e/rdma_e2e_test.go
@@ -29,7 +29,16 @@ const (
 	responderDeviceName = "rxe1"
 	// gidIndex 1 selects the IPv4-mapped RoCEv2 GID for soft-RoCE devices.
 	// Adjust if ibv_devinfo shows a different valid index for your environment.
-	gidIndex          = 1
+	gidIndex = 1
+	// testServiceLevel and testTrafficClass are deliberately non-zero across
+	// every e2e test in this package to regression-test the sl/traffic_class
+	// wiring (config -> bridge -> Zig RdmaDevice -> Address Handle): AH
+	// creation must still succeed and probes must still round-trip with a
+	// non-default SL/DSCP. rdma_rxe (soft-RoCE) does not implement PFC/DSCP
+	// queuing, so this cannot verify the actual priority-queue *effect* --
+	// only that the values flow through without breaking the data path.
+	testServiceLevel  = uint8(3)
+	testTrafficClass  = uint8(96) // DSCP 24 << 2
 	eventRingCapacity = 256
 	probeTimeoutMS    = uint32(1000)
 	testTimeout       = 30 * time.Second
@@ -58,7 +67,7 @@ func TestRDMAE2ETwoDevices(t *testing.T) {
 	defer rdmaCtx.Destroy()
 
 	// --- Devices ---
-	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open prober device %q (gidIndex=%d): %v", proberDeviceName, gidIndex, err)
 	}
@@ -66,7 +75,7 @@ func TestRDMAE2ETwoDevices(t *testing.T) {
 	t.Logf("prober  device: name=%s GID=%s IP=%s",
 		proberDev.Info.DeviceName, proberDev.Info.GID, proberDev.Info.IPAddr)
 
-	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open responder device %q (gidIndex=%d): %v", responderDeviceName, gidIndex, err)
 	}

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -630,11 +630,15 @@ func (a *Agent) Run(ctx context.Context) error {
 // devices are opened by index.
 func (a *Agent) openDevices() error {
 	gidIndex := a.cfg.GIDIndex
+	// Config.Validate() guarantees ServiceLevel is in [0,7] and TrafficClass
+	// is in [0,255], so both narrow to uint8 without loss.
+	sl := uint8(a.cfg.ServiceLevel)
+	tc := uint8(a.cfg.TrafficClass)
 
 	if len(a.cfg.AllowedDeviceNames) > 0 {
 		// Open only the explicitly allowed devices by name.
 		for _, name := range a.cfg.AllowedDeviceNames {
-			dev, err := a.rdmaCtx.OpenDeviceByName(name, gidIndex)
+			dev, err := a.rdmaCtx.OpenDeviceByName(name, gidIndex, sl, tc)
 			if err != nil {
 				a.logger.Warn().Err(err).
 					Str("device_name", name).
@@ -656,7 +660,7 @@ func (a *Agent) openDevices() error {
 		}
 
 		for i := 0; i < count; i++ {
-			dev, err := a.rdmaCtx.OpenDevice(i, gidIndex)
+			dev, err := a.rdmaCtx.OpenDevice(i, gidIndex, sl, tc)
 			if err != nil {
 				a.logger.Warn().Err(err).
 					Int("index", i).

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -20,18 +20,26 @@ const DefaultFlowLabelRotationPeriodSec = 3600
 
 // AgentConfig holds all configuration for the agent.
 type AgentConfig struct {
-	AgentID                   string   `mapstructure:"agent_id"`
-	HostName                  string   `mapstructure:"hostname"`
-	TorID                     string   `mapstructure:"tor_id"`
-	ControllerAddr            string   `mapstructure:"controller_addr"`
-	LogLevel                  string   `mapstructure:"log_level"`
-	ProbeIntervalMS           uint32   `mapstructure:"probe_interval_ms"`
-	OtelCollectorAddr         string   `mapstructure:"otel_collector_addr"`
-	MetricsEnabled            bool     `mapstructure:"metrics_enabled"`
-	AllowedDeviceNames        []string `mapstructure:"allowed_device_names"`
-	GIDIndex                  int      `mapstructure:"gid_index"`
-	PinglistUpdateIntervalSec uint32   `mapstructure:"pinglist_update_interval_sec"`
-	TargetProbeRatePerSecond  int      `mapstructure:"target_probe_rate_per_second"`
+	AgentID            string   `mapstructure:"agent_id"`
+	HostName           string   `mapstructure:"hostname"`
+	TorID              string   `mapstructure:"tor_id"`
+	ControllerAddr     string   `mapstructure:"controller_addr"`
+	LogLevel           string   `mapstructure:"log_level"`
+	ProbeIntervalMS    uint32   `mapstructure:"probe_interval_ms"`
+	OtelCollectorAddr  string   `mapstructure:"otel_collector_addr"`
+	MetricsEnabled     bool     `mapstructure:"metrics_enabled"`
+	AllowedDeviceNames []string `mapstructure:"allowed_device_names"`
+	GIDIndex           int      `mapstructure:"gid_index"`
+	// ServiceLevel is the Service Level (SL, PFC priority) applied to every
+	// Address Handle the agent's RDMA devices create (0-7; see Validate()).
+	ServiceLevel int `mapstructure:"service_level"`
+	// TrafficClass is the IPv6/GRH traffic class octet applied to every
+	// Address Handle the agent's RDMA devices create (0-255; see
+	// Validate()). RoCEv2 DSCP occupies the upper 6 bits of this octet: a
+	// target DSCP value D maps to traffic_class = D << 2.
+	TrafficClass              int    `mapstructure:"traffic_class"`
+	PinglistUpdateIntervalSec uint32 `mapstructure:"pinglist_update_interval_sec"`
+	TargetProbeRatePerSecond  int    `mapstructure:"target_probe_rate_per_second"`
 	// FlowLabelRotationPeriodSec is the period over which the rotating subset
 	// of each target's ECMP flow-label set is refreshed (time-based ECMP path
 	// rotation). See DefaultFlowLabelRotationPeriodSec.
@@ -59,6 +67,8 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	v.SetDefault("metrics_enabled", true)
 	v.SetDefault("allowed_device_names", []string{})
 	v.SetDefault("gid_index", 0)
+	v.SetDefault("service_level", 0)
+	v.SetDefault("traffic_class", 0)
 	v.SetDefault("pinglist_update_interval_sec", 300)
 	v.SetDefault("target_probe_rate_per_second", DefaultTargetProbeRatePerSecond)
 	v.SetDefault("flow_label_rotation_period_sec", DefaultFlowLabelRotationPeriodSec)
@@ -125,6 +135,8 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 		MetricsEnabled:             v.GetBool("metrics_enabled"),
 		AllowedDeviceNames:         v.GetStringSlice("allowed_device_names"),
 		GIDIndex:                   v.GetInt("gid_index"),
+		ServiceLevel:               v.GetInt("service_level"),
+		TrafficClass:               v.GetInt("traffic_class"),
 		PinglistUpdateIntervalSec:  v.GetUint32("pinglist_update_interval_sec"),
 		TargetProbeRatePerSecond:   v.GetInt("target_probe_rate_per_second"),
 		FlowLabelRotationPeriodSec: v.GetUint32("flow_label_rotation_period_sec"),
@@ -143,6 +155,18 @@ func (c *AgentConfig) Validate() error {
 	// GID index must be non-negative; it indexes into the RNIC's GID table.
 	if c.GIDIndex < 0 {
 		return fmt.Errorf("gid_index must be >= 0, got: %d", c.GIDIndex)
+	}
+
+	// Service Level maps directly to ibv_ah_attr.sl, a 4-bit verbs field of
+	// which only the low 3 bits (0-7) are meaningful as PFC priority.
+	if c.ServiceLevel < 0 || c.ServiceLevel > 7 {
+		return fmt.Errorf("service_level must be between 0 and 7, got: %d", c.ServiceLevel)
+	}
+
+	// Traffic class maps directly to the one-byte GRH traffic_class field
+	// (ibv_ah_attr.grh.traffic_class).
+	if c.TrafficClass < 0 || c.TrafficClass > 255 {
+		return fmt.Errorf("traffic_class must be between 0 and 255, got: %d", c.TrafficClass)
 	}
 
 	// A zero or negative probe interval would make time.NewTicker panic at
@@ -171,6 +195,8 @@ func BindAgentFlags(flags *pflag.FlagSet) {
 	flags.Bool("metrics-enabled", true, "Enable OpenTelemetry metrics export")
 	flags.StringSlice("allowed-device-names", []string{}, "List of allowed RDMA device names (empty = all)")
 	flags.Int("gid-index", 0, "GID index to use for RDMA devices (must be >= 0)")
+	flags.Int("service-level", 0, "Service Level (SL, PFC priority) for Address Handles (0-7)")
+	flags.Int("traffic-class", 0, "GRH traffic class (DSCP << 2) for Address Handles (0-255)")
 	flags.Uint32("pinglist-update-interval-sec", 300, "Pinglist update interval in seconds")
 	flags.Int("target-probe-rate-per-second", DefaultTargetProbeRatePerSecond, "Probe rate per second per target")
 	flags.Uint32("flow-label-rotation-period-sec", DefaultFlowLabelRotationPeriodSec, "Period (seconds) over which the rotating ~20% of each target's ECMP flow-label set is refreshed")

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -318,6 +318,51 @@ func TestLoadAgentConfig_NegativeGIDIndex(t *testing.T) {
 	}
 }
 
+func TestLoadAgentConfig_ServiceLevelAndTrafficClassDefaults(t *testing.T) {
+	cfg, err := LoadAgentConfig("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ServiceLevel != 0 {
+		t.Errorf("ServiceLevel = %d, want 0", cfg.ServiceLevel)
+	}
+	if cfg.TrafficClass != 0 {
+		t.Errorf("TrafficClass = %d, want 0", cfg.TrafficClass)
+	}
+}
+
+func TestLoadAgentConfig_NegativeServiceLevel(t *testing.T) {
+	t.Setenv("RPINGMESH_SERVICE_LEVEL", "-1")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for a negative service_level, got nil")
+	}
+}
+
+func TestLoadAgentConfig_ServiceLevelExceedsMax(t *testing.T) {
+	t.Setenv("RPINGMESH_SERVICE_LEVEL", "8")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for service_level=8 (max is 7), got nil")
+	}
+}
+
+func TestLoadAgentConfig_NegativeTrafficClass(t *testing.T) {
+	t.Setenv("RPINGMESH_TRAFFIC_CLASS", "-1")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for a negative traffic_class, got nil")
+	}
+}
+
+func TestLoadAgentConfig_TrafficClassExceedsMax(t *testing.T) {
+	t.Setenv("RPINGMESH_TRAFFIC_CLASS", "256")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for traffic_class=256 (max is 255), got nil")
+	}
+}
+
 func TestLoadAgentConfig_ZeroProbeInterval(t *testing.T) {
 	t.Setenv("RPINGMESH_PROBE_INTERVAL_MS", "0")
 
@@ -350,6 +395,46 @@ func TestAgentConfig_Validate(t *testing.T) {
 		{
 			name:    "zero flow label rotation period",
 			cfg:     AgentConfig{GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 0},
+			wantErr: true,
+		},
+		{
+			name: "valid service level and traffic class at bounds",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				ServiceLevel: 7, TrafficClass: 255,
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative service level",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				ServiceLevel: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "service level exceeds max",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				ServiceLevel: 8,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative traffic class",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				TrafficClass: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "traffic class exceeds max",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				TrafficClass: 256,
+			},
 			wantErr: true,
 		},
 	}

--- a/rebuild/internal/rdmabridge/bridge.go
+++ b/rebuild/internal/rdmabridge/bridge.go
@@ -159,7 +159,9 @@ func (ctx *Context) GetDeviceCount() int {
 
 // OpenDevice opens an RDMA device by its index in the device list.
 // The gidIndex specifies which GID table entry to use on the active port.
-func (ctx *Context) OpenDevice(index int, gidIndex int) (*Device, error) {
+// sl and tc are the Service Level (PFC priority, 0-7) and GRH traffic class
+// (DSCP << 2) applied to every Address Handle created for this device.
+func (ctx *Context) OpenDevice(index int, gidIndex int, sl uint8, tc uint8) (*Device, error) {
 	var devHandle C.rdma_device_t
 	var cInfo C.rdma_device_info_t
 
@@ -167,6 +169,8 @@ func (ctx *Context) OpenDevice(index int, gidIndex int) (*Device, error) {
 		ctx.handle,
 		C.int32_t(index),
 		C.int32_t(gidIndex),
+		C.uint8_t(sl),
+		C.uint8_t(tc),
 		&devHandle,
 		&cInfo,
 	)
@@ -185,7 +189,9 @@ func (ctx *Context) OpenDevice(index int, gidIndex int) (*Device, error) {
 
 // OpenDeviceByName opens an RDMA device by its name (e.g., "mlx5_0", "rxe0").
 // The gidIndex specifies which GID table entry to use on the active port.
-func (ctx *Context) OpenDeviceByName(name string, gidIndex int) (*Device, error) {
+// sl and tc are the Service Level (PFC priority, 0-7) and GRH traffic class
+// (DSCP << 2) applied to every Address Handle created for this device.
+func (ctx *Context) OpenDeviceByName(name string, gidIndex int, sl uint8, tc uint8) (*Device, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
@@ -196,6 +202,8 @@ func (ctx *Context) OpenDeviceByName(name string, gidIndex int) (*Device, error)
 		ctx.handle,
 		cName,
 		C.int32_t(gidIndex),
+		C.uint8_t(sl),
+		C.uint8_t(tc),
 		&devHandle,
 		&cInfo,
 	)

--- a/rebuild/zig/include/rdma_bridge.h
+++ b/rebuild/zig/include/rdma_bridge.h
@@ -194,14 +194,23 @@ int32_t rdma_get_device_count(rdma_context_t ctx);
  * specified GID index on the first active port, allocates a PD, and
  * populates the device info struct.
  *
- * @param ctx        Context handle
- * @param index      Device index (0-based)
- * @param gid_index  GID table index to use on the active port
- * @param out_dev    Receives the device handle
- * @param out_info   Receives device information (name, GID, IP, port)
- * @return           0 on success, negative error code on failure
+ * @param ctx             Context handle
+ * @param index           Device index (0-based)
+ * @param gid_index       GID table index to use on the active port
+ * @param service_level   Service Level (SL, PFC priority) to store on the
+ *                        device and apply to every Address Handle created
+ *                        for it (0-7; only the low 3 bits are meaningful).
+ * @param traffic_class   IPv6/GRH traffic class octet to store on the device
+ *                        and apply to every Address Handle created for it.
+ *                        RoCEv2 DSCP occupies the upper 6 bits of this
+ *                        octet, so a target DSCP value D maps to
+ *                        traffic_class = D << 2.
+ * @param out_dev         Receives the device handle
+ * @param out_info        Receives device information (name, GID, IP, port)
+ * @return                0 on success, negative error code on failure
  */
 int32_t rdma_open_device(rdma_context_t ctx, int32_t index, int32_t gid_index,
+                         uint8_t service_level, uint8_t traffic_class,
                          rdma_device_t* out_dev, rdma_device_info_t* out_info);
 
 /*
@@ -209,15 +218,18 @@ int32_t rdma_open_device(rdma_context_t ctx, int32_t index, int32_t gid_index,
  *
  * Same as rdma_open_device but looks up the device by name (e.g., "mlx5_0").
  *
- * @param ctx        Context handle
- * @param name       Null-terminated device name string
- * @param gid_index  GID table index to use on the active port
- * @param out_dev    Receives the device handle
- * @param out_info   Receives device information
- * @return           0 on success, negative error code on failure
+ * @param ctx             Context handle
+ * @param name            Null-terminated device name string
+ * @param gid_index       GID table index to use on the active port
+ * @param service_level   Service Level (SL, PFC priority); see rdma_open_device.
+ * @param traffic_class   GRH traffic class octet; see rdma_open_device.
+ * @param out_dev         Receives the device handle
+ * @param out_info        Receives device information
+ * @return                0 on success, negative error code on failure
  */
 int32_t rdma_open_device_by_name(rdma_context_t ctx, const char* name,
-                                 int32_t gid_index, rdma_device_t* out_dev,
+                                 int32_t gid_index, uint8_t service_level,
+                                 uint8_t traffic_class, rdma_device_t* out_dev,
                                  rdma_device_info_t* out_info);
 
 /*

--- a/rebuild/zig/src/device.zig
+++ b/rebuild/zig/src/device.zig
@@ -107,9 +107,14 @@ pub fn getDeviceCount(ctx: *types.RdmaContext) i32 {
 ///      validates the GID's RoCE type via sysfs; see logGidTypeInfo())
 ///   4. Populate the DeviceInfo struct with name, GID, and IP
 ///
+/// `sl` and `traffic_class` are static, agent-configured values stored on
+/// the returned device and later applied to every Address Handle created
+/// for it (see createAddressHandle() in queue.zig); they do not affect
+/// device discovery or GID selection.
+///
 /// On failure, all partially allocated resources are cleaned up before
 /// returning the error.
-pub fn openDevice(ctx: *types.RdmaContext, index: i32, gid_index: i32) DeviceError!*types.RdmaDevice {
+pub fn openDevice(ctx: *types.RdmaContext, index: i32, gid_index: i32, sl: u8, traffic_class: u8) DeviceError!*types.RdmaDevice {
     // Validate index bounds
     if (index < 0 or index >= ctx.device_count) {
         types.setLastError("device index out of range");
@@ -178,6 +183,8 @@ pub fn openDevice(ctx: *types.RdmaContext, index: i32, gid_index: i32) DeviceErr
         .port_num = port_result.port_num,
         .gid_index = @intCast(gid_index),
         .gid = port_result.gid,
+        .sl = sl,
+        .traffic_class = traffic_class,
         .device_info = types.DeviceInfo{
             .device_name = device_name,
             .gid = gid_str,
@@ -193,8 +200,9 @@ pub fn openDevice(ctx: *types.RdmaContext, index: i32, gid_index: i32) DeviceErr
 /// Open an RDMA device by name (e.g., "mlx5_0", "rxe0").
 ///
 /// Iterates through the device list and finds the device with the matching
-/// name, then delegates to the openDevice logic.
-pub fn openDeviceByName(ctx: *types.RdmaContext, name: [*:0]const u8, gid_index: i32) DeviceError!*types.RdmaDevice {
+/// name, then delegates to the openDevice logic. `sl` and `traffic_class`
+/// are forwarded unchanged; see openDevice() for their meaning.
+pub fn openDeviceByName(ctx: *types.RdmaContext, name: [*:0]const u8, gid_index: i32, sl: u8, traffic_class: u8) DeviceError!*types.RdmaDevice {
     const device_list = ctx.device_list orelse {
         types.setLastError("device list is null");
         return DeviceError.GetDeviceListFailed;
@@ -211,7 +219,7 @@ pub fn openDeviceByName(ctx: *types.RdmaContext, name: [*:0]const u8, gid_index:
 
         const dev_name = std.mem.sliceTo(dev_name_ptr, 0);
         if (std.mem.eql(u8, dev_name, target_name)) {
-            return openDevice(ctx, i, gid_index);
+            return openDevice(ctx, i, gid_index, sl, traffic_class);
         }
     }
 
@@ -551,6 +559,8 @@ export fn rdma_open_device(
     ctx_ptr: ?*types.RdmaContext,
     index: i32,
     gid_index: i32,
+    service_level: u8,
+    traffic_class: u8,
     out_dev: *?*types.RdmaDevice,
     out_info: *types.DeviceInfo,
 ) i32 {
@@ -559,7 +569,7 @@ export fn rdma_open_device(
         return -1;
     };
 
-    const dev = openDevice(ctx, index, gid_index) catch return -1;
+    const dev = openDevice(ctx, index, gid_index, service_level, traffic_class) catch return -1;
     out_dev.* = dev;
     out_info.* = dev.device_info;
     return 0;
@@ -573,6 +583,8 @@ export fn rdma_open_device_by_name(
     ctx_ptr: ?*types.RdmaContext,
     name: ?[*:0]const u8,
     gid_index: i32,
+    service_level: u8,
+    traffic_class: u8,
     out_dev: *?*types.RdmaDevice,
     out_info: *types.DeviceInfo,
 ) i32 {
@@ -585,7 +597,7 @@ export fn rdma_open_device_by_name(
         return -1;
     };
 
-    const dev = openDeviceByName(ctx, name_ptr, gid_index) catch return -1;
+    const dev = openDeviceByName(ctx, name_ptr, gid_index, service_level, traffic_class) catch return -1;
     out_dev.* = dev;
     out_info.* = dev.device_info;
     return 0;

--- a/rebuild/zig/src/queue.zig
+++ b/rebuild/zig/src/queue.zig
@@ -246,6 +246,9 @@ pub fn destroyQueue(queue: *types.UdQueue) void {
 ///   - Flow label for ECMP path pinning
 ///   - Source GID index from the device configuration
 ///   - Maximum hop limit (255)
+///   - Service Level (sl) and traffic class (DSCP) from the device
+///     configuration (static per-agent values; see RdmaDevice.sl /
+///     RdmaDevice.traffic_class)
 ///
 /// Uses ibv_create_ah() (not rdma_create_ah()) to match the Go implementation.
 pub fn createAddressHandle(
@@ -258,23 +261,19 @@ pub fn createAddressHandle(
     // Global routing is required for RoCE
     ah_attr.is_global = 1;
     ah_attr.port_num = dev.port_num;
-    // Known limitation: sl and traffic_class are fixed at 0 rather than
-    // being configurable. On a production lossless fabric that relies on
-    // PFC/ECN and DSCP-to-TC mappings (RoCEv2 congestion control), probe
-    // traffic sharing traffic_class=0 with best-effort/background traffic
-    // may land in an unintended priority queue, skewing latency
-    // measurements relative to the application traffic the probes are
-    // meant to represent. Left as-is here (no behavior change); a future
-    // fix would thread a configurable DSCP/traffic_class value through
-    // from the agent configuration.
-    ah_attr.sl = 0; // Service Level
+    // Service Level (PFC priority) and traffic class (DSCP) are static,
+    // agent-configured values stored on the device at open time (see
+    // device.zig openDevice()) rather than per-send arguments, since every
+    // send on this device shares the same lossless-class intent and the AH
+    // is already rebuilt per send for flow_label (ECMP) rotation.
+    ah_attr.sl = dev.sl;
 
     // GRH settings
     ah_attr.grh.dgid = types.bytesToGid(target_gid);
     ah_attr.grh.flow_label = flow_label;
     ah_attr.grh.sgid_index = dev.gid_index;
     ah_attr.grh.hop_limit = 255;
-    ah_attr.grh.traffic_class = 0;
+    ah_attr.grh.traffic_class = dev.traffic_class;
 
     const ah = c.ibv_create_ah(dev.pd, &ah_attr) orelse {
         types.setLastError("ibv_create_ah() failed");

--- a/rebuild/zig/src/types.zig
+++ b/rebuild/zig/src/types.zig
@@ -122,6 +122,18 @@ pub const RdmaDevice = struct {
     /// GID value queried from the device (union ibv_gid).
     gid: c.ibv_gid,
 
+    /// Service Level (SL, PFC priority) applied to every Address Handle
+    /// created for this device. Configured once at device-open time from
+    /// agent configuration (0-7; only the low 3 bits are meaningful to the
+    /// verbs API). See createAddressHandle() in queue.zig.
+    sl: u8,
+
+    /// GRH traffic class octet applied to every Address Handle created for
+    /// this device. Configured once at device-open time from agent
+    /// configuration. RoCEv2 DSCP occupies the upper 6 bits of this octet:
+    /// a target DSCP value D maps to traffic_class = D << 2.
+    traffic_class: u8,
+
     /// Human-readable device information matching rdma_device_info_t in the
     /// C header. This is filled during device open and returned to Go.
     device_info: DeviceInfo,
@@ -436,6 +448,21 @@ test "gidToString IPv4-mapped GID" {
     const result = gidToString(gid_bytes);
     const expected = "0000:0000:0000:0000:0000:ffff:0ac8:0001";
     try std.testing.expectEqualStrings(expected, result[0..expected.len]);
+}
+
+test "RdmaDevice stores sl and traffic_class as configured" {
+    // No real ibv_context/ibv_pd is available in a unit test (that requires
+    // an RDMA device), so this only exercises the value-propagation part of
+    // the sl/traffic_class wiring: that RdmaDevice carries whatever open
+    // time passes in through to the fields createAddressHandle() reads (see
+    // queue.zig). The AH-creation effect itself can only be exercised on
+    // real RDMA hardware/soft-RoCE (see e2e/rdma_e2e_test.go).
+    var dev: RdmaDevice = undefined;
+    dev.sl = 3;
+    dev.traffic_class = 96; // DSCP 24 << 2
+
+    try std.testing.expectEqual(@as(u8, 3), dev.sl);
+    try std.testing.expectEqual(@as(u8, 96), dev.traffic_class);
 }
 
 test "setLastError and getLastError" {


### PR DESCRIPTION
## Summary

`createAddressHandle()` (`zig/src/queue.zig`) hardcoded `ah_attr.sl = 0` and `ah_attr.grh.traffic_class = 0`, so probe traffic could never carry the PFC priority (SL) or DSCP marking a production lossless fabric expects. Probes could land in an unintended priority queue and measure latency that does not represent the application traffic they are meant to stand in for.

This PR threads two new agent-wide config keys, `service_level` and `traffic_class`, all the way down to the Address Handle:

```
config -> agent.openDevices -> rdmabridge.OpenDevice(ByName)
       -> rdma_open_device(_by_name) -> RdmaDevice{sl, traffic_class}
       -> createAddressHandle (ibv_ah_attr.sl / .grh.traffic_class)
```

- `zig/include/rdma_bridge.h`: added `uint8_t service_level, uint8_t traffic_class` to `rdma_open_device` / `rdma_open_device_by_name` (source of truth updated first).
- `zig/src/types.zig`: `RdmaDevice` gains `sl: u8` / `traffic_class: u8`.
- `zig/src/device.zig`: `openDevice`/`openDeviceByName` and their C-ABI exports accept and store the new fields.
- `zig/src/queue.zig`: `createAddressHandle` now reads `dev.sl` / `dev.traffic_class` instead of hardcoded `0`.
- `internal/rdmabridge/bridge.go`: `OpenDevice`/`OpenDeviceByName` gain `sl, tc uint8` params; all Cgo call sites updated in this same PR.
- `internal/agent/agent.go`: `openDevices()` passes `cfg.ServiceLevel`/`cfg.TrafficClass` (narrowed to `uint8`, safe because `Validate()` bounds them).
- `internal/config/agent_config.go`: new `service_level` (0-7, default 0) and `traffic_class` (0-255, default 0) keys, following the existing snake_case/`RPINGMESH_`/`--kebab` convention, with range validation in `Validate()`.
- `README.md`: documents both keys, notes `traffic_class = DSCP << 2` for RoCEv2, and updates the stale "always 0" Limitations entry to describe the current per-agent (not per-target) scope and the rxe/soft-RoCE verification caveat.
- `e2e/*_test.go`: all `OpenDeviceByName` call sites updated to pass non-zero test SL/TC values, so the RDMA e2e suite regression-tests that Address Handle creation and the probe/ACK round trip still succeed with non-default values.

**Deliberately out of scope** (per design): per-target QoS (`PingTarget.priority` -> SL) is left for future work; this PR only wires the agent-wide static value.

## Test plan

- [x] `go test ./internal/config/...` (new SL/TC range tests: negative, at-bound, over-bound) — pass locally.
- [x] Zig unit test in `types.zig` verifying `RdmaDevice` carries the configured `sl`/`traffic_class` values (AH creation itself needs real/soft RDMA hardware, exercised below).
- [x] Full verification via a Linux Docker container built from `Dockerfile.e2e` (colima, since libibverbs/librdmacm are unavailable on macOS):
  - `go vet ./...` — pass
  - `go test $(go list ./... | grep -v /e2e)` — pass (all packages)
  - `make test-zig` (`zig build test`) — pass
  - `make build` (controller + agent, full CGO/Zig link) — pass
- [x] `make test-e2e` (soft-RoCE, rxe0/rxe1 via colima) with non-zero SL(=3)/TC(=96) baked into the shared e2e test constants — all 4 e2e tests pass (`TestRDMAE2ETwoDevices`, `TestMultiRNICBothDevicesProbe`, `TestECMPMultiFlowLabel`, `TestProbeToOTelMetrics`). As expected on rxe, this only confirms AH creation/round-trip succeed with non-default values, not that PFC/DSCP queuing actually took effect (rxe doesn't implement that); README calls this out explicitly.

## Known residual concerns for review

- Per-target QoS is not implemented (by design, deferred).
- rxe/soft-RoCE cannot verify the actual PFC/DSCP *effect*, only that the values propagate without breaking the data path — this is documented in the README but is an inherent limitation of the e2e environment, not something fixable in this PR.
- `traffic_class` is a raw octet, not the DSCP value itself; documented clearly (`traffic_class = DSCP << 2`) to avoid ambiguity, per an anticipated review question.