### PR TITLE
feat(rebuild): add opt-in TLS/mTLS for controller-agent gRPC

### DIFF
--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -220,6 +220,11 @@ via Cgo (`CGO_ENABLED=1`).
 | `metrics_enabled` | `true` | Enable OpenTelemetry export |
 | `otel_collector_addr` | `localhost:4317` | OTLP gRPC collector endpoint |
 | `log_level` | `info` | Log level: debug, info, warn, error |
+| `tls_mode` | `disabled` | gRPC transport security for the controller connection: `disabled` \| `tls` \| `mtls` (see [TLS/mTLS for controller-agent gRPC](#tlsmtls-for-controller-agent-grpc)) |
+| `tls_cert_file` | `""` | Client certificate file (required when `tls_mode=mtls`) |
+| `tls_key_file` | `""` | Client private key file (required when `tls_mode=mtls`) |
+| `tls_ca_file` | `""` | CA file used to verify the controller's certificate (required when `tls_mode` is `tls` or `mtls`) |
+| `tls_server_name` | `""` | Overrides the name used for TLS SNI/verification; needed when `controller_addr` is an IP literal that doesn't match the server certificate's subject |
 
 ### Controller (`configs/controller.yaml`)
 
@@ -234,6 +239,36 @@ via Cgo (`CGO_ENABLED=1`).
 | `ecmp_coverage_probability` | `0.9` | Target probability (p, in (0,1)) that generated flow labels cover all ECMP paths |
 | `ecmp_max_flow_labels` | `64` | Hard cap on flow labels per target (bounds probe amplification) |
 | `log_level` | `info` | Log level |
+| `tls_mode` | `disabled` | gRPC transport security for the listener: `disabled` \| `tls` \| `mtls` (see [TLS/mTLS for controller-agent gRPC](#tlsmtls-for-controller-agent-grpc)) |
+| `tls_cert_file` | `""` | Server certificate file (required when `tls_mode` is `tls` or `mtls`) |
+| `tls_key_file` | `""` | Server private key file (required when `tls_mode` is `tls` or `mtls`) |
+| `tls_ca_file` | `""` | CA file used to verify client certificates (required when `tls_mode=mtls`) |
+| `tls_server_name` | `""` | Present for config-key symmetry with the agent; unused by the controller (server) role |
+
+### TLS/mTLS for controller-agent gRPC
+
+By default (`tls_mode: disabled`), controller-agent gRPC is plaintext, matching the
+original behavior; the controller and every `GRPCControllerClient` log a warning once
+at startup when running in this mode. Two opt-in modes are available, selected
+symmetrically via the `tls_mode` key on both sides:
+
+- `tls`: the agent verifies the controller's certificate; the controller does not
+  authenticate the agent. Controller needs `tls_cert_file`/`tls_key_file`; agent needs
+  `tls_ca_file`.
+- `mtls`: mutual authentication. Both sides need `tls_cert_file`, `tls_key_file`, and
+  `tls_ca_file` (the controller's `tls_ca_file` is the CA that signs agent client
+  certificates; the agent's is the CA that signs the controller's server certificate;
+  a single CA can serve both roles). This is the recommended mode for production
+  deployments.
+
+`tls_server_name` on the agent overrides the name used for TLS server-name
+verification, which is required when `controller_addr` is an IP literal rather than a
+DNS name matching the controller certificate's subject. `Validate()` fails fast at
+config-load time if a mode's required certificate files are missing or unreadable,
+rather than deferring the failure to the first gRPC handshake. `InsecureSkipVerify` is
+never used; there is deliberately no way to disable server certificate verification
+other than falling back to `tls_mode: disabled`. Certificate loading is static (no
+hot-reload): rotating certificates requires a restart.
 
 ### Environment Variable Overrides
 
@@ -512,8 +547,12 @@ sudo rdma link add rxe0 type rxe netdev eth0
   monitor RDMA QP lifecycle events for service-aware monitoring. This rebuild
   focuses on the probing infrastructure.
 
-- **No TLS on gRPC.** Controller-agent communication uses plaintext gRPC, assuming
-  a trusted internal network. mTLS can be added via gRPC transport credentials.
+- **TLS/mTLS on gRPC is opt-in, not default.** Controller-agent communication
+  supports `tls`/`mtls` transport security (see
+  [TLS/mTLS for controller-agent gRPC](#tlsmtls-for-controller-agent-grpc)), but the
+  default `tls_mode: disabled` still uses plaintext gRPC for backward compatibility.
+  Production deployments should set `tls_mode: mtls` on both sides. Certificate
+  loading is static (no hot-reload) and rotation is not a goal of this implementation.
 
 - **Only a single, uniform probe rate cap.** The Prober enforces
   `target_probe_rate_per_second` as a per-target cap (the aggregate limit

--- a/rebuild/cmd/controller/main.go
+++ b/rebuild/cmd/controller/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/yuuki/rpingmesh/rebuild/internal/config"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller"
@@ -70,6 +71,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Int("ecmpPathsAssumed", cfg.EcmpPathsAssumed).
 		Float64("ecmpCoverageProbability", cfg.EcmpCoverageProbability).
 		Int("ecmpMaxFlowLabels", cfg.EcmpMaxFlowLabels).
+		Str("tlsMode", cfg.TLSMode).
 		Msg("Starting rpingmesh-controller")
 
 	// Initialize RNIC registry backed by rqlite.
@@ -96,8 +98,24 @@ func run(cmd *cobra.Command, args []string) error {
 		MaxFlowLabels:       cfg.EcmpMaxFlowLabels,
 	})
 
+	// Configure gRPC server transport security from tls_mode. disabled (the
+	// default) preserves the original plaintext behavior for backward
+	// compatibility.
+	var serverOpts []grpc.ServerOption
+	switch cfg.TLSMode {
+	case config.TLSModeDisabled, "":
+		log.Warn().Msg("gRPC server starting with tls_mode=disabled: controller-agent traffic is plaintext and unauthenticated; set tls_mode to tls or mtls for production deployments")
+	default:
+		tlsConfig, err := config.ServerTLSConfig(cfg.TLSMode, cfg.TLSCertFile, cfg.TLSKeyFile, cfg.TLSCAFile)
+		if err != nil {
+			return fmt.Errorf("failed to build server TLS configuration: %w", err)
+		}
+		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+		log.Info().Str("tlsMode", cfg.TLSMode).Msg("gRPC server TLS enabled")
+	}
+
 	// Create and configure the gRPC server.
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(serverOpts...)
 	controller_agent.RegisterControllerServiceServer(grpcServer, svc)
 
 	// Start listening on the configured address.

--- a/rebuild/e2e/controller/agent_controller_e2e_test.go
+++ b/rebuild/e2e/controller/agent_controller_e2e_test.go
@@ -76,7 +76,9 @@ func newClient(t *testing.T) *controller_client.GRPCControllerClient {
 	addr := controllerAddr()
 	waitForController(t, addr, 30*time.Second)
 
-	client, err := controller_client.NewGRPCControllerClient(addr)
+	// nil tlsCfg: this suite exercises the plaintext default path, matching
+	// docker-compose.e2e-controller.yml's tls_mode=disabled controller.
+	client, err := controller_client.NewGRPCControllerClient(addr, nil)
 	if err != nil {
 		t.Fatalf("failed to create gRPC client: %v", err)
 	}

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -134,7 +134,13 @@ func (a *Agent) Initialize(ctx context.Context) error {
 	a.logger.Info().
 		Str("controller_addr", a.cfg.ControllerAddr).
 		Msg("Creating gRPC controller client")
-	grpcClient, err := controller_client.NewGRPCControllerClient(a.cfg.ControllerAddr)
+	grpcClient, err := controller_client.NewGRPCControllerClient(a.cfg.ControllerAddr, &config.TLSClientConfig{
+		Mode:       a.cfg.TLSMode,
+		CertFile:   a.cfg.TLSCertFile,
+		KeyFile:    a.cfg.TLSKeyFile,
+		CAFile:     a.cfg.TLSCAFile,
+		ServerName: a.cfg.TLSServerName,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC controller client: %w", err)
 	}

--- a/rebuild/internal/agent/controller_client/controller_client.go
+++ b/rebuild/internal/agent/controller_client/controller_client.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/yuuki/rpingmesh/rebuild/internal/config"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -36,14 +38,35 @@ type GRPCControllerClient struct {
 	logger zerolog.Logger
 }
 
-// NewGRPCControllerClient creates a new gRPC client connected to the controller
-// at the given address. The address should be in "host:port" format. The
-// connection uses insecure credentials, which is acceptable for internal
-// network communication.
-func NewGRPCControllerClient(controllerAddr string) (*GRPCControllerClient, error) {
+// NewGRPCControllerClient creates a new gRPC client connected to the
+// controller at the given address. The address should be in "host:port"
+// format. tlsCfg selects the transport credentials: a nil tlsCfg, or one
+// with Mode == config.TLSModeDisabled (or the empty string), uses insecure
+// credentials, preserving the original plaintext behavior for backward
+// compatibility; a non-nil tlsCfg with Mode == tls or mtls builds TLS
+// transport credentials instead.
+func NewGRPCControllerClient(controllerAddr string, tlsCfg *config.TLSClientConfig) (*GRPCControllerClient, error) {
+	mode := config.TLSModeDisabled
+	if tlsCfg != nil && tlsCfg.Mode != "" {
+		mode = tlsCfg.Mode
+	}
+
+	var transportCreds credentials.TransportCredentials
+	if mode == config.TLSModeDisabled {
+		log.Warn().Str("controller_addr", controllerAddr).
+			Msg("gRPC controller client using tls_mode=disabled: controller-agent traffic is plaintext and unauthenticated; set tls_mode to tls or mtls for production deployments")
+		transportCreds = insecure.NewCredentials()
+	} else {
+		tlsConfig, err := config.ClientTLSConfig(tlsCfg.Mode, tlsCfg.CertFile, tlsCfg.KeyFile, tlsCfg.CAFile, tlsCfg.ServerName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build client TLS configuration for controller at %s: %w", controllerAddr, err)
+		}
+		transportCreds = credentials.NewTLS(tlsConfig)
+	}
+
 	conn, err := grpc.NewClient(
 		controllerAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(transportCreds),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client for controller at %s: %w", controllerAddr, err)

--- a/rebuild/internal/agent/controller_client/controller_client_test.go
+++ b/rebuild/internal/agent/controller_client/controller_client_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"net"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/yuuki/rpingmesh/rebuild/internal/config"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -115,12 +117,41 @@ func newTestClient(t *testing.T, srv *fakeControllerServer) *GRPCControllerClien
 // dials lazily (no I/O happens until the first RPC), so this needs no
 // network access.
 func TestNewGRPCControllerClient_Construct(t *testing.T) {
-	c, err := NewGRPCControllerClient("127.0.0.1:1")
+	c, err := NewGRPCControllerClient("127.0.0.1:1", nil)
 	if err != nil {
 		t.Fatalf("NewGRPCControllerClient: %v", err)
 	}
 	if err := c.Close(); err != nil {
 		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestNewGRPCControllerClient_ExplicitDisabled verifies that an explicit
+// &config.TLSClientConfig{Mode: config.TLSModeDisabled} behaves identically
+// to a nil tlsCfg: insecure credentials, no certificate files required.
+func TestNewGRPCControllerClient_ExplicitDisabled(t *testing.T) {
+	c, err := NewGRPCControllerClient("127.0.0.1:1", &config.TLSClientConfig{Mode: config.TLSModeDisabled})
+	if err != nil {
+		t.Fatalf("NewGRPCControllerClient: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestNewGRPCControllerClient_TLSConfigError verifies that a tlsCfg
+// requesting mtls with a nonexistent certificate file fails fast at
+// construction time (building the *tls.Config), rather than at the first
+// RPC's handshake.
+func TestNewGRPCControllerClient_TLSConfigError(t *testing.T) {
+	tlsCfg := &config.TLSClientConfig{
+		Mode:     config.TLSModeMTLS,
+		CertFile: filepath.Join(t.TempDir(), "missing-cert.pem"),
+		KeyFile:  filepath.Join(t.TempDir(), "missing-key.pem"),
+		CAFile:   filepath.Join(t.TempDir(), "missing-ca.pem"),
+	}
+	if _, err := NewGRPCControllerClient("127.0.0.1:1", tlsCfg); err == nil {
+		t.Fatal("expected an error for missing mtls certificate files, got nil")
 	}
 }
 

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -44,6 +44,18 @@ type AgentConfig struct {
 	// of each target's ECMP flow-label set is refreshed (time-based ECMP path
 	// rotation). See DefaultFlowLabelRotationPeriodSec.
 	FlowLabelRotationPeriodSec uint32 `mapstructure:"flow_label_rotation_period_sec"`
+
+	// TLS settings for the gRPC connection to the controller. See
+	// internal/config/tls.go for mode semantics. TLSMode defaults to
+	// TLSModeDisabled, preserving plaintext gRPC for backward compatibility.
+	TLSMode     string `mapstructure:"tls_mode"`
+	TLSCertFile string `mapstructure:"tls_cert_file"`
+	TLSKeyFile  string `mapstructure:"tls_key_file"`
+	TLSCAFile   string `mapstructure:"tls_ca_file"`
+	// TLSServerName overrides the name used for TLS SNI/verification against
+	// the controller; useful when controller_addr is an IP literal that
+	// doesn't match the server certificate's subject.
+	TLSServerName string `mapstructure:"tls_server_name"`
 }
 
 // LoadAgentConfig loads agent configuration from a YAML file, environment
@@ -72,6 +84,11 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	v.SetDefault("pinglist_update_interval_sec", 300)
 	v.SetDefault("target_probe_rate_per_second", DefaultTargetProbeRatePerSecond)
 	v.SetDefault("flow_label_rotation_period_sec", DefaultFlowLabelRotationPeriodSec)
+	v.SetDefault("tls_mode", TLSModeDisabled)
+	v.SetDefault("tls_cert_file", "")
+	v.SetDefault("tls_key_file", "")
+	v.SetDefault("tls_ca_file", "")
+	v.SetDefault("tls_server_name", "")
 
 	// Enable environment variable override with RPINGMESH_ prefix.
 	// Underscores in env var names map to underscores in config keys.
@@ -140,6 +157,11 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 		PinglistUpdateIntervalSec:  v.GetUint32("pinglist_update_interval_sec"),
 		TargetProbeRatePerSecond:   v.GetInt("target_probe_rate_per_second"),
 		FlowLabelRotationPeriodSec: v.GetUint32("flow_label_rotation_period_sec"),
+		TLSMode:                    v.GetString("tls_mode"),
+		TLSCertFile:                v.GetString("tls_cert_file"),
+		TLSKeyFile:                 v.GetString("tls_key_file"),
+		TLSCAFile:                  v.GetString("tls_ca_file"),
+		TLSServerName:              v.GetString("tls_server_name"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -180,6 +202,13 @@ func (c *AgentConfig) Validate() error {
 		return fmt.Errorf("flow_label_rotation_period_sec must be > 0, got: %d", c.FlowLabelRotationPeriodSec)
 	}
 
+	// The agent is the gRPC client of the controller connection: fail fast
+	// if the certificate files required by tls_mode are missing, rather
+	// than at the first dial attempt.
+	if err := validateTLSFiles(tlsRoleClient, c.TLSMode, c.TLSCertFile, c.TLSKeyFile, c.TLSCAFile); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -200,4 +229,9 @@ func BindAgentFlags(flags *pflag.FlagSet) {
 	flags.Uint32("pinglist-update-interval-sec", 300, "Pinglist update interval in seconds")
 	flags.Int("target-probe-rate-per-second", DefaultTargetProbeRatePerSecond, "Probe rate per second per target")
 	flags.Uint32("flow-label-rotation-period-sec", DefaultFlowLabelRotationPeriodSec, "Period (seconds) over which the rotating ~20% of each target's ECMP flow-label set is refreshed")
+	flags.String("tls-mode", TLSModeDisabled, "gRPC transport security mode for the controller connection (disabled|tls|mtls)")
+	flags.String("tls-cert-file", "", "Client certificate file (required when tls-mode=mtls)")
+	flags.String("tls-key-file", "", "Client private key file (required when tls-mode=mtls)")
+	flags.String("tls-ca-file", "", "CA file used to verify the controller's certificate (required when tls-mode is tls or mtls)")
+	flags.String("tls-server-name", "", "Server name for TLS SNI/verification (optional; defaults to the name derived from controller-addr)")
 }

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -45,6 +45,9 @@ func TestLoadControllerConfig_Defaults(t *testing.T) {
 	if cfg.InterTorSampleSize != DefaultInterTorSampleSize {
 		t.Errorf("InterTorSampleSize = %d, want %d", cfg.InterTorSampleSize, DefaultInterTorSampleSize)
 	}
+	if cfg.TLSMode != TLSModeDisabled {
+		t.Errorf("TLSMode = %q, want %q (backward-compatible default)", cfg.TLSMode, TLSModeDisabled)
+	}
 }
 
 func TestLoadControllerConfig_FileOverridesDefault(t *testing.T) {
@@ -234,6 +237,46 @@ func TestControllerConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "tls_mode disabled requires no certificate files",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 64,
+				TLSMode: TLSModeDisabled,
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown tls_mode is rejected",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 64,
+				TLSMode: "bogus",
+			},
+			wantErr: true,
+		},
+		{
+			name: "tls_mode=tls without server cert/key is rejected",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 64,
+				TLSMode: TLSModeTLS,
+			},
+			wantErr: true,
+		},
+		{
+			name: "tls_mode=mtls without ca/cert/key is rejected",
+			cfg: ControllerConfig{
+				ListenAddr: ":50051", DatabaseURI: "http://localhost:4001", LogLevel: "info",
+				ActiveThresholdSec: 300, StaleThresholdSec: 900, InterTorSampleSize: 5,
+				EcmpPathsAssumed: 16, EcmpCoverageProbability: 0.9, EcmpMaxFlowLabels: 64,
+				TLSMode: TLSModeMTLS,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -275,6 +318,9 @@ func TestLoadAgentConfig_Defaults(t *testing.T) {
 	}
 	if cfg.HostName == "" {
 		t.Error("HostName should be auto-detected, got empty string")
+	}
+	if cfg.TLSMode != TLSModeDisabled {
+		t.Errorf("TLSMode = %q, want %q (backward-compatible default)", cfg.TLSMode, TLSModeDisabled)
 	}
 }
 
@@ -371,6 +417,22 @@ func TestLoadAgentConfig_ZeroProbeInterval(t *testing.T) {
 	}
 }
 
+func TestLoadAgentConfig_MTLSMissingFiles(t *testing.T) {
+	t.Setenv("RPINGMESH_TLS_MODE", TLSModeMTLS)
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for tls_mode=mtls with no cert/key/ca configured, got nil")
+	}
+}
+
+func TestLoadAgentConfig_InvalidTLSMode(t *testing.T) {
+	t.Setenv("RPINGMESH_TLS_MODE", "bogus")
+
+	if _, err := LoadAgentConfig("", nil); err == nil {
+		t.Fatal("expected an error for an unknown tls_mode, got nil")
+	}
+}
+
 func TestAgentConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -437,6 +499,38 @@ func TestAgentConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "tls_mode disabled requires no certificate files",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				TLSMode: TLSModeDisabled,
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown tls_mode is rejected",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				TLSMode: "bogus",
+			},
+			wantErr: true,
+		},
+		{
+			name: "tls_mode=tls without ca file is rejected",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				TLSMode: TLSModeTLS,
+			},
+			wantErr: true,
+		},
+		{
+			name: "tls_mode=mtls without ca/cert/key is rejected",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				TLSMode: TLSModeMTLS,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -446,5 +540,24 @@ func TestAgentConfig_Validate(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestAgentConfig_Validate_MTLSWithRealFiles verifies that tls_mode=mtls
+// passes Validate() once all three certificate files actually exist on
+// disk, using freshly generated test certificates rather than a hard-coded
+// stub path (real existence checking is the behavior under test).
+func TestAgentConfig_Validate_MTLSWithRealFiles(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	cfg := AgentConfig{
+		GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+		TLSMode:     TLSModeMTLS,
+		TLSCertFile: certs.clientCertFile,
+		TLSKeyFile:  certs.clientKeyFile,
+		TLSCAFile:   certs.caFile,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil when all tls files exist", err)
 	}
 }

--- a/rebuild/internal/config/controller_config.go
+++ b/rebuild/internal/config/controller_config.go
@@ -61,6 +61,17 @@ type ControllerConfig struct {
 	EcmpPathsAssumed        int     `mapstructure:"ecmp_paths_assumed"`
 	EcmpCoverageProbability float64 `mapstructure:"ecmp_coverage_probability"`
 	EcmpMaxFlowLabels       int     `mapstructure:"ecmp_max_flow_labels"`
+
+	// TLS settings for the gRPC server. See internal/config/tls.go for mode
+	// semantics. TLSMode defaults to TLSModeDisabled, preserving plaintext
+	// gRPC for backward compatibility. These keys are symmetric with
+	// AgentConfig's; TLSServerName is not used by the controller (server)
+	// role but is kept for config-key symmetry across agent.yaml/controller.yaml.
+	TLSMode       string `mapstructure:"tls_mode"`
+	TLSCertFile   string `mapstructure:"tls_cert_file"`
+	TLSKeyFile    string `mapstructure:"tls_key_file"`
+	TLSCAFile     string `mapstructure:"tls_ca_file"`
+	TLSServerName string `mapstructure:"tls_server_name"`
 }
 
 // LoadControllerConfig loads controller configuration from a YAML file,
@@ -83,6 +94,11 @@ func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerC
 	v.SetDefault("ecmp_paths_assumed", DefaultEcmpPathsAssumed)
 	v.SetDefault("ecmp_coverage_probability", DefaultEcmpCoverageProbability)
 	v.SetDefault("ecmp_max_flow_labels", DefaultEcmpMaxFlowLabels)
+	v.SetDefault("tls_mode", TLSModeDisabled)
+	v.SetDefault("tls_cert_file", "")
+	v.SetDefault("tls_key_file", "")
+	v.SetDefault("tls_ca_file", "")
+	v.SetDefault("tls_server_name", "")
 
 	// Enable environment variable override with RPINGMESH_ prefix
 	v.SetEnvPrefix("RPINGMESH")
@@ -128,6 +144,11 @@ func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerC
 		EcmpPathsAssumed:        v.GetInt("ecmp_paths_assumed"),
 		EcmpCoverageProbability: v.GetFloat64("ecmp_coverage_probability"),
 		EcmpMaxFlowLabels:       v.GetInt("ecmp_max_flow_labels"),
+		TLSMode:                 v.GetString("tls_mode"),
+		TLSCertFile:             v.GetString("tls_cert_file"),
+		TLSKeyFile:              v.GetString("tls_key_file"),
+		TLSCAFile:               v.GetString("tls_ca_file"),
+		TLSServerName:           v.GetString("tls_server_name"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -207,6 +228,13 @@ func (c *ControllerConfig) Validate() error {
 		return fmt.Errorf("ecmp_max_flow_labels must be <= %d, got: %d", MaxEcmpFlowLabels, c.EcmpMaxFlowLabels)
 	}
 
+	// The controller is the gRPC server of the controller-agent connection:
+	// fail fast if the certificate files required by tls_mode are missing,
+	// rather than at the first client handshake.
+	if err := validateTLSFiles(tlsRoleServer, c.TLSMode, c.TLSCertFile, c.TLSKeyFile, c.TLSCAFile); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -222,4 +250,9 @@ func BindControllerFlags(flags *pflag.FlagSet) {
 	flags.Int("ecmp-paths-assumed", DefaultEcmpPathsAssumed, "Assumed ECMP fabric width (m) for Eq.(1) flow-label coverage sizing")
 	flags.Float64("ecmp-coverage-probability", DefaultEcmpCoverageProbability, "Target probability (p, in (0,1)) that generated flow labels cover all ECMP paths")
 	flags.Int("ecmp-max-flow-labels", DefaultEcmpMaxFlowLabels, "Hard cap on the number of flow labels per target (bounds probe amplification)")
+	flags.String("tls-mode", TLSModeDisabled, "gRPC transport security mode (disabled|tls|mtls)")
+	flags.String("tls-cert-file", "", "Server certificate file (required when tls-mode is tls or mtls)")
+	flags.String("tls-key-file", "", "Server private key file (required when tls-mode is tls or mtls)")
+	flags.String("tls-ca-file", "", "CA file used to verify client certificates (required when tls-mode=mtls)")
+	flags.String("tls-server-name", "", "Reserved for config-key symmetry with the agent; unused by the controller (server) role")
 }

--- a/rebuild/internal/config/tls.go
+++ b/rebuild/internal/config/tls.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TLS modes for controller-agent gRPC communication.
+//
+//   - TLSModeDisabled (the default) preserves the original plaintext gRPC
+//     behavior for backward compatibility.
+//   - TLSModeTLS authenticates the server only (the client verifies the
+//     controller's certificate but presents none of its own).
+//   - TLSModeMTLS additionally requires and verifies a client certificate,
+//     mutually authenticating both ends.
+const (
+	TLSModeDisabled = "disabled"
+	TLSModeTLS      = "tls"
+	TLSModeMTLS     = "mtls"
+)
+
+// TLSClientConfig carries the TLS settings a gRPC client (the agent, dialing
+// the controller) needs to build its transport credentials. A nil
+// *TLSClientConfig, or one with Mode == TLSModeDisabled (or the empty
+// string), means "use insecure/plaintext credentials" -- the pre-existing
+// default behavior.
+type TLSClientConfig struct {
+	Mode       string
+	CertFile   string
+	KeyFile    string
+	CAFile     string
+	ServerName string
+}
+
+// tlsRole distinguishes which certificate files validateTLSFiles requires
+// for a given mode: TLSModeTLS has different requirements on the server
+// side (must present a certificate/key) than on the client side (only needs
+// a CA to verify the server), while TLSModeMTLS requires all three files on
+// both sides.
+type tlsRole int
+
+const (
+	tlsRoleServer tlsRole = iota
+	tlsRoleClient
+)
+
+// validateTLSFiles fails fast at config-load time if the certificate files
+// required by mode (for the given role) are missing or unreadable, rather
+// than deferring the failure to the first TLS handshake attempt.
+func validateTLSFiles(role tlsRole, mode, certFile, keyFile, caFile string) error {
+	switch mode {
+	case TLSModeDisabled, "":
+		return nil
+	case TLSModeTLS:
+		if role == tlsRoleServer {
+			if err := requireTLSFile("tls_cert_file", certFile); err != nil {
+				return err
+			}
+			return requireTLSFile("tls_key_file", keyFile)
+		}
+		// Client role: no certificate of its own to present, only a CA to
+		// verify the server's certificate against.
+		return requireTLSFile("tls_ca_file", caFile)
+	case TLSModeMTLS:
+		// Both roles need all three files: the server verifies the client's
+		// certificate against the CA (and vice versa), and both present a
+		// certificate/key of their own.
+		if err := requireTLSFile("tls_ca_file", caFile); err != nil {
+			return err
+		}
+		if err := requireTLSFile("tls_cert_file", certFile); err != nil {
+			return err
+		}
+		return requireTLSFile("tls_key_file", keyFile)
+	default:
+		return fmt.Errorf("tls_mode must be one of %q, %q, or %q, got %q", TLSModeDisabled, TLSModeTLS, TLSModeMTLS, mode)
+	}
+}
+
+// requireTLSFile returns an error if path is empty or does not name a file
+// that can be stat'd, naming field in the error so the operator knows which
+// config key to fix.
+func requireTLSFile(field, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("%s is required for the configured tls_mode", field)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("%s %q: %w", field, path, err)
+	}
+	return nil
+}
+
+// ServerTLSConfig builds the *tls.Config a gRPC server should use for the
+// given mode. It returns (nil, nil) for TLSModeDisabled (and the empty
+// string), signaling the caller to fall back to grpc.NewServer's default of
+// no transport security.
+func ServerTLSConfig(mode, certFile, keyFile, caFile string) (*tls.Config, error) {
+	switch mode {
+	case TLSModeDisabled, "":
+		return nil, nil
+	case TLSModeTLS:
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load server certificate/key: %w", err)
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}, nil
+	case TLSModeMTLS:
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load server certificate/key: %w", err)
+		}
+		caPool, err := loadCACertPool(caFile)
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			ClientCAs:    caPool,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			MinVersion:   tls.VersionTLS12,
+		}, nil
+	default:
+		return nil, fmt.Errorf("tls_mode must be one of %q, %q, or %q, got %q", TLSModeDisabled, TLSModeTLS, TLSModeMTLS, mode)
+	}
+}
+
+// ClientTLSConfig builds the *tls.Config a gRPC client should use for the
+// given mode. It returns (nil, nil) for TLSModeDisabled (and the empty
+// string), signaling the caller to fall back to insecure credentials.
+// serverName overrides the name used for both SNI and certificate
+// verification; leave it empty to let the TLS stack derive it from the dial
+// target, which is the common case when controller_addr is a DNS name
+// matching the server certificate. InsecureSkipVerify is deliberately never
+// set here: use tls_server_name to handle IP-literal controller_addr values
+// instead of disabling verification.
+func ClientTLSConfig(mode, certFile, keyFile, caFile, serverName string) (*tls.Config, error) {
+	switch mode {
+	case TLSModeDisabled, "":
+		return nil, nil
+	case TLSModeTLS:
+		caPool, err := loadCACertPool(caFile)
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{
+			RootCAs:    caPool,
+			ServerName: serverName,
+			MinVersion: tls.VersionTLS12,
+		}, nil
+	case TLSModeMTLS:
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate/key: %w", err)
+		}
+		caPool, err := loadCACertPool(caFile)
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      caPool,
+			ServerName:   serverName,
+			MinVersion:   tls.VersionTLS12,
+		}, nil
+	default:
+		return nil, fmt.Errorf("tls_mode must be one of %q, %q, or %q, got %q", TLSModeDisabled, TLSModeTLS, TLSModeMTLS, mode)
+	}
+}
+
+// loadCACertPool reads and parses a PEM-encoded CA bundle from caFile.
+func loadCACertPool(caFile string) (*x509.CertPool, error) {
+	pemBytes, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tls_ca_file %q: %w", caFile, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("failed to parse any PEM certificates from tls_ca_file %q", caFile)
+	}
+	return pool, nil
+}

--- a/rebuild/internal/config/tls_test.go
+++ b/rebuild/internal/config/tls_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yuuki/rpingmesh/rebuild/internal/testutil/tlscerts"
+)
+
+// testCertSet holds file paths to a freshly generated, in-memory CA plus a
+// server and client leaf certificate signed by it -- everything
+// ServerTLSConfig/ClientTLSConfig need to build a real *tls.Config in tests,
+// without depending on committed fixture certificates that could expire.
+type testCertSet struct {
+	caFile         string
+	serverCertFile string
+	serverKeyFile  string
+	clientCertFile string
+	clientKeyFile  string
+}
+
+func newTestCertSet(t *testing.T) testCertSet {
+	t.Helper()
+	dir := t.TempDir()
+
+	ca, err := tlscerts.NewCA()
+	if err != nil {
+		t.Fatalf("tlscerts.NewCA: %v", err)
+	}
+	caFile := writeFile(t, dir, "ca.pem", ca.CAPEM())
+
+	serverCertPEM, serverKeyPEM, err := ca.IssueLeaf(tlscerts.LeafOptions{
+		CommonName:  "controller",
+		DNSNames:    []string{"localhost"},
+		IPs:         []net.IP{net.ParseIP("127.0.0.1")},
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	if err != nil {
+		t.Fatalf("IssueLeaf(server): %v", err)
+	}
+	clientCertPEM, clientKeyPEM, err := ca.IssueLeaf(tlscerts.LeafOptions{
+		CommonName:  "agent",
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	if err != nil {
+		t.Fatalf("IssueLeaf(client): %v", err)
+	}
+
+	return testCertSet{
+		caFile:         caFile,
+		serverCertFile: writeFile(t, dir, "server-cert.pem", serverCertPEM),
+		serverKeyFile:  writeFile(t, dir, "server-key.pem", serverKeyPEM),
+		clientCertFile: writeFile(t, dir, "client-cert.pem", clientCertPEM),
+		clientKeyFile:  writeFile(t, dir, "client-key.pem", clientKeyPEM),
+	}
+}
+
+func writeFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+	return path
+}
+
+// --- ServerTLSConfig ---
+
+func TestServerTLSConfig_Disabled(t *testing.T) {
+	cfg, err := ServerTLSConfig(TLSModeDisabled, "", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("cfg = %+v, want nil for disabled mode", cfg)
+	}
+}
+
+func TestServerTLSConfig_TLS_LoadsCertificate(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	cfg, err := ServerTLSConfig(TLSModeTLS, certs.serverCertFile, certs.serverKeyFile, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates = %d, want 1", len(cfg.Certificates))
+	}
+	if cfg.ClientAuth != tls.NoClientCert {
+		t.Errorf("ClientAuth = %v, want NoClientCert for tls mode", cfg.ClientAuth)
+	}
+}
+
+func TestServerTLSConfig_TLS_MissingCertFile(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	if _, err := ServerTLSConfig(TLSModeTLS, filepath.Join(t.TempDir(), "missing.pem"), certs.serverKeyFile, ""); err == nil {
+		t.Fatal("expected an error for a missing server certificate file, got nil")
+	}
+}
+
+func TestServerTLSConfig_MTLS_SetsClientCAsAndRequiresClientCert(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	cfg, err := ServerTLSConfig(TLSModeMTLS, certs.serverCertFile, certs.serverKeyFile, certs.caFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates = %d, want 1", len(cfg.Certificates))
+	}
+	if cfg.ClientCAs == nil {
+		t.Error("ClientCAs = nil, want a populated CertPool for mtls mode")
+	}
+	if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Errorf("ClientAuth = %v, want RequireAndVerifyClientCert for mtls mode", cfg.ClientAuth)
+	}
+}
+
+func TestServerTLSConfig_MTLS_MissingCAFile(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	if _, err := ServerTLSConfig(TLSModeMTLS, certs.serverCertFile, certs.serverKeyFile, filepath.Join(t.TempDir(), "missing-ca.pem")); err == nil {
+		t.Fatal("expected an error for a missing CA file, got nil")
+	}
+}
+
+func TestServerTLSConfig_UnknownMode(t *testing.T) {
+	if _, err := ServerTLSConfig("bogus", "", "", ""); err == nil {
+		t.Fatal("expected an error for an unknown tls_mode, got nil")
+	}
+}
+
+// --- ClientTLSConfig ---
+
+func TestClientTLSConfig_Disabled(t *testing.T) {
+	cfg, err := ClientTLSConfig(TLSModeDisabled, "", "", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("cfg = %+v, want nil for disabled mode", cfg)
+	}
+}
+
+func TestClientTLSConfig_TLS_SetsRootCAs(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	cfg, err := ClientTLSConfig(TLSModeTLS, "", "", certs.caFile, "controller.example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Error("RootCAs = nil, want a populated CertPool for tls mode")
+	}
+	if len(cfg.Certificates) != 0 {
+		t.Errorf("Certificates = %d, want 0 (client presents no cert in tls mode)", len(cfg.Certificates))
+	}
+	if cfg.ServerName != "controller.example" {
+		t.Errorf("ServerName = %q, want %q", cfg.ServerName, "controller.example")
+	}
+}
+
+func TestClientTLSConfig_TLS_MissingCAFile(t *testing.T) {
+	if _, err := ClientTLSConfig(TLSModeTLS, "", "", filepath.Join(t.TempDir(), "missing-ca.pem"), ""); err == nil {
+		t.Fatal("expected an error for a missing CA file, got nil")
+	}
+}
+
+func TestClientTLSConfig_MTLS_SetsCertificateAndRootCAs(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	cfg, err := ClientTLSConfig(TLSModeMTLS, certs.clientCertFile, certs.clientKeyFile, certs.caFile, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates = %d, want 1", len(cfg.Certificates))
+	}
+	if cfg.RootCAs == nil {
+		t.Error("RootCAs = nil, want a populated CertPool for mtls mode")
+	}
+}
+
+func TestClientTLSConfig_MTLS_MissingClientCert(t *testing.T) {
+	certs := newTestCertSet(t)
+
+	if _, err := ClientTLSConfig(TLSModeMTLS, filepath.Join(t.TempDir(), "missing.pem"), certs.clientKeyFile, certs.caFile, ""); err == nil {
+		t.Fatal("expected an error for a missing client certificate file, got nil")
+	}
+}
+
+func TestClientTLSConfig_UnknownMode(t *testing.T) {
+	if _, err := ClientTLSConfig("bogus", "", "", "", ""); err == nil {
+		t.Fatal("expected an error for an unknown tls_mode, got nil")
+	}
+}

--- a/rebuild/internal/controller/mtls_integration_test.go
+++ b/rebuild/internal/controller/mtls_integration_test.go
@@ -1,0 +1,217 @@
+package controller
+
+import (
+	"context"
+	"crypto/x509"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/yuuki/rpingmesh/rebuild/internal/agent/controller_client"
+	"github.com/yuuki/rpingmesh/rebuild/internal/config"
+	"github.com/yuuki/rpingmesh/rebuild/internal/testutil/tlscerts"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// This file exercises the controller-agent gRPC mTLS path (P1-B) end to
+// end: a real ControllerService served over a real TCP listener with TLS
+// transport credentials, dialed by the actual GRPCControllerClient used by
+// agents. It deliberately avoids rqlite and docker: the registry is the
+// same in-memory fakeRegistry used by service_test.go, and certificates are
+// generated fresh in-process via internal/testutil/tlscerts, so this test
+// runs anywhere "go test" does.
+
+// mtlsFixture bundles a freshly generated CA plus server and client leaf
+// certificates, written to temp files so they can be passed to
+// config.ServerTLSConfig/ClientTLSConfig (and, transitively,
+// tls.LoadX509KeyPair) exactly as an operator's tls_cert_file/tls_key_file/
+// tls_ca_file config values would be.
+type mtlsFixture struct {
+	caFile         string
+	serverCertFile string
+	serverKeyFile  string
+	clientCertFile string
+	clientKeyFile  string
+}
+
+func newMTLSFixture(t *testing.T) mtlsFixture {
+	t.Helper()
+	dir := t.TempDir()
+
+	ca, err := tlscerts.NewCA()
+	if err != nil {
+		t.Fatalf("tlscerts.NewCA: %v", err)
+	}
+
+	write := func(name string, data []byte) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	serverCertPEM, serverKeyPEM, err := ca.IssueLeaf(tlscerts.LeafOptions{
+		CommonName:  "controller",
+		DNSNames:    []string{"localhost"},
+		IPs:         []net.IP{net.ParseIP("127.0.0.1")},
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	if err != nil {
+		t.Fatalf("issue server leaf certificate: %v", err)
+	}
+	clientCertPEM, clientKeyPEM, err := ca.IssueLeaf(tlscerts.LeafOptions{
+		CommonName:  "agent",
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	if err != nil {
+		t.Fatalf("issue client leaf certificate: %v", err)
+	}
+
+	return mtlsFixture{
+		caFile:         write("ca.pem", ca.CAPEM()),
+		serverCertFile: write("server-cert.pem", serverCertPEM),
+		serverKeyFile:  write("server-key.pem", serverKeyPEM),
+		clientCertFile: write("client-cert.pem", clientCertPEM),
+		clientKeyFile:  write("client-key.pem", clientKeyPEM),
+	}
+}
+
+// startMTLSController starts a real ControllerService -- backed by the
+// in-memory fakeRegistry from service_test.go, not rqlite -- on a real TCP
+// listener with mTLS server credentials built from fixture via the same
+// config.ServerTLSConfig helper cmd/controller/main.go uses. It returns the
+// listener address; the server is stopped via t.Cleanup.
+func startMTLSController(t *testing.T, fixture mtlsFixture) string {
+	t.Helper()
+
+	svc := newTestService(&fakeRegistry{})
+
+	tlsConfig, err := config.ServerTLSConfig(config.TLSModeMTLS, fixture.serverCertFile, fixture.serverKeyFile, fixture.caFile)
+	if err != nil {
+		t.Fatalf("config.ServerTLSConfig: %v", err)
+	}
+
+	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	controller_agent.RegisterControllerServiceServer(grpcServer, svc)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	go grpcServer.Serve(lis)
+	t.Cleanup(grpcServer.Stop)
+
+	return lis.Addr().String()
+}
+
+// TestMTLS_ClientWithCertificate_Succeeds verifies that an agent-side
+// GRPCControllerClient configured with tls_mode=mtls and a certificate
+// signed by the same CA the controller trusts can complete
+// RegisterAgent/GetPinglist over a real TCP + TLS connection.
+func TestMTLS_ClientWithCertificate_Succeeds(t *testing.T) {
+	fixture := newMTLSFixture(t)
+	addr := startMTLSController(t, fixture)
+
+	client, err := controller_client.NewGRPCControllerClient(addr, &config.TLSClientConfig{
+		Mode:     config.TLSModeMTLS,
+		CertFile: fixture.clientCertFile,
+		KeyFile:  fixture.clientKeyFile,
+		CAFile:   fixture.caFile,
+		// The dial target is an IP:port (net.Listen("tcp", "127.0.0.1:0")),
+		// so the authority gRPC would otherwise derive for verification is
+		// "127.0.0.1" -- not a name the server certificate carries. Setting
+		// ServerName explicitly to a SAN the certificate does carry is
+		// exactly the tls_server_name escape hatch described in the README.
+		ServerName: "localhost",
+	})
+	if err != nil {
+		t.Fatalf("NewGRPCControllerClient: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.RegisterAgent(ctx, &controller_agent.AgentRegistrationRequest{
+		AgentId: "mtls-agent-1",
+		TorId:   "tor-1",
+		Rnics: []*controller_agent.RnicInfo{
+			{Gid: "fe80::1", Qpn: 100, IpAddress: "10.0.0.1", DeviceName: "mlx5_0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterAgent over mtls: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Fatalf("RegisterAgent rejected: %s", resp.GetMessage())
+	}
+
+	if _, err := client.GetPinglist(ctx, "mtls-agent-1", "tor-1", "fe80::1", controller_agent.PinglistType_TOR_MESH); err != nil {
+		t.Fatalf("GetPinglist over mtls: %v", err)
+	}
+}
+
+// TestMTLS_ClientWithoutCertificate_Rejected verifies that a client dialing
+// the same mtls-configured controller without presenting a client
+// certificate (tls_mode=tls: it verifies the server but presents none of
+// its own) is rejected, proving the server's
+// tls.RequireAndVerifyClientCert is actually enforced rather than silently
+// accepting anonymous connections.
+func TestMTLS_ClientWithoutCertificate_Rejected(t *testing.T) {
+	fixture := newMTLSFixture(t)
+	addr := startMTLSController(t, fixture)
+
+	client, err := controller_client.NewGRPCControllerClient(addr, &config.TLSClientConfig{
+		Mode:       config.TLSModeTLS, // verifies the server; presents no client certificate
+		CAFile:     fixture.caFile,
+		ServerName: "localhost",
+	})
+	if err != nil {
+		t.Fatalf("NewGRPCControllerClient: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err = client.RegisterAgent(ctx, &controller_agent.AgentRegistrationRequest{
+		AgentId: "no-cert-agent",
+		TorId:   "tor-1",
+	})
+	if err == nil {
+		t.Fatal("expected RegisterAgent to fail for a client presenting no certificate against an mtls controller, got nil")
+	}
+	t.Logf("client without a certificate was correctly rejected: %v", err)
+}
+
+// TestMTLS_PlaintextClient_Rejected verifies that a plaintext (tls_mode
+// disabled) client cannot talk to an mtls-configured controller: dialing
+// with insecure credentials against a TLS listener must fail, not silently
+// downgrade.
+func TestMTLS_PlaintextClient_Rejected(t *testing.T) {
+	fixture := newMTLSFixture(t)
+	addr := startMTLSController(t, fixture)
+
+	client, err := controller_client.NewGRPCControllerClient(addr, nil) // nil => insecure/plaintext
+	if err != nil {
+		t.Fatalf("NewGRPCControllerClient: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err = client.RegisterAgent(ctx, &controller_agent.AgentRegistrationRequest{
+		AgentId: "plaintext-agent",
+		TorId:   "tor-1",
+	})
+	if err == nil {
+		t.Fatal("expected RegisterAgent to fail for a plaintext client against an mtls controller, got nil")
+	}
+	t.Logf("plaintext client was correctly rejected: %v", err)
+}

--- a/rebuild/internal/testutil/tlscerts/tlscerts.go
+++ b/rebuild/internal/testutil/tlscerts/tlscerts.go
@@ -1,0 +1,118 @@
+// Package tlscerts generates short-lived, in-memory self-signed
+// certificates for TLS/mTLS tests. Tests that exercise
+// internal/config.ServerTLSConfig/ClientTLSConfig and the controller/agent
+// gRPC TLS paths need real certificate files, but committing fixture
+// certificates would eventually expire and break CI; generating a fresh CA
+// and leaf certificates on every test run avoids that entirely.
+package tlscerts
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// validity is deliberately generous (well beyond any single test run) since
+// these certificates are generated fresh in-process and never persisted.
+const validity = 24 * time.Hour
+
+// CA is an in-memory self-signed certificate authority used to mint leaf
+// certificates for TLS/mTLS tests.
+type CA struct {
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+	certPEM []byte
+}
+
+// NewCA generates a fresh self-signed CA certificate and key pair.
+func NewCA() (*CA, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate CA key: %w", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "rpingmesh-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(validity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("create CA certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return &CA{cert: cert, key: key, certPEM: certPEM}, nil
+}
+
+// CAPEM returns the PEM-encoded CA certificate, suitable for writing to a
+// tls_ca_file.
+func (ca *CA) CAPEM() []byte {
+	return ca.certPEM
+}
+
+// LeafOptions configures IssueLeaf.
+type LeafOptions struct {
+	CommonName string
+	DNSNames   []string
+	IPs        []net.IP
+	// ExtKeyUsage selects server-auth, client-auth, or both, matching how
+	// the certificate will be used in the test.
+	ExtKeyUsage []x509.ExtKeyUsage
+}
+
+// IssueLeaf mints a leaf certificate signed by ca, returning PEM-encoded
+// certificate and private key bytes ready to write to tls_cert_file /
+// tls_key_file.
+func (ca *CA) IssueLeaf(opts LeafOptions) (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate serial: %w", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: opts.CommonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(validity),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  opts.ExtKeyUsage,
+		DNSNames:     opts.DNSNames,
+		IPAddresses:  opts.IPs,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create leaf certificate: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal leaf key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM, nil
+}


### PR DESCRIPTION
## Summary

- Adds opt-in TLS/mTLS for controller-agent gRPC (P1-B from the P1 design doc), gated by a new symmetric `tls_mode` config key (`disabled`|`tls`|`mtls`) on both `agent.yaml` and `controller.yaml`. Default stays `disabled` (plaintext, insecure credentials) for full backward compatibility.
- New `internal/config/tls.go`: shared helper building server/client `*tls.Config` from mode + `tls_cert_file`/`tls_key_file`/`tls_ca_file`, plus `Validate()` fail-fast checks that the files a mode requires actually exist. `InsecureSkipVerify` is intentionally never used; `tls_server_name` exists for IP-literal `controller_addr` values instead.
- `cmd/controller/main.go` wires `grpc.Creds(...)` from the same helper; `internal/agent/controller_client.NewGRPCControllerClient` gains a `*config.TLSClientConfig` parameter (`nil` == disabled) and `internal/agent/agent.go` passes the agent's TLS config through. Both the controller and the client log a warning once when running with `tls_mode=disabled`.
- README Configuration tables gain the TLS keys for both agent and controller, plus a new "TLS/mTLS for controller-agent gRPC" section; the "No TLS on gRPC" Limitations entry is updated to reflect that TLS/mTLS is now implemented (opt-in), with certificate hot-reload explicitly out of scope.
- New `internal/testutil/tlscerts` helper generates a fresh self-signed CA + leaf certificates in-process for tests, so nothing depends on committed fixture certificates that could expire and break CI.

## Test plan

- [x] `internal/config/tls_test.go` (new): unit tests for `ServerTLSConfig`/`ClientTLSConfig` mode-by-mode (disabled/tls/mtls), including missing-file errors and unknown-mode rejection.
- [x] `internal/config/config_test.go`: extended `Validate()`/`Load*Config` tables for both `AgentConfig` and `ControllerConfig` — `mtls` missing ca/cert/key rejected, `disabled` requires nothing, unknown `tls_mode` string rejected, and a real-files-present `mtls` success case.
- [x] `internal/controller/mtls_integration_test.go` (new): RDMA/docker-free end-to-end test — starts a real `ControllerService` (in-memory fake registry, no rqlite) on a real TCP listener with mTLS server credentials, dials it with the real `GRPCControllerClient` and exercises `RegisterAgent`/`GetPinglist`; also verifies a client presenting no certificate and a plaintext client are both rejected.
- [x] `internal/agent/controller_client/controller_client_test.go`: updated call sites for the new `NewGRPCControllerClient` signature, plus new cases for explicit-disabled and TLS-config-error paths.
- [x] `cd rebuild && go vet ./...` and `go test $(go list ./... | grep -v /e2e)` — run inside a Linux/CGO Docker container built from `Dockerfile.e2e` (macOS can't link `librdmabridge.a`); all packages vet and test clean, including `internal/agent` (CGO) and both `cmd/controller`/`cmd/agent` binaries building successfully.
- [x] `docker compose -f docker-compose.e2e-controller.yml up --build --abort-on-container-exit` — confirms the existing plaintext-default e2e-controller path (rqlite + controller + `e2e/controller` test suite) still passes unchanged, with the expected `tlsMode=disabled` warning logged.

## Remaining concerns

- Certificate loading is static; hot-reload/rotation is explicitly out of scope per the design doc (documented in the README).
- `tls_server_name` on the controller side is unused (kept only for config-key symmetry with the agent) — flagged in code comments and README.
- P1-C (Analyzer) is being developed in parallel on a separate branch touching `controller_client.go`/`agent.go`/`service.go`; conflicts are expected to be resolved at merge time per the task instructions, not in this PR.