### PR TITLE
feat(rebuild): minimal Analyzer Phase 1 (per-path aggregation + SLA detection)

### DIFF
--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -54,8 +54,12 @@ MetricsCollector (exports OTLP metrics) shared across all of them.
 libibverbs operations: device enumeration, QP creation, CQ polling, packet
 serialization, and send/receive. Exposes a C-ABI that Go calls via Cgo.
 
-> **Note:** The Analyzer component and eBPF service tracing from the original
-> implementation are out of scope for this rebuild.
+> **Note:** A Phase 1 Analyzer is implemented: agents aggregate probe results
+> per path over fixed windows and report `PathSummary` batches to the controller
+> via `ReportProbeAnalysis`, where an in-process analyzer detects per-path SLA
+> violations (loss ratio and p99 network-RTT thresholds). Topology-aware
+> switch/link fault localization (Phase 2) and eBPF service tracing remain out
+> of scope for this rebuild.
 
 ## 6-Timestamp Probing Protocol
 
@@ -217,6 +221,8 @@ via Cgo (`CGO_ENABLED=1`).
 | `allowed_device_names` | `[]` | Device filter (empty = all devices) |
 | `metrics_enabled` | `true` | Enable OpenTelemetry export |
 | `otel_collector_addr` | `localhost:4317` | OTLP gRPC collector endpoint |
+| `analysis_report_enabled` | `true` | Aggregate probe results per path and report `PathSummary` batches to the controller's analyzer (best-effort; never blocks probing) |
+| `analysis_window_sec` | `30` | Per-path aggregation window length in seconds |
 | `log_level` | `info` | Log level: debug, info, warn, error |
 
 ### Controller (`configs/controller.yaml`)
@@ -231,6 +237,11 @@ via Cgo (`CGO_ENABLED=1`).
 | `ecmp_paths_assumed` | `16` | Assumed ECMP fabric width (m) for Eq.(1) flow-label coverage sizing |
 | `ecmp_coverage_probability` | `0.9` | Target probability (p, in (0,1)) that generated flow labels cover all ECMP paths |
 | `ecmp_max_flow_labels` | `64` | Hard cap on flow labels per target (bounds probe amplification) |
+| `analyzer_enabled` | `true` | Enable the Phase 1 analyzer: ingest agent-reported summaries and detect SLA violations |
+| `analyzer_sla_loss_ratio` | `0.02` | Per-path loss ratio (0..1) above which a window is flagged as a loss SLA violation |
+| `analyzer_sla_network_rtt_p99_ns` | `500000` | Per-path p99 network-RTT (ns) above which a window is flagged as an RTT SLA violation (0 disables the check) |
+| `analyzer_window_retention` | `20` | Number of recent windows the analyzer retains in memory |
+| `otel_collector_addr` | `localhost:4317` | OTLP gRPC endpoint for analyzer metrics (`service.name=rpingmesh-analyzer`) |
 | `log_level` | `info` | Log level |
 
 ### Environment Variable Overrides
@@ -422,6 +433,17 @@ The agent exports the following OTLP metrics:
 
 All metrics carry two attributes: `source_tor` and `target_tor`.
 
+The controller-side analyzer (Phase 1) exports the following OTLP metrics under
+`service.name=rpingmesh-analyzer`:
+
+| Metric | Type | Attributes | Description |
+|--------|------|-----------|-------------|
+| `rpingmesh.analyzer.path_summaries_total` | Counter | — | Per-path window summaries ingested |
+| `rpingmesh.analyzer.sla_violations_total` | Counter | `source_tor`, `target_tor`, `kind` (`loss`/`rtt`) | SLA violations detected |
+
+Analyzer metric attributes are ToR-level only, matching the agent convention;
+per-path GID detail appears only in findings logs, never as a metric attribute.
+
 Histogram bucket boundaries (nanoseconds):
 ```
 100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000, 5000000, 10000000
@@ -502,9 +524,14 @@ sudo rdma link add rxe0 type rxe netdev eth0
 
 ## Limitations and Future Work
 
-- **Analyzer not implemented.** The data aggregation and analysis component from
-  the original design is out of scope. Probe results are exported as OTLP metrics
-  for external analysis.
+- **Analyzer is Phase 1 only (SLA detection, no fault localization).** Agents
+  aggregate probe results per path over fixed windows and report `PathSummary`
+  batches to the controller, where an in-process analyzer flags per-path SLA
+  violations (loss ratio and p99 network-RTT thresholds) to logs and OTLP
+  metrics. Topology-aware cross-agent switch/link fault *localization* (Phase 2)
+  is future work: it needs a topology join and cross-agent quantile synthesis
+  built on the summaries this phase already collects. Summaries are held
+  in-memory (a bounded recent-window ring); durable storage is not yet wired up.
 
 - **eBPF service tracing not implemented.** The original R-Pingmesh uses eBPF to
   monitor RDMA QP lifecycle events for service-aware monitoring. This rebuild
@@ -526,10 +553,11 @@ sudo rdma link add rxe0 type rxe netdev eth0
   pinglist is still a fixed, configurable random sample of `inter_tor_sample_size`
   ToRs, not itself derived from a coverage-probability target.
 
-- **Analyzer and Service Tracing remain out of scope.** As noted above, the
-  data-aggregation/anomaly-detection Analyzer (switch/link fault
-  localization, priority ranking) and eBPF-based service tracing from the
-  original design are not part of this rebuild.
+- **Analyzer fault localization and Service Tracing remain out of scope.** As
+  noted above, the analyzer detects SLA violations (Phase 1) but does not yet
+  perform topology-aware switch/link fault localization or priority ranking
+  (Phase 2); eBPF-based service tracing from the original design is also not
+  part of this rebuild.
 
 - **No agent self-protection.** There is no hard CPU/memory cap on the
   agent process and no fail-closed behavior (e.g. backing off or shutting

--- a/rebuild/cmd/controller/main.go
+++ b/rebuild/cmd/controller/main.go
@@ -12,14 +12,21 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/grpc"
 
 	"github.com/yuuki/rpingmesh/rebuild/internal/config"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller"
+	"github.com/yuuki/rpingmesh/rebuild/internal/controller/analyzer"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller/pinglist"
 	"github.com/yuuki/rpingmesh/rebuild/internal/controller/registry"
+	"github.com/yuuki/rpingmesh/rebuild/internal/telemetry"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 )
+
+// analyzerServiceName is the OTel service.name reported by the controller-side
+// analyzer's metrics, distinguishing them from agent metrics in the collector.
+const analyzerServiceName = "rpingmesh-analyzer"
 
 var configPath string
 
@@ -96,6 +103,22 @@ func run(cmd *cobra.Command, args []string) error {
 		MaxFlowLabels:       cfg.EcmpMaxFlowLabels,
 	})
 
+	// Set up the Phase 1 analyzer if enabled: it ingests agent-reported
+	// per-path summaries and flags SLA violations. Its OTLP metrics are
+	// best-effort (service.name=rpingmesh-analyzer); a failure to build the
+	// meter provider degrades to log-only findings rather than failing startup.
+	// The provider is returned so it can be flushed on shutdown.
+	analyzerProvider := setupAnalyzer(cfg, svc)
+	if analyzerProvider != nil {
+		defer func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := analyzerProvider.Shutdown(shutdownCtx); err != nil {
+				log.Error().Err(err).Msg("Failed to shut down analyzer metrics provider")
+			}
+		}()
+	}
+
 	// Create and configure the gRPC server.
 	grpcServer := grpc.NewServer()
 	controller_agent.RegisterControllerServiceServer(grpcServer, svc)
@@ -154,4 +177,50 @@ func run(cmd *cobra.Command, args []string) error {
 
 	log.Info().Msg("Controller stopped")
 	return nil
+}
+
+// setupAnalyzer builds the Phase 1 analyzer (when enabled) and wires it into
+// svc. It attempts to create an OTLP meter provider tagged
+// service.name=rpingmesh-analyzer for the analyzer's metrics; if that fails,
+// the analyzer still runs with log-only findings. It returns the meter provider
+// (or nil) so the caller can flush it on shutdown.
+func setupAnalyzer(cfg *config.ControllerConfig, svc *controller.ControllerService) *sdkmetric.MeterProvider {
+	if !cfg.AnalyzerEnabled {
+		log.Info().Msg("Analyzer disabled")
+		return nil
+	}
+
+	var provider *sdkmetric.MeterProvider
+	var metrics *analyzer.Metrics
+	if cfg.OtelCollectorAddr != "" {
+		p, err := telemetry.NewMeterProvider(context.Background(), cfg.OtelCollectorAddr, analyzerServiceName)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to create analyzer meter provider; continuing with log-only findings")
+		} else {
+			m, err := analyzer.NewMetrics(p.Meter("rpingmesh.analyzer"))
+			if err != nil {
+				log.Warn().Err(err).Msg("Failed to register analyzer metrics; continuing with log-only findings")
+				_ = p.Shutdown(context.Background())
+			} else {
+				provider = p
+				metrics = m
+			}
+		}
+	}
+
+	az := analyzer.New(analyzer.Config{
+		SLALossRatio:       cfg.AnalyzerSLALossRatio,
+		SLANetworkRTTP99Ns: cfg.AnalyzerSLANetworkRTTP99Ns,
+		WindowRetention:    cfg.AnalyzerWindowRetention,
+	}, metrics)
+	svc.SetAnalyzer(az)
+
+	log.Info().
+		Float64("slaLossRatio", cfg.AnalyzerSLALossRatio).
+		Uint64("slaNetworkRttP99Ns", cfg.AnalyzerSLANetworkRTTP99Ns).
+		Int("windowRetention", cfg.AnalyzerWindowRetention).
+		Bool("metricsEnabled", metrics != nil).
+		Msg("Analyzer enabled")
+
+	return provider
 }

--- a/rebuild/configs/agent.yaml
+++ b/rebuild/configs/agent.yaml
@@ -20,6 +20,13 @@ pinglist_update_interval_sec: 300 # Pinglist refresh interval
 # controller (see controller.yaml ecmp_* settings).
 flow_label_rotation_period_sec: 3600
 
+# Analyzer reporting (Phase 1)
+# When enabled, the agent aggregates probe results per path over fixed windows
+# and reports PathSummary batches to the controller's analyzer via
+# ReportProbeAnalysis. Reporting is best-effort and never blocks probing.
+analysis_report_enabled: true
+analysis_window_sec: 30          # per-path aggregation window length
+
 # RDMA settings
 gid_index: 0                     # GID table index to use
 allowed_device_names: []         # Empty = all devices

--- a/rebuild/configs/controller.yaml
+++ b/rebuild/configs/controller.yaml
@@ -14,5 +14,16 @@ ecmp_paths_assumed: 16            # Assumed ECMP fabric width (m)
 ecmp_coverage_probability: 0.9    # Target coverage probability (p, in (0,1))
 ecmp_max_flow_labels: 64          # Hard cap on labels per target (bounds amplification)
 
+# Analyzer (Phase 1)
+# Ingests agent-reported per-path window summaries and flags SLA violations
+# (per-path loss ratio and p99 network-RTT threshold breaches). Findings go to
+# logs (with GID detail) and OTLP metrics (rpingmesh.analyzer.*, ToR-level
+# attributes only).
+analyzer_enabled: true
+analyzer_sla_loss_ratio: 0.02            # per-path loss ratio (0..1) that is a violation
+analyzer_sla_network_rtt_p99_ns: 500000  # per-path p99 network-RTT (ns) that is a violation (0 disables)
+analyzer_window_retention: 20            # recent windows retained in memory
+otel_collector_addr: "localhost:4317"    # OTLP endpoint for analyzer metrics
+
 # Logging
 log_level: "info"                       # debug, info, warn, error

--- a/rebuild/e2e/controller/analysis_e2e_test.go
+++ b/rebuild/e2e/controller/analysis_e2e_test.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// TestReportProbeAnalysisSLADetection exercises the full ReportProbeAnalysis
+// path against a real controller (with its analyzer enabled by default): a
+// pseudo-agent reports a batch of per-path window summaries, one of which
+// breaches the default loss SLA and one the default p99-RTT SLA, and the
+// controller's analyzer must flag exactly those. The ack's sla_violations
+// count is the observable end-to-end signal (no OTLP collector needed here).
+//
+// It runs in the RDMA-free e2e-controller compose stack
+// (docker-compose.e2e-controller.yml), like the registration/pinglist tests.
+func TestReportProbeAnalysisSLADetection(t *testing.T) {
+	client := newClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	report := &controller_agent.ProbeAnalysisReport{
+		AgentId: "analysis-agent-1",
+		Summaries: []*controller_agent.PathSummary{
+			// Loss violation: 10% loss >> default 2% threshold.
+			{
+				SourceGid:         "fe80::a1",
+				SourceTorId:       "tor-src",
+				TargetGid:         "fe80::b1",
+				TargetTorId:       "tor-dst-1",
+				TargetQpn:         100,
+				WindowStartUnixNs: uint64(time.Now().UnixNano()),
+				WindowDurationMs:  30000,
+				ProbeTotal:        100,
+				ProbeSuccess:      90,
+				ProbeFailed:       10,
+				NetworkRttP99Ns:   100_000, // healthy RTT
+			},
+			// RTT violation: p99 800us >> default 500us threshold, no loss.
+			{
+				SourceGid:         "fe80::a1",
+				SourceTorId:       "tor-src",
+				TargetGid:         "fe80::b2",
+				TargetTorId:       "tor-dst-2",
+				TargetQpn:         101,
+				WindowStartUnixNs: uint64(time.Now().UnixNano()),
+				WindowDurationMs:  30000,
+				ProbeTotal:        100,
+				ProbeSuccess:      100,
+				ProbeFailed:       0,
+				NetworkRttP99Ns:   800_000,
+			},
+			// Clean path: no loss, healthy RTT -> no violation.
+			{
+				SourceGid:         "fe80::a1",
+				SourceTorId:       "tor-src",
+				TargetGid:         "fe80::b3",
+				TargetTorId:       "tor-dst-3",
+				TargetQpn:         102,
+				WindowStartUnixNs: uint64(time.Now().UnixNano()),
+				WindowDurationMs:  30000,
+				ProbeTotal:        100,
+				ProbeSuccess:      100,
+				ProbeFailed:       0,
+				NetworkRttP99Ns:   120_000,
+			},
+		},
+	}
+
+	ack, err := client.ReportProbeAnalysis(ctx, report)
+	if err != nil {
+		t.Fatalf("ReportProbeAnalysis failed: %v", err)
+	}
+	if !ack.GetAccepted() {
+		t.Fatalf("report not accepted; is the analyzer enabled on the controller?")
+	}
+	// Two of the three summaries breach an SLA (loss, rtt); the third is clean.
+	if ack.GetSlaViolations() != 2 {
+		t.Errorf("SlaViolations = %d, want 2 (1 loss + 1 rtt, 1 clean)", ack.GetSlaViolations())
+	}
+}
+
+// TestReportProbeAnalysisNoViolations verifies a batch of healthy summaries is
+// accepted with zero violations.
+func TestReportProbeAnalysisNoViolations(t *testing.T) {
+	client := newClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	report := &controller_agent.ProbeAnalysisReport{
+		AgentId: "analysis-agent-2",
+		Summaries: []*controller_agent.PathSummary{
+			{
+				SourceGid:       "fe80::c1",
+				SourceTorId:     "tor-src",
+				TargetGid:       "fe80::d1",
+				TargetTorId:     "tor-dst",
+				ProbeTotal:      1000,
+				ProbeSuccess:    1000,
+				ProbeFailed:     0,
+				NetworkRttP99Ns: 50_000,
+			},
+		},
+	}
+
+	ack, err := client.ReportProbeAnalysis(ctx, report)
+	if err != nil {
+		t.Fatalf("ReportProbeAnalysis failed: %v", err)
+	}
+	if !ack.GetAccepted() {
+		t.Fatalf("report not accepted")
+	}
+	if ack.GetSlaViolations() != 0 {
+		t.Errorf("SlaViolations = %d, want 0", ack.GetSlaViolations())
+	}
+}

--- a/rebuild/e2e/probe_analysis_e2e_test.go
+++ b/rebuild/e2e/probe_analysis_e2e_test.go
@@ -1,0 +1,165 @@
+// Package e2e: TestProbeToPathAggregator validates the analyzer's agent-side
+// data path on real (soft-RoCE) RDMA devices:
+//
+//	Prober → RDMA probe → Responder ACKs → ProbeResult (SourceGID stamped)
+//	    → PathAggregator window aggregation → PathSummary
+//
+// It complements TestProbeToOTelMetrics (the metrics branch) by exercising the
+// second fan-out branch introduced for Phase 1 analysis. Assertions are shape
+// assertions (matching the soft-RoCE tolerance policy): it does not require any
+// specific success/loss ratio, only that real results aggregate into a summary
+// keyed by the prober's actual source GID and the target's ToR.
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/yuuki/rpingmesh/rebuild/internal/agent"
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
+	"github.com/yuuki/rpingmesh/rebuild/internal/rdmabridge"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+func TestProbeToPathAggregator(t *testing.T) {
+	if os.Getenv("RDMA_E2E_ENABLED") != "1" {
+		t.Skip("RDMA_E2E_ENABLED not set; run via 'make test-e2e' or set RDMA_E2E_ENABLED=1")
+	}
+
+	const (
+		sourceTorID     = "tor-agg-source"
+		targetTorID     = "tor-agg-target"
+		probeIntervalMS = uint32(200)
+		windowNs        = uint64(60 * time.Second) // one window spanning the whole test
+		gatherDuration  = 3 * time.Second
+		drainTimeout    = 2 * time.Second
+	)
+
+	rdmaCtx, err := rdmabridge.Init()
+	if err != nil {
+		t.Fatalf("rdmabridge.Init: %v", err)
+	}
+	defer rdmaCtx.Destroy()
+
+	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	if err != nil {
+		t.Fatalf("open prober device %q: %v", proberDeviceName, err)
+	}
+	defer proberDev.Close()
+
+	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	if err != nil {
+		t.Fatalf("open responder device %q: %v", responderDeviceName, err)
+	}
+	defer responderDev.Close()
+
+	proberRing, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create prober ring: %v", err)
+	}
+	defer proberRing.Destroy()
+
+	responderRing, err := rdmabridge.NewEventRing(eventRingCapacity)
+	if err != nil {
+		t.Fatalf("create responder ring: %v", err)
+	}
+	defer responderRing.Destroy()
+
+	prober, err := agent.NewProber(proberDev, proberRing, probeIntervalMS)
+	if err != nil {
+		t.Fatalf("NewProber: %v", err)
+	}
+	responder, err := agent.NewResponder(responderDev, responderRing)
+	if err != nil {
+		t.Fatalf("NewResponder: %v", err)
+	}
+
+	responderQueueInfo := responder.GetQueueInfo()
+	mockClient := &mockControllerClient{
+		targets: []*controller_agent.PingTarget{
+			{
+				TargetGid:        responderDev.Info.GID,
+				TargetQpn:        responderQueueInfo.QPN,
+				TargetIp:         responderDev.Info.IPAddr,
+				TargetHostname:   "e2e-agg-responder",
+				TargetTorId:      targetTorID,
+				TargetDeviceName: responderDev.Info.DeviceName,
+			},
+		},
+	}
+
+	monitor := agent.NewClusterMonitor(mockClient, prober, "e2e-agg-agent", sourceTorID, proberDev.Info.GID, 3600)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := responder.Start(ctx); err != nil {
+		t.Fatalf("responder.Start: %v", err)
+	}
+	if err := prober.Start(ctx); err != nil {
+		t.Fatalf("prober.Start: %v", err)
+	}
+	if err := monitor.Start(ctx); err != nil {
+		t.Fatalf("monitor.Start: %v", err)
+	}
+
+	// Feed real probe results into a PathAggregator (the analysis branch's
+	// consumer), exactly as the AnalysisReporter would.
+	agg := probe.NewPathAggregator(windowNs)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case result, ok := <-prober.Results():
+				if !ok {
+					return
+				}
+				agg.AddResult(result, uint64(time.Now().UnixNano()))
+			}
+		}
+	}()
+
+	// Let the prober run for a few windows' worth of probe rounds so the
+	// aggregator accumulates real results.
+	time.Sleep(gatherDuration)
+
+	// Controlled shutdown, then drain.
+	monitor.Stop()
+	prober.Destroy()
+	responder.Destroy()
+	select {
+	case <-consumerDone:
+	case <-time.After(drainTimeout):
+		t.Log("WARNING: aggregator consumer did not drain within drainTimeout")
+	}
+
+	summaries := agg.Flush()
+	if len(summaries) == 0 {
+		t.Fatal("no path summaries produced from real probe results")
+	}
+
+	for _, s := range summaries {
+		if s.SourceGID == ([16]byte{}) {
+			t.Errorf("summary has zero SourceGID; prober did not stamp the source RNIC GID")
+		}
+		if s.TargetTorID != targetTorID {
+			t.Errorf("summary TargetTorID = %q, want %q", s.TargetTorID, targetTorID)
+		}
+		if s.ProbeTotal == 0 {
+			t.Errorf("summary ProbeTotal = 0, want > 0")
+		}
+		// total must partition into success + failed + invalid.
+		if s.ProbeTotal != s.ProbeSuccess+s.ProbeFailed+s.InvalidRTTCount {
+			t.Errorf("summary counts do not partition: total=%d success=%d failed=%d invalid=%d",
+				s.ProbeTotal, s.ProbeSuccess, s.ProbeFailed, s.InvalidRTTCount)
+		}
+		t.Logf("summary: total=%d success=%d failed=%d invalid=%d min=%d max=%d p50=%d p99=%d",
+			s.ProbeTotal, s.ProbeSuccess, s.ProbeFailed, s.InvalidRTTCount,
+			s.NetworkRTTMinNs, s.NetworkRTTMaxNs, s.NetworkRTTP50Ns, s.NetworkRTTP99Ns)
+	}
+}

--- a/rebuild/e2e/probe_analysis_e2e_test.go
+++ b/rebuild/e2e/probe_analysis_e2e_test.go
@@ -43,13 +43,13 @@ func TestProbeToPathAggregator(t *testing.T) {
 	}
 	defer rdmaCtx.Destroy()
 
-	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex)
+	proberDev, err := rdmaCtx.OpenDeviceByName(proberDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open prober device %q: %v", proberDeviceName, err)
 	}
 	defer proberDev.Close()
 
-	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex)
+	responderDev, err := rdmaCtx.OpenDeviceByName(responderDeviceName, gidIndex, testServiceLevel, testTrafficClass)
 	if err != nil {
 		t.Fatalf("open responder device %q: %v", responderDeviceName, err)
 	}

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -95,6 +95,16 @@ type Agent struct {
 	// reporting is disabled.
 	analysisReporter *AnalysisReporter
 
+	// metricsResultsActive records whether a metrics result consumer will drain
+	// a.results (i.e. a.metrics != nil). It is decided before createResultsFanIn
+	// and read by each fan-in goroutine: when false, the fan-in does NOT send on
+	// a.results at all. Otherwise a full a.results (which nobody drains when
+	// metrics are disabled or MetricsCollector creation failed) would block the
+	// fan-in, stopping it reading from the probers and starving the independent
+	// analysis tee. Analysis reporting can be enabled without metrics, so the
+	// two branches must not be coupled.
+	metricsResultsActive bool
+
 	// agentIP is the host's outbound IP toward the controller, reported in the
 	// registration request's agent_ip field. Best-effort: empty if it cannot be
 	// determined, which never blocks registration.
@@ -194,6 +204,15 @@ func (a *Agent) Initialize(ctx context.Context) error {
 			Msg("Prober created")
 	}
 
+	// Create the metrics collector (if enabled) BEFORE the results fan-in, so
+	// the fan-in knows whether a metrics result consumer will actually drain
+	// a.results. If none will (metrics disabled, or MetricsCollector creation
+	// failed), the fan-in must not send on a.results -- once its buffer filled,
+	// the fan-in would block, stop reading from the probers, and starve the
+	// independent analysis tee too.
+	a.createMetricsCollector(ctx)
+	a.metricsResultsActive = a.metrics != nil
+
 	// Fan-in every prober's Results() channel into a single stream so the
 	// rest of Initialize/Start can keep treating "the" probe result stream
 	// as one channel, as before. When analysis reporting is enabled this also
@@ -231,36 +250,8 @@ func (a *Agent) Initialize(ctx context.Context) error {
 			Msg("Responder created")
 	}
 
-	// Step 7: Create metrics collector if enabled.
-	if a.cfg.MetricsEnabled {
-		a.logger.Info().
-			Str("collector_addr", a.cfg.OtelCollectorAddr).
-			Msg("Creating metrics collector")
-		mc, err := telemetry.NewMetricsCollector(ctx, a.cfg.OtelCollectorAddr)
-		if err != nil {
-			a.logger.Warn().Err(err).
-				Msg("Failed to create metrics collector, continuing without metrics")
-		} else {
-			a.metrics = mc
-			// Surface event-ring drop counts (rings were created in step 4,
-			// above) as an OTel observable counter. A growing count means the
-			// Go poller goroutine is not draining rdma_event_ring_poll fast
-			// enough and completion events are being silently discarded.
-			// Both readers aggregate across all per-device rings under a
-			// single label ("prober"/"responder") to keep metric cardinality
-			// low (matching the source_tor/target_tor-only convention used
-			// elsewhere), rather than reporting one data point per device.
-			if err := a.metrics.RegisterEventRingDropCallback(map[string]func() uint64{
-				"prober":    a.proberRingDropCount,
-				"responder": a.responderRingDropCount,
-			}); err != nil {
-				a.logger.Warn().Err(err).
-					Msg("Failed to register event ring drop count callback")
-			}
-		}
-	} else {
-		a.logger.Info().Msg("Metrics collection is disabled")
-	}
+	// (The metrics collector is created earlier, before the results fan-in; see
+	// createMetricsCollector above.)
 
 	// Determine the host's outbound IP toward the controller so it can be
 	// reported in the registration. Best-effort: on failure agentIP stays
@@ -756,18 +747,58 @@ func (a *Agent) createEventRings() error {
 	return nil
 }
 
+// createMetricsCollector creates the OTel MetricsCollector when metrics are
+// enabled, leaving a.metrics nil (and logging) if metrics are disabled or if
+// creation fails. It is called before createResultsFanIn so the fan-in can
+// tell, via a.metrics != nil, whether a metrics result consumer will run.
+func (a *Agent) createMetricsCollector(ctx context.Context) {
+	if !a.cfg.MetricsEnabled {
+		a.logger.Info().Msg("Metrics collection is disabled")
+		return
+	}
+
+	a.logger.Info().
+		Str("collector_addr", a.cfg.OtelCollectorAddr).
+		Msg("Creating metrics collector")
+	mc, err := telemetry.NewMetricsCollector(ctx, a.cfg.OtelCollectorAddr)
+	if err != nil {
+		a.logger.Warn().Err(err).
+			Msg("Failed to create metrics collector, continuing without metrics")
+		return
+	}
+	a.metrics = mc
+
+	// Surface event-ring drop counts (rings were created earlier) as an OTel
+	// observable counter. A growing count means the Go poller goroutine is not
+	// draining rdma_event_ring_poll fast enough and completion events are being
+	// silently discarded. Both readers aggregate across all per-device rings
+	// under a single label ("prober"/"responder") to keep metric cardinality
+	// low (matching the source_tor/target_tor-only convention used elsewhere),
+	// rather than reporting one data point per device.
+	if err := a.metrics.RegisterEventRingDropCallback(map[string]func() uint64{
+		"prober":    a.proberRingDropCount,
+		"responder": a.responderRingDropCount,
+	}); err != nil {
+		a.logger.Warn().Err(err).
+			Msg("Failed to register event ring drop count callback")
+	}
+}
+
 // createResultsFanIn creates the shared results channel and starts one
 // fan-in goroutine per prober that forwards its Results() into the shared
 // channel. This lets Start() and the metrics result consumer keep treating
 // "the" probe result stream as a single channel even though every device now
 // has its own Prober.
 //
-// Each fan-in goroutine selects between sending on a.results and reading
-// from resultsDone, so it can always return promptly once Stop calls
-// stopResultsFanIn -- whether or not anything is (or ever was) draining
-// a.results. Without this, a fan-in goroutine could block forever on a full
-// a.results when metrics are disabled (or MetricsCollector creation
-// failed), leaking the goroutine and every buffered result.
+// When a.metricsResultsActive is true, each fan-in goroutine selects between
+// sending on a.results and reading from resultsDone, so it can always return
+// promptly once Stop calls stopResultsFanIn -- whether or not anything is (or
+// ever was) draining a.results (e.g. metrics active but the consumer has
+// already stopped during shutdown). When it is false (no metrics consumer will
+// run), the fan-in skips the a.results send entirely: sending on a channel
+// nobody drains would, once full, block the goroutine, stop it reading from the
+// prober, and starve the independent analysis tee. Analysis can be enabled
+// without metrics, so the two branches must stay decoupled.
 func (a *Agent) createResultsFanIn() {
 	a.results = make(chan *probe.ProbeResult, resultChanSize)
 	a.resultsDone = make(chan struct{})
@@ -791,6 +822,12 @@ func (a *Agent) createResultsFanIn() {
 					case a.analysisResults <- result:
 					default:
 					}
+				}
+				// Primary metrics path. Skipped entirely when no metrics
+				// consumer will drain a.results, so a slow/absent metrics
+				// consumer cannot stall the fan-in (and thus the analysis tee).
+				if !a.metricsResultsActive {
+					continue
 				}
 				select {
 				case a.results <- result:

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -82,6 +82,19 @@ type Agent struct {
 	// forever instead of letting Stop complete deterministically.
 	resultsDone chan struct{}
 
+	// analysisResults is the secondary fan-out branch of the results fan-in,
+	// feeding the AnalysisReporter (per-path window aggregation). It is nil
+	// when analysis reporting is disabled. The fan-in tees onto it with a
+	// non-blocking send so a backed-up aggregator can never stall the primary
+	// metrics path; it is closed by stopResultsFanIn after every fan-in
+	// goroutine has exited (so no send races the close).
+	analysisResults chan *probe.ProbeResult
+
+	// analysisReporter drives the PathAggregator and ships completed window
+	// summaries to the controller via ReportProbeAnalysis. nil when analysis
+	// reporting is disabled.
+	analysisReporter *AnalysisReporter
+
 	// agentIP is the host's outbound IP toward the controller, reported in the
 	// registration request's agent_ip field. Best-effort: empty if it cannot be
 	// determined, which never blocks registration.
@@ -177,8 +190,25 @@ func (a *Agent) Initialize(ctx context.Context) error {
 
 	// Fan-in every prober's Results() channel into a single stream so the
 	// rest of Initialize/Start can keep treating "the" probe result stream
-	// as one channel, as before.
+	// as one channel, as before. When analysis reporting is enabled this also
+	// creates the secondary analysis branch that the fan-in tees onto.
 	a.createResultsFanIn()
+
+	// Create the analysis reporter (per-path window aggregation + SLA
+	// reporting to the controller) if enabled. It consumes the analysis branch
+	// created by createResultsFanIn and reports on this agent's behalf.
+	if a.cfg.AnalysisReportEnabled {
+		a.analysisReporter = NewAnalysisReporter(
+			a.grpcClient,
+			a.cfg.AgentID,
+			a.cfg.TorID,
+			a.cfg.AnalysisWindowSec,
+			a.analysisResults,
+		)
+		a.logger.Info().
+			Uint32("window_sec", a.cfg.AnalysisWindowSec).
+			Msg("Analysis reporter created")
+	}
 
 	// Step 6: Create one responder per device.
 	a.logger.Info().Int("device_count", len(a.devices)).Msg("Creating responders")
@@ -438,6 +468,12 @@ func (a *Agent) Start(ctx context.Context) error {
 		a.logger.Info().Msg("Metrics result consumer started")
 	}
 
+	// Start the analysis reporter if enabled. It consumes the secondary
+	// analysis branch of the fan-in independently of the metrics consumer.
+	if a.analysisReporter != nil {
+		a.analysisReporter.Start(ctx)
+	}
+
 	a.logger.Info().Msg("Agent started")
 	return nil
 }
@@ -477,6 +513,13 @@ func (a *Agent) Stop(ctx context.Context) {
 	// nothing draining it (e.g. metrics disabled), which in turn lets the
 	// metrics result consumer's range loop finish.
 	a.stopResultsFanIn()
+
+	// Wait for the analysis reporter to drain the now-closed analysis branch
+	// and ship its final window summary. This must happen before the gRPC
+	// client is closed below, since the final flush is sent over it.
+	if a.analysisReporter != nil {
+		a.analysisReporter.Wait()
+	}
 
 	// Stop all responders.
 	for _, resp := range a.responders {
@@ -718,12 +761,27 @@ func (a *Agent) createEventRings() error {
 func (a *Agent) createResultsFanIn() {
 	a.results = make(chan *probe.ProbeResult, resultChanSize)
 	a.resultsDone = make(chan struct{})
+	if a.cfg.AnalysisReportEnabled {
+		a.analysisResults = make(chan *probe.ProbeResult, resultChanSize)
+	}
 
 	for _, prober := range a.probers {
 		a.resultsWg.Add(1)
 		go func(p *Prober) {
 			defer a.resultsWg.Done()
 			for result := range p.Results() {
+				// Secondary, best-effort tee to the analysis path. The send is
+				// non-blocking (dropped if the analysis buffer is full) so a
+				// slow or backed-up aggregator/reporter can never stall the
+				// primary metrics path below. Done first so a full a.results
+				// (e.g. metrics slow) does not also starve analysis of this
+				// result.
+				if a.analysisResults != nil {
+					select {
+					case a.analysisResults <- result:
+					default:
+					}
+				}
 				select {
 				case a.results <- result:
 				case <-a.resultsDone:
@@ -760,6 +818,12 @@ func (a *Agent) stopResultsFanIn() {
 	close(a.resultsDone)
 	a.resultsWg.Wait()
 	close(a.results)
+	// Close the analysis branch too (only after every fan-in goroutine has
+	// exited, so no tee send can race this close). This is what ends the
+	// AnalysisReporter's run loop and triggers its final-window flush.
+	if a.analysisResults != nil {
+		close(a.analysisResults)
+	}
 }
 
 // proberRingDropCount sums EventRing.DropCount() across every prober ring

--- a/rebuild/internal/agent/agent_test.go
+++ b/rebuild/internal/agent/agent_test.go
@@ -119,6 +119,81 @@ func TestAgent_CreateResultsFanIn_MergesResultsFromEveryProber(t *testing.T) {
 	}
 }
 
+// TestAgent_CreateResultsFanIn_TeesToAnalysis verifies that, with analysis
+// reporting enabled, every fan-in result is delivered to BOTH the metrics
+// channel and the analysis branch (the tee), so the analyzer sees the same
+// stream the metrics consumer does.
+func TestAgent_CreateResultsFanIn_TeesToAnalysis(t *testing.T) {
+	probers := []*Prober{fakeProber(4)}
+	a := newTestAgent(nil, probers)
+	a.cfg.AnalysisReportEnabled = true
+
+	a.createResultsFanIn()
+
+	if a.analysisResults == nil {
+		t.Fatal("analysisResults channel not created when analysis enabled")
+	}
+
+	probers[0].emitResult(&probe.ProbeResult{SequenceNum: 7})
+
+	// Metrics branch.
+	select {
+	case r := <-a.results:
+		if r.SequenceNum != 7 {
+			t.Errorf("metrics branch seq = %d, want 7", r.SequenceNum)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result on metrics branch")
+	}
+
+	// Analysis branch (the tee).
+	select {
+	case r := <-a.analysisResults:
+		if r.SequenceNum != 7 {
+			t.Errorf("analysis branch seq = %d, want 7", r.SequenceNum)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result on analysis branch")
+	}
+}
+
+// TestAgent_CreateResultsFanIn_SlowAnalysisDoesNotStallMetrics verifies the
+// key non-blocking contract: when the analysis branch backs up (nothing drains
+// a.analysisResults, its buffer fills), the metrics path must still receive
+// every result. The tee's analysis send is non-blocking (drops on a full
+// buffer) precisely so a slow aggregator cannot stall metrics.
+func TestAgent_CreateResultsFanIn_SlowAnalysisDoesNotStallMetrics(t *testing.T) {
+	// More than the analysis branch buffer (resultChanSize) so it overflows.
+	const total = resultChanSize + 100
+
+	prober := fakeProber(total) // hold all emitted results without dropping
+	a := newTestAgent(nil, []*Prober{prober})
+	a.cfg.AnalysisReportEnabled = true
+
+	a.createResultsFanIn()
+
+	// Nothing ever drains a.analysisResults: the aggregator is "stuck".
+	for i := 0; i < total; i++ {
+		prober.emitResult(&probe.ProbeResult{SequenceNum: uint64(i)})
+	}
+	prober.Destroy() // close Results() so the fan-in drains and eventually exits
+
+	// The metrics branch must still receive all `total` results.
+	got := 0
+	timeout := time.After(5 * time.Second)
+	for got < total {
+		select {
+		case _, ok := <-a.results:
+			if !ok {
+				t.Fatalf("metrics channel closed after %d results, want %d", got, total)
+			}
+			got++
+		case <-timeout:
+			t.Fatalf("slow analysis branch stalled metrics: only %d/%d results delivered", got, total)
+		}
+	}
+}
+
 func TestAgent_StopResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t *testing.T) {
 	probers := []*Prober{fakeProber(1), fakeProber(1)}
 	a := newTestAgent(nil, probers)
@@ -155,6 +230,30 @@ func TestAgent_StopResultsFanIn_ClosesSharedChannelAfterAllProbersDestroyed(t *t
 		}
 	default:
 		t.Fatal("expected a.results to already be closed once stopResultsFanIn returned")
+	}
+}
+
+// TestAgent_StopResultsFanIn_ClosesAnalysisBranch verifies that shutting down
+// the fan-in also closes the analysis branch (after every fan-in goroutine has
+// exited), which is what ends the AnalysisReporter's run loop.
+func TestAgent_StopResultsFanIn_ClosesAnalysisBranch(t *testing.T) {
+	probers := []*Prober{fakeProber(1)}
+	a := newTestAgent(nil, probers)
+	a.cfg.AnalysisReportEnabled = true
+
+	a.createResultsFanIn()
+	for _, p := range probers {
+		p.Destroy()
+	}
+	a.stopResultsFanIn()
+
+	select {
+	case _, ok := <-a.analysisResults:
+		if ok {
+			t.Fatal("expected analysisResults closed with no pending data")
+		}
+	default:
+		t.Fatal("expected analysisResults to be closed after stopResultsFanIn")
 	}
 }
 

--- a/rebuild/internal/agent/agent_test.go
+++ b/rebuild/internal/agent/agent_test.go
@@ -95,6 +95,7 @@ func TestAgent_CreateClusterMonitors_OnePerDeviceWithMatchingRequesterGID(t *tes
 func TestAgent_CreateResultsFanIn_MergesResultsFromEveryProber(t *testing.T) {
 	probers := []*Prober{fakeProber(4), fakeProber(4)}
 	a := newTestAgent(nil, probers)
+	a.metricsResultsActive = true // a metrics consumer will drain a.results
 
 	a.createResultsFanIn()
 
@@ -127,6 +128,7 @@ func TestAgent_CreateResultsFanIn_TeesToAnalysis(t *testing.T) {
 	probers := []*Prober{fakeProber(4)}
 	a := newTestAgent(nil, probers)
 	a.cfg.AnalysisReportEnabled = true
+	a.metricsResultsActive = true // a metrics consumer will drain a.results
 
 	a.createResultsFanIn()
 
@@ -169,6 +171,7 @@ func TestAgent_CreateResultsFanIn_SlowAnalysisDoesNotStallMetrics(t *testing.T) 
 	prober := fakeProber(total) // hold all emitted results without dropping
 	a := newTestAgent(nil, []*Prober{prober})
 	a.cfg.AnalysisReportEnabled = true
+	a.metricsResultsActive = true // metrics consumer active; it drains a.results
 
 	a.createResultsFanIn()
 
@@ -258,13 +261,14 @@ func TestAgent_StopResultsFanIn_ClosesAnalysisBranch(t *testing.T) {
 }
 
 // TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock reproduces the
-// scenario a review of PR #31 flagged: when metrics are disabled (or
-// MetricsCollector creation failed), Start never drains a.results. If a
-// fan-in goroutine has no way to abandon a blocked send once a.results
-// fills up, stopResultsFanIn (called from Agent.Stop) would hang forever
-// waiting on resultsWg, leaking the goroutine and every buffered result.
-// createResultsFanIn's select on resultsDone must let it return promptly
-// regardless.
+// scenario a review of PR #31 flagged: the metrics branch is active (so the
+// fan-in forwards to a.results), but nothing is draining a.results at shutdown
+// -- e.g. Stop is reached after the metrics result consumer has already
+// stopped, or before Start ever ran it. If a fan-in goroutine had no way to
+// abandon a blocked send once a.results fills up, stopResultsFanIn (called
+// from Agent.Stop) would hang forever waiting on resultsWg, leaking the
+// goroutine and every buffered result. createResultsFanIn's select on
+// resultsDone must let it return promptly regardless.
 func TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock(t *testing.T) {
 	// More results than a.results' buffer (resultChanSize) can hold, so at
 	// least one forwarded result is guaranteed to overflow it and block the
@@ -273,6 +277,9 @@ func TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock(t *testing.T) {
 
 	prober := fakeProber(overflow)
 	a := newTestAgent(nil, []*Prober{prober})
+	// Metrics branch active: the fan-in forwards to a.results, exercising the
+	// resultsDone escape when nothing drains it.
+	a.metricsResultsActive = true
 
 	a.createResultsFanIn()
 
@@ -281,7 +288,7 @@ func TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock(t *testing.T) {
 	}
 
 	// Nothing ever reads from a.results in this test: no metrics result
-	// consumer, matching the metrics-disabled/unavailable scenario.
+	// consumer is draining it.
 	prober.Destroy()
 
 	done := make(chan struct{})
@@ -296,4 +303,46 @@ func TestAgent_StopResultsFanIn_NoConsumer_DoesNotDeadlock(t *testing.T) {
 		t.Fatal("stopResultsFanIn deadlocked with no consumer draining a.results: " +
 			"the fan-in goroutine could not abandon a blocked send")
 	}
+}
+
+// TestAgent_CreateResultsFanIn_NoMetricsConsumer_AnalysisStillFlows verifies
+// the fix for the metrics/analysis coupling: when NO metrics consumer will
+// drain a.results (metrics disabled, or MetricsCollector creation failed:
+// a.metricsResultsActive == false) but analysis reporting IS enabled, the
+// fan-in must keep delivering results to the analysis branch instead of
+// blocking on a.results once its buffer fills.
+//
+// The emit-one/receive-one loop makes the check deterministic: a fan-in that
+// (incorrectly) still forwarded to the undrained a.results would fill it after
+// resultChanSize results and then block on the metrics send, so the analysis
+// branch would stop receiving around that point. Because the loop runs well
+// past resultChanSize, the fix (skip the a.results send when no consumer) is
+// what lets every result reach analysis.
+func TestAgent_CreateResultsFanIn_NoMetricsConsumer_AnalysisStillFlows(t *testing.T) {
+	const total = resultChanSize + 50 // well past where a coupled fan-in would jam
+
+	prober := fakeProber(total)
+	a := newTestAgent(nil, []*Prober{prober})
+	a.cfg.AnalysisReportEnabled = true
+	a.metricsResultsActive = false // no metrics consumer will drain a.results
+
+	a.createResultsFanIn()
+
+	// Emit one, receive one. Draining each result before emitting the next
+	// keeps the analysis buffer from filling (so nothing is dropped) and, more
+	// importantly, proves flow continues past resultChanSize -- the point a
+	// metrics-coupled fan-in would have jammed.
+	for i := 0; i < total; i++ {
+		prober.emitResult(&probe.ProbeResult{SequenceNum: uint64(i)})
+		select {
+		case <-a.analysisResults:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("analysis stalled at result %d (past a.results buffer %d): "+
+				"fan-in is coupled to the undrained metrics channel", i, resultChanSize)
+		}
+	}
+
+	// Clean shutdown of the fan-in.
+	prober.Destroy()
+	a.stopResultsFanIn()
 }

--- a/rebuild/internal/agent/analysis_reporter.go
+++ b/rebuild/internal/agent/analysis_reporter.go
@@ -1,0 +1,195 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// maxSummariesPerReport caps how many PathSummary entries a single
+// ReportProbeAnalysis RPC carries, so a burst of many paths is split across a
+// few bounded messages rather than one oversized one.
+const maxSummariesPerReport = 256
+
+// finalFlushTimeout bounds the best-effort send of the last partial window at
+// shutdown, when the reporter's run context is already cancelled and a fresh
+// context is used instead.
+const finalFlushTimeout = 5 * time.Second
+
+// analysisSender is the subset of controller_client.GRPCControllerClient used
+// by the reporter. Declaring it here (at the point of use) lets the reporter
+// be unit tested against a fake without a real gRPC connection.
+type analysisSender interface {
+	ReportProbeAnalysis(
+		ctx context.Context,
+		report *controller_agent.ProbeAnalysisReport,
+	) (*controller_agent.ProbeAnalysisAck, error)
+}
+
+// AnalysisReporter drains merged probe results into a per-path PathAggregator
+// and, at each window boundary, ships the completed window summaries to the
+// controller via ReportProbeAnalysis. It is deliberately best-effort: a send
+// failure drops that batch and is logged, never retried, so a slow or
+// unreachable controller cannot stall probing or block shutdown.
+type AnalysisReporter struct {
+	agg         *probe.PathAggregator
+	sender      analysisSender
+	agentID     string
+	sourceTorID string
+	windowDur   time.Duration
+
+	// input is the fan-out branch of the prober results fan-in; closed by
+	// Agent.stopResultsFanIn during shutdown, which is what ends the run loop.
+	input <-chan *probe.ProbeResult
+
+	// nowFn is injectable so tests can control window boundaries.
+	nowFn func() time.Time
+
+	logger zerolog.Logger
+	wg     sync.WaitGroup
+}
+
+// NewAnalysisReporter constructs a reporter aggregating into windowSec-long
+// windows and reporting to sender on behalf of agentID (whose RNICs all share
+// sourceTorID). input is the result stream to consume.
+func NewAnalysisReporter(
+	sender analysisSender,
+	agentID, sourceTorID string,
+	windowSec uint32,
+	input <-chan *probe.ProbeResult,
+) *AnalysisReporter {
+	if windowSec == 0 {
+		windowSec = 1
+	}
+	windowDur := time.Duration(windowSec) * time.Second
+	return &AnalysisReporter{
+		agg:         probe.NewPathAggregator(uint64(windowDur.Nanoseconds())),
+		sender:      sender,
+		agentID:     agentID,
+		sourceTorID: sourceTorID,
+		windowDur:   windowDur,
+		input:       input,
+		nowFn:       time.Now,
+		logger:      log.With().Str("component", "analysis_reporter").Logger(),
+	}
+}
+
+// Start launches the reporter goroutine. It returns immediately; the goroutine
+// runs until input is closed or ctx is cancelled, then flushes a final partial
+// window (best-effort) before exiting. Call Wait to block until it has exited
+// (do so before closing the gRPC client so the final flush can still be sent).
+func (r *AnalysisReporter) Start(ctx context.Context) {
+	r.wg.Add(1)
+	go r.run(ctx)
+	r.logger.Info().
+		Dur("window", r.windowDur).
+		Msg("Analysis reporter started")
+}
+
+// Wait blocks until the reporter goroutine has fully exited.
+func (r *AnalysisReporter) Wait() {
+	r.wg.Wait()
+}
+
+func (r *AnalysisReporter) run(ctx context.Context) {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.windowDur)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.flushFinal()
+			return
+		case res, ok := <-r.input:
+			if !ok {
+				// The fan-in closed the branch: agent is shutting down.
+				r.flushFinal()
+				return
+			}
+			r.agg.AddResult(res, uint64(r.nowFn().UnixNano()))
+		case <-ticker.C:
+			summaries := r.agg.Collect(uint64(r.nowFn().UnixNano()))
+			r.report(ctx, summaries)
+		}
+	}
+}
+
+// flushFinal emits any remaining (including in-progress) window summaries on a
+// fresh context, since run's context may already be cancelled at this point.
+func (r *AnalysisReporter) flushFinal() {
+	summaries := r.agg.Flush()
+	if len(summaries) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), finalFlushTimeout)
+	defer cancel()
+	r.report(ctx, summaries)
+}
+
+// report batches summaries into bounded ProbeAnalysisReport messages and sends
+// them best-effort. Any send error is logged and the batch dropped; monitoring
+// is best-effort and must never stall probing.
+func (r *AnalysisReporter) report(ctx context.Context, summaries []probe.PathSummary) {
+	if len(summaries) == 0 {
+		return
+	}
+
+	for start := 0; start < len(summaries); start += maxSummariesPerReport {
+		end := start + maxSummariesPerReport
+		if end > len(summaries) {
+			end = len(summaries)
+		}
+		batch := summaries[start:end]
+
+		report := &controller_agent.ProbeAnalysisReport{
+			AgentId:   r.agentID,
+			Summaries: make([]*controller_agent.PathSummary, 0, len(batch)),
+		}
+		for i := range batch {
+			report.Summaries = append(report.Summaries, r.toProto(&batch[i]))
+		}
+
+		ack, err := r.sender.ReportProbeAnalysis(ctx, report)
+		if err != nil {
+			r.logger.Warn().Err(err).
+				Int("summary_count", len(batch)).
+				Msg("Failed to report probe analysis, dropping batch (best-effort)")
+			continue
+		}
+		r.logger.Debug().
+			Int("summary_count", len(batch)).
+			Bool("accepted", ack.GetAccepted()).
+			Uint32("sla_violations", ack.GetSlaViolations()).
+			Msg("Reported probe analysis window")
+	}
+}
+
+// toProto maps an aggregator PathSummary to its proto form, stamping the
+// agent-wide source ToR (which the aggregator does not carry) and rendering
+// GIDs as canonical strings.
+func (r *AnalysisReporter) toProto(s *probe.PathSummary) *controller_agent.PathSummary {
+	return &controller_agent.PathSummary{
+		SourceGid:        probe.FormatGID(s.SourceGID),
+		SourceTorId:      r.sourceTorID,
+		TargetGid:        probe.FormatGID(s.TargetGID),
+		TargetTorId:      s.TargetTorID,
+		TargetQpn:        s.TargetQPN,
+		WindowStartUnixNs: s.WindowStartUnixNs,
+		WindowDurationMs:  s.WindowDurationMs,
+		ProbeTotal:        s.ProbeTotal,
+		ProbeSuccess:      s.ProbeSuccess,
+		ProbeFailed:       s.ProbeFailed,
+		NetworkRttMinNs:   s.NetworkRTTMinNs,
+		NetworkRttMaxNs:   s.NetworkRTTMaxNs,
+		NetworkRttP50Ns:   s.NetworkRTTP50Ns,
+		NetworkRttP99Ns:   s.NetworkRTTP99Ns,
+		InvalidRttCount:   s.InvalidRTTCount,
+	}
+}

--- a/rebuild/internal/agent/analysis_reporter.go
+++ b/rebuild/internal/agent/analysis_reporter.go
@@ -128,13 +128,26 @@ func (r *AnalysisReporter) run(ctx context.Context) {
 			}
 			r.agg.AddResult(res, uint64(r.nowFn().UnixNano()))
 		case <-ticker.C:
-			// Periodic window flush. Uses the run context so an in-flight
-			// periodic send is abandoned promptly once the agent starts
-			// shutting down (ctx cancelled); any window still open at that
-			// point is picked up by flushFinal instead.
-			r.report(ctx, r.agg.Collect(uint64(r.nowFn().UnixNano())))
+			r.collectAndReport(ctx)
 		}
 	}
+}
+
+// collectAndReport performs one periodic window collection: it harvests the
+// completed windows and sends them.
+//
+// It is a no-op once ctx is cancelled (shutdown has begun). This is important:
+// Collect removes the completed windows from the aggregator, so if the
+// subsequent send failed on the cancelled ctx those summaries would be lost and
+// never retried -- even for a reachable controller. Skipping the collection
+// leaves the windows in the aggregator, where flushFinal (which sends on an
+// independent context after the input closes) picks them up. In-flight periodic
+// sends still abort promptly on ctx cancellation, keeping shutdown fast.
+func (r *AnalysisReporter) collectAndReport(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	r.report(ctx, r.agg.Collect(uint64(r.nowFn().UnixNano())))
 }
 
 // flushFinal emits any remaining (including in-progress) window summaries on a

--- a/rebuild/internal/agent/analysis_reporter.go
+++ b/rebuild/internal/agent/analysis_reporter.go
@@ -80,9 +80,15 @@ func NewAnalysisReporter(
 }
 
 // Start launches the reporter goroutine. It returns immediately; the goroutine
-// runs until input is closed or ctx is cancelled, then flushes a final partial
-// window (best-effort) before exiting. Call Wait to block until it has exited
-// (do so before closing the gRPC client so the final flush can still be sent).
+// runs until its input channel is closed (by Agent.stopResultsFanIn at
+// shutdown), then flushes and sends the final window before exiting. It does
+// NOT stop on ctx cancellation: on a signal stop the ctx is cancelled before
+// the fan-in is torn down, so exiting on ctx would drop the last results still
+// draining out of the fan-in. ctx only bounds in-flight periodic sends; the
+// final flush uses an independent context so it is delivered regardless. Call
+// Wait to block until it has exited -- do so after stopResultsFanIn (which
+// closes the input) and before closing the gRPC client (so the final flush can
+// still be sent).
 func (r *AnalysisReporter) Start(ctx context.Context) {
 	r.wg.Add(1)
 	go r.run(ctx)
@@ -104,19 +110,29 @@ func (r *AnalysisReporter) run(ctx context.Context) {
 
 	for {
 		select {
-		case <-ctx.Done():
-			r.flushFinal()
-			return
 		case res, ok := <-r.input:
 			if !ok {
-				// The fan-in closed the branch: agent is shutting down.
+				// The input branch was closed by Agent.stopResultsFanIn, which
+				// runs only after every prober was destroyed and every fan-in
+				// goroutine drained. That close is the SOLE shutdown trigger:
+				// draining off it (rather than ctx cancellation) guarantees the
+				// last results still flowing out of the fan-in during prober
+				// teardown are aggregated into the final window instead of
+				// being dropped. On a signal stop the ctx passed to Start is
+				// cancelled first, but we deliberately keep reading here until
+				// the channel closes. flushFinal sends on an independent
+				// context so the final window is delivered even though ctx is
+				// already cancelled.
 				r.flushFinal()
 				return
 			}
 			r.agg.AddResult(res, uint64(r.nowFn().UnixNano()))
 		case <-ticker.C:
-			summaries := r.agg.Collect(uint64(r.nowFn().UnixNano()))
-			r.report(ctx, summaries)
+			// Periodic window flush. Uses the run context so an in-flight
+			// periodic send is abandoned promptly once the agent starts
+			// shutting down (ctx cancelled); any window still open at that
+			// point is picked up by flushFinal instead.
+			r.report(ctx, r.agg.Collect(uint64(r.nowFn().UnixNano())))
 		}
 	}
 }
@@ -176,11 +192,11 @@ func (r *AnalysisReporter) report(ctx context.Context, summaries []probe.PathSum
 // GIDs as canonical strings.
 func (r *AnalysisReporter) toProto(s *probe.PathSummary) *controller_agent.PathSummary {
 	return &controller_agent.PathSummary{
-		SourceGid:        probe.FormatGID(s.SourceGID),
-		SourceTorId:      r.sourceTorID,
-		TargetGid:        probe.FormatGID(s.TargetGID),
-		TargetTorId:      s.TargetTorID,
-		TargetQpn:        s.TargetQPN,
+		SourceGid:         probe.FormatGID(s.SourceGID),
+		SourceTorId:       r.sourceTorID,
+		TargetGid:         probe.FormatGID(s.TargetGID),
+		TargetTorId:       s.TargetTorID,
+		TargetQpn:         s.TargetQPN,
 		WindowStartUnixNs: s.WindowStartUnixNs,
 		WindowDurationMs:  s.WindowDurationMs,
 		ProbeTotal:        s.ProbeTotal,

--- a/rebuild/internal/agent/analysis_reporter_test.go
+++ b/rebuild/internal/agent/analysis_reporter_test.go
@@ -1,0 +1,173 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// fakeSender records ReportProbeAnalysis calls and can be scripted to error.
+type fakeSender struct {
+	mu      sync.Mutex
+	reports []*controller_agent.ProbeAnalysisReport
+	err     error
+}
+
+func (f *fakeSender) ReportProbeAnalysis(
+	_ context.Context, report *controller_agent.ProbeAnalysisReport,
+) (*controller_agent.ProbeAnalysisAck, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reports = append(f.reports, report)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &controller_agent.ProbeAnalysisAck{Accepted: true}, nil
+}
+
+func (f *fakeSender) allSummaries() []*controller_agent.PathSummary {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []*controller_agent.PathSummary
+	for _, r := range f.reports {
+		out = append(out, r.GetSummaries()...)
+	}
+	return out
+}
+
+func (f *fakeSender) reportCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.reports)
+}
+
+// validProbeResult builds a Success result whose 6 timestamps yield a valid,
+// positive NetworkRTT, so it aggregates into probe_success with an RTT sample.
+func validProbeResult(src, tgt [16]byte, tor string, qpn uint32) *probe.ProbeResult {
+	return &probe.ProbeResult{
+		SourceGID:   src,
+		TargetGID:   tgt,
+		TargetTorID: tor,
+		TargetQPN:   qpn,
+		Success:     true,
+		T1:          1000,
+		T2:          2000,
+		T3:          3000,
+		T4:          3500,
+		T5:          4500, // NetworkRTT = (4500-2000)-500 = 2000ns
+		T6:          4600,
+	}
+}
+
+func srcGID(b byte) [16]byte {
+	var g [16]byte
+	g[15] = b
+	return g
+}
+
+// TestAnalysisReporter_FinalFlushOnInputClose verifies that closing the input
+// channel (what Agent.stopResultsFanIn does at shutdown) makes the reporter
+// flush its in-progress window and exit. A long window ensures the periodic
+// ticker never fires, so the report we observe comes solely from the final
+// flush.
+func TestAnalysisReporter_FinalFlushOnInputClose(t *testing.T) {
+	fake := &fakeSender{}
+	input := make(chan *probe.ProbeResult, 4)
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 3600, input)
+	r.Start(context.Background())
+
+	src, tgt := srcGID(1), srcGID(2)
+	input <- validProbeResult(src, tgt, "tor-b", 42)
+	input <- validProbeResult(src, tgt, "tor-b", 42)
+	close(input)
+
+	r.Wait()
+
+	summaries := fake.allSummaries()
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary from final flush, got %d", len(summaries))
+	}
+	s := summaries[0]
+	if s.GetProbeTotal() != 2 || s.GetProbeSuccess() != 2 {
+		t.Errorf("summary counts: total=%d success=%d, want 2/2", s.GetProbeTotal(), s.GetProbeSuccess())
+	}
+	// source_tor is stamped by the reporter (the aggregator does not carry it).
+	if s.GetSourceTorId() != "tor-a" {
+		t.Errorf("SourceTorId = %q, want tor-a", s.GetSourceTorId())
+	}
+	if s.GetTargetTorId() != "tor-b" || s.GetTargetQpn() != 42 {
+		t.Errorf("target metadata: tor=%q qpn=%d", s.GetTargetTorId(), s.GetTargetQpn())
+	}
+	if s.GetSourceGid() == "" || s.GetTargetGid() == "" {
+		t.Errorf("GIDs not formatted onto proto summary")
+	}
+}
+
+// TestAnalysisReporter_CtxCancelStops verifies the reporter also exits promptly
+// on context cancellation (not only input close).
+func TestAnalysisReporter_CtxCancelStops(t *testing.T) {
+	fake := &fakeSender{}
+	input := make(chan *probe.ProbeResult, 4)
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 3600, input)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx)
+	cancel()
+
+	done := make(chan struct{})
+	go func() { r.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reporter did not stop on context cancellation")
+	}
+}
+
+// TestAnalysisReporter_ReportBestEffortOnError verifies a send error is
+// swallowed (best-effort), not propagated or panicking.
+func TestAnalysisReporter_ReportBestEffortOnError(t *testing.T) {
+	fake := &fakeSender{err: errors.New("controller down")}
+	input := make(chan *probe.ProbeResult, 4)
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 3600, input)
+	r.Start(context.Background())
+
+	input <- validProbeResult(srcGID(1), srcGID(2), "tor-b", 1)
+	close(input)
+	r.Wait() // must return despite the send error
+
+	if fake.reportCount() != 1 {
+		t.Errorf("expected 1 (failed) report attempt, got %d", fake.reportCount())
+	}
+}
+
+// TestAnalysisReporter_BatchSplitting verifies that more than
+// maxSummariesPerReport summaries are split across multiple bounded reports.
+func TestAnalysisReporter_BatchSplitting(t *testing.T) {
+	fake := &fakeSender{}
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 30, nil)
+
+	n := maxSummariesPerReport + 5
+	summaries := make([]probe.PathSummary, n)
+	for i := range summaries {
+		summaries[i] = probe.PathSummary{
+			SourceGID:   srcGID(1),
+			TargetGID:   srcGID(byte(i%200 + 1)),
+			TargetTorID: "tor-b",
+			ProbeTotal:  1,
+		}
+	}
+	r.report(context.Background(), summaries)
+
+	if fake.reportCount() != 2 {
+		t.Errorf("expected 2 reports for %d summaries (cap %d), got %d",
+			n, maxSummariesPerReport, fake.reportCount())
+	}
+	if got := len(fake.allSummaries()); got != n {
+		t.Errorf("total summaries across reports = %d, want %d", got, n)
+	}
+}

--- a/rebuild/internal/agent/analysis_reporter_test.go
+++ b/rebuild/internal/agent/analysis_reporter_test.go
@@ -108,9 +108,12 @@ func TestAnalysisReporter_FinalFlushOnInputClose(t *testing.T) {
 	}
 }
 
-// TestAnalysisReporter_CtxCancelStops verifies the reporter also exits promptly
-// on context cancellation (not only input close).
-func TestAnalysisReporter_CtxCancelStops(t *testing.T) {
+// TestAnalysisReporter_CtxCancelAloneDoesNotStop verifies the shutdown
+// contract: the reporter does NOT exit on ctx cancellation; it exits only when
+// its input channel is closed. On a signal stop the ctx is cancelled before the
+// fan-in is torn down, so exiting on ctx would drop the last results still
+// draining out of the fan-in.
+func TestAnalysisReporter_CtxCancelAloneDoesNotStop(t *testing.T) {
 	fake := &fakeSender{}
 	input := make(chan *probe.ProbeResult, 4)
 	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 3600, input)
@@ -119,12 +122,64 @@ func TestAnalysisReporter_CtxCancelStops(t *testing.T) {
 	r.Start(ctx)
 	cancel()
 
+	// The reporter must still be running: Wait must not return on ctx cancel.
 	done := make(chan struct{})
 	go func() { r.Wait(); close(done) }()
 	select {
 	case <-done:
+		t.Fatal("reporter exited on ctx cancellation; it must exit only when input closes")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: still running.
+	}
+
+	// Closing the input is the only thing that stops it.
+	close(input)
+	select {
+	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("reporter did not stop on context cancellation")
+		t.Fatal("reporter did not stop after input closed")
+	}
+}
+
+// TestAnalysisReporter_SignalStopFlushesResultsAfterCtxCancel reproduces the
+// signal-stop ordering the reporter must survive: cmd/agent cancels the Start
+// context first, and only afterward does Agent.Stop tear down the probers and
+// fan-in, pushing the last results and finally closing the input. Those
+// post-cancel results must be aggregated into the final window AND actually
+// sent, even though ctx is already cancelled.
+func TestAnalysisReporter_SignalStopFlushesResultsAfterCtxCancel(t *testing.T) {
+	fake := &fakeSender{}
+	input := make(chan *probe.ProbeResult, 8)
+	// Long window so the periodic ticker never fires: the only send is the
+	// final flush, making the assertion unambiguous.
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 3600, input)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx)
+
+	// Signal stop: context is cancelled FIRST...
+	cancel()
+
+	// ...then the fan-in's final results arrive (as probers are stopped), and
+	// only then is the input closed by stopResultsFanIn.
+	src, tgt := srcGID(1), srcGID(2)
+	input <- validProbeResult(src, tgt, "tor-b", 42)
+	input <- validProbeResult(src, tgt, "tor-b", 42)
+	input <- validProbeResult(src, tgt, "tor-b", 42)
+	close(input)
+
+	r.Wait()
+
+	// All three post-cancel results must be in the final window and delivered.
+	summaries := fake.allSummaries()
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 final summary, got %d (post-cancel results were dropped)", len(summaries))
+	}
+	if got := summaries[0].GetProbeTotal(); got != 3 {
+		t.Errorf("final summary ProbeTotal = %d, want 3 (all post-cancel results aggregated)", got)
+	}
+	if fake.reportCount() != 1 {
+		t.Errorf("final flush was not sent despite cancelled ctx: reportCount = %d, want 1", fake.reportCount())
 	}
 }
 

--- a/rebuild/internal/agent/analysis_reporter_test.go
+++ b/rebuild/internal/agent/analysis_reporter_test.go
@@ -200,6 +200,67 @@ func TestAnalysisReporter_ReportBestEffortOnError(t *testing.T) {
 	}
 }
 
+// TestAnalysisReporter_PeriodicSkippedAfterCancelRecoveredByFinalFlush verifies
+// the fix for the periodic-send-after-cancel data loss: once ctx is cancelled,
+// a periodic collection is skipped entirely, so its completed windows are NOT
+// removed from the aggregator by a Collect whose send would then fail on the
+// cancelled ctx. The windows survive in the aggregator and are delivered by the
+// final flush (independent context) instead.
+func TestAnalysisReporter_PeriodicSkippedAfterCancelRecoveredByFinalFlush(t *testing.T) {
+	fake := &fakeSender{}
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 1, nil) // 1s windows
+
+	// Aggregate two results into window [0, 1e9); pin nowFn past that window so
+	// a periodic Collect would consider it complete (and would remove it).
+	src, tgt := srcGID(1), srcGID(2)
+	r.agg.AddResult(validProbeResult(src, tgt, "tor-b", 42), 0)
+	r.agg.AddResult(validProbeResult(src, tgt, "tor-b", 42), 0)
+	r.nowFn = func() time.Time { return time.Unix(2, 0) } // 2s: window [0,1s) is complete
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shutdown has begun
+
+	// Periodic collection under a cancelled ctx must be a no-op: nothing sent,
+	// and the completed window must remain in the aggregator (not consumed by a
+	// Collect that would then fail to send).
+	r.collectAndReport(ctx)
+	if fake.reportCount() != 0 {
+		t.Fatalf("periodic report ran under cancelled ctx (reportCount=%d, want 0): "+
+			"its Collected window would be lost", fake.reportCount())
+	}
+
+	// The final flush (independent context) must recover and send the window.
+	r.flushFinal()
+	summaries := fake.allSummaries()
+	if len(summaries) != 1 {
+		t.Fatalf("final flush did not recover the window: got %d summaries, want 1", len(summaries))
+	}
+	if got := summaries[0].GetProbeTotal(); got != 2 {
+		t.Errorf("recovered summary ProbeTotal=%d, want 2", got)
+	}
+}
+
+// TestAnalysisReporter_PeriodicCollectsWhenLive is the positive control for the
+// test above: with a live (non-cancelled) ctx, a periodic collection DOES
+// harvest and send the completed window, confirming the skip is specifically
+// gated on ctx cancellation.
+func TestAnalysisReporter_PeriodicCollectsWhenLive(t *testing.T) {
+	fake := &fakeSender{}
+	r := NewAnalysisReporter(fake, "agent-1", "tor-a", 1, nil)
+
+	src, tgt := srcGID(1), srcGID(2)
+	r.agg.AddResult(validProbeResult(src, tgt, "tor-b", 42), 0)
+	r.nowFn = func() time.Time { return time.Unix(2, 0) } // window [0,1s) complete
+
+	r.collectAndReport(context.Background()) // live ctx: must collect + send
+	if fake.reportCount() != 1 {
+		t.Fatalf("live periodic report did not send: reportCount=%d, want 1", fake.reportCount())
+	}
+	if summaries := fake.allSummaries(); len(summaries) != 1 || summaries[0].GetProbeTotal() != 1 {
+		t.Fatalf("live periodic report sent wrong data: %+v", summaries)
+	}
+}
+
 // TestAnalysisReporter_BatchSplitting verifies that more than
 // maxSummariesPerReport summaries are split across multiple bounded reports.
 func TestAnalysisReporter_BatchSplitting(t *testing.T) {

--- a/rebuild/internal/agent/controller_client/controller_client.go
+++ b/rebuild/internal/agent/controller_client/controller_client.go
@@ -153,3 +153,34 @@ func (c *GRPCControllerClient) GetPinglist(
 
 	return resp.GetTargets(), nil
 }
+
+// ReportProbeAnalysis sends a batch of window-aggregated per-path summaries to
+// the controller's analyzer. It is best-effort: the caller (the agent's
+// analysis reporter) drops the batch on any error rather than retrying, so a
+// slow or unreachable controller never stalls active probing. The RPC is
+// bounded by rpcTimeout like the other calls.
+func (c *GRPCControllerClient) ReportProbeAnalysis(
+	ctx context.Context,
+	report *controller_agent.ProbeAnalysisReport,
+) (*controller_agent.ProbeAnalysisAck, error) {
+	c.logger.Debug().
+		Str("agent_id", report.GetAgentId()).
+		Int("summary_count", len(report.GetSummaries())).
+		Msg("Reporting probe analysis to controller")
+
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	resp, err := c.client.ReportProbeAnalysis(rpcCtx, report)
+	if err != nil {
+		return nil, fmt.Errorf("ReportProbeAnalysis RPC failed: %w", err)
+	}
+
+	c.logger.Debug().
+		Str("agent_id", report.GetAgentId()).
+		Bool("accepted", resp.GetAccepted()).
+		Uint32("sla_violations", resp.GetSlaViolations()).
+		Msg("Probe analysis reported")
+
+	return resp, nil
+}

--- a/rebuild/internal/agent/controller_client/controller_client_test.go
+++ b/rebuild/internal/agent/controller_client/controller_client_test.go
@@ -41,6 +41,13 @@ type fakeControllerServer struct {
 	pinglistDelay time.Duration
 	pinglistResp  *controller_agent.PinglistResponse
 	pinglistErr   error
+
+	// reportFunc, if set, handles ReportProbeAnalysis; otherwise a default
+	// accepted=true ack is returned. reportCalls counts invocations and
+	// lastReport captures the most recent request for assertions.
+	reportFunc  func(req *controller_agent.ProbeAnalysisReport) (*controller_agent.ProbeAnalysisAck, error)
+	reportCalls int
+	lastReport  *controller_agent.ProbeAnalysisReport
 }
 
 func (s *fakeControllerServer) RegisterAgent(
@@ -74,6 +81,20 @@ func (s *fakeControllerServer) GetPinglist(
 		return s.pinglistResp, nil
 	}
 	return &controller_agent.PinglistResponse{}, nil
+}
+
+func (s *fakeControllerServer) ReportProbeAnalysis(
+	_ context.Context, req *controller_agent.ProbeAnalysisReport,
+) (*controller_agent.ProbeAnalysisAck, error) {
+	s.mu.Lock()
+	s.reportCalls++
+	s.lastReport = req
+	s.mu.Unlock()
+
+	if s.reportFunc != nil {
+		return s.reportFunc(req)
+	}
+	return &controller_agent.ProbeAnalysisAck{Accepted: true}, nil
 }
 
 // newTestClient starts srv on an in-process bufconn listener and returns a
@@ -242,6 +263,60 @@ func TestGetPinglist_Success(t *testing.T) {
 	}
 	if len(targets) != 2 {
 		t.Fatalf("got %d targets, want 2", len(targets))
+	}
+}
+
+// TestReportProbeAnalysis_Success verifies the happy path: the report is
+// delivered unchanged and the analyzer's ack (accepted + violation count) is
+// returned to the caller.
+func TestReportProbeAnalysis_Success(t *testing.T) {
+	srv := &fakeControllerServer{
+		reportFunc: func(_ *controller_agent.ProbeAnalysisReport) (*controller_agent.ProbeAnalysisAck, error) {
+			return &controller_agent.ProbeAnalysisAck{Accepted: true, SlaViolations: 2}, nil
+		},
+	}
+	c := newTestClient(t, srv)
+
+	report := &controller_agent.ProbeAnalysisReport{
+		AgentId: "agent-1",
+		Summaries: []*controller_agent.PathSummary{
+			{SourceGid: "fe80::1", TargetGid: "fe80::2", ProbeTotal: 100, ProbeFailed: 50},
+		},
+	}
+	ack, err := c.ReportProbeAnalysis(context.Background(), report)
+	if err != nil {
+		t.Fatalf("ReportProbeAnalysis: %v", err)
+	}
+	if !ack.GetAccepted() {
+		t.Errorf("ack.Accepted = false, want true")
+	}
+	if ack.GetSlaViolations() != 2 {
+		t.Errorf("ack.SlaViolations = %d, want 2", ack.GetSlaViolations())
+	}
+	if srv.reportCalls != 1 {
+		t.Errorf("server saw %d ReportProbeAnalysis calls, want 1", srv.reportCalls)
+	}
+	if got := len(srv.lastReport.GetSummaries()); got != 1 {
+		t.Errorf("server received %d summaries, want 1", got)
+	}
+}
+
+// TestReportProbeAnalysis_RPCError verifies that a transport-level error is
+// wrapped and returned with a nil ack, so the reporter can drop the batch.
+func TestReportProbeAnalysis_RPCError(t *testing.T) {
+	srv := &fakeControllerServer{
+		reportFunc: func(_ *controller_agent.ProbeAnalysisReport) (*controller_agent.ProbeAnalysisAck, error) {
+			return nil, status.Error(codes.Unavailable, "controller busy")
+		},
+	}
+	c := newTestClient(t, srv)
+
+	ack, err := c.ReportProbeAnalysis(context.Background(), &controller_agent.ProbeAnalysisReport{AgentId: "agent-1"})
+	if err == nil {
+		t.Fatal("ReportProbeAnalysis: want error, got nil")
+	}
+	if ack != nil {
+		t.Errorf("ack = %+v, want nil on RPC error", ack)
 	}
 }
 

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -194,8 +194,8 @@ type pendingProbe struct {
 // processes first and second ACK responses via its event ring, and
 // produces ProbeResult values on a buffered channel.
 type Prober struct {
-	queue *rdmabridge.Queue
-	ring  *rdmabridge.EventRing
+	queue  *rdmabridge.Queue
+	ring   *rdmabridge.EventRing
 	device *rdmabridge.Device
 	// sourceGID is the parsed 16-byte GID of the bound device, stamped onto
 	// every emitted ProbeResult so the per-path aggregator can key results by

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -194,9 +194,14 @@ type pendingProbe struct {
 // processes first and second ACK responses via its event ring, and
 // produces ProbeResult values on a buffered channel.
 type Prober struct {
-	queue         *rdmabridge.Queue
-	ring          *rdmabridge.EventRing
-	device        *rdmabridge.Device
+	queue *rdmabridge.Queue
+	ring  *rdmabridge.EventRing
+	device *rdmabridge.Device
+	// sourceGID is the parsed 16-byte GID of the bound device, stamped onto
+	// every emitted ProbeResult so the per-path aggregator can key results by
+	// (source, target). Parsed once at construction; zero if the device GID is
+	// unparseable or the Prober was built without a device (test fakes).
+	sourceGID     [16]byte
 	targets       []*controller_agent.PingTarget
 	targetsMu     sync.RWMutex
 	pending       map[uint64]*pendingProbe // sequence_num -> pending probe info
@@ -277,10 +282,19 @@ func NewProber(device *rdmabridge.Device, ring *rdmabridge.EventRing, probeInter
 		return nil, err
 	}
 
+	// Parse the device GID once so every emitted result can carry its source
+	// without re-parsing. Best-effort: a parse failure leaves sourceGID zero,
+	// which only means such results are not path-aggregated.
+	var sourceGID [16]byte
+	if gid, err := probe.ParseGID(device.Info.GID); err == nil {
+		sourceGID = gid
+	}
+
 	p := &Prober{
 		queue:                      queue,
 		ring:                       ring,
 		device:                     device,
+		sourceGID:                  sourceGID,
 		pending:                    make(map[uint64]*pendingProbe),
 		agentEpoch:                 rand.Uint32(),
 		resultChan:                 make(chan *probe.ProbeResult, resultChanSize),
@@ -942,6 +956,10 @@ func newFailedResult(seqNum uint64, target *controller_agent.PingTarget, flowLab
 // hold pendingMu at the call site's caller); a full channel drops the result
 // with a warning.
 func (p *Prober) emitResult(result *probe.ProbeResult) {
+	// Stamp the source RNIC GID so downstream per-path aggregation can key by
+	// (source, target). Single-writer point: the result is still owned by the
+	// prober here, before any consumer sees it.
+	result.SourceGID = p.sourceGID
 	select {
 	case p.resultChan <- result:
 	default:

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -18,6 +18,12 @@ const DefaultTargetProbeRatePerSecond = 10
 // for time-series continuity. 3600s (1h) matches the R-Pingmesh paper.
 const DefaultFlowLabelRotationPeriodSec = 3600
 
+// DefaultAnalysisWindowSec is the default aggregation window (seconds) over
+// which the agent's PathAggregator groups per-path probe results before
+// reporting a summary to the controller's analyzer. 30s balances reporting
+// volume against detection latency.
+const DefaultAnalysisWindowSec = 30
+
 // AgentConfig holds all configuration for the agent.
 type AgentConfig struct {
 	AgentID                   string   `mapstructure:"agent_id"`
@@ -36,6 +42,14 @@ type AgentConfig struct {
 	// of each target's ECMP flow-label set is refreshed (time-based ECMP path
 	// rotation). See DefaultFlowLabelRotationPeriodSec.
 	FlowLabelRotationPeriodSec uint32 `mapstructure:"flow_label_rotation_period_sec"`
+
+	// AnalysisReportEnabled turns on per-path window aggregation and reporting
+	// of PathSummary batches to the controller's analyzer via
+	// ReportProbeAnalysis. Reporting is best-effort and never blocks probing.
+	AnalysisReportEnabled bool `mapstructure:"analysis_report_enabled"`
+	// AnalysisWindowSec is the aggregation window length in seconds. See
+	// DefaultAnalysisWindowSec.
+	AnalysisWindowSec uint32 `mapstructure:"analysis_window_sec"`
 }
 
 // LoadAgentConfig loads agent configuration from a YAML file, environment
@@ -62,6 +76,8 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	v.SetDefault("pinglist_update_interval_sec", 300)
 	v.SetDefault("target_probe_rate_per_second", DefaultTargetProbeRatePerSecond)
 	v.SetDefault("flow_label_rotation_period_sec", DefaultFlowLabelRotationPeriodSec)
+	v.SetDefault("analysis_report_enabled", true)
+	v.SetDefault("analysis_window_sec", DefaultAnalysisWindowSec)
 
 	// Enable environment variable override with RPINGMESH_ prefix.
 	// Underscores in env var names map to underscores in config keys.
@@ -128,6 +144,8 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 		PinglistUpdateIntervalSec:  v.GetUint32("pinglist_update_interval_sec"),
 		TargetProbeRatePerSecond:   v.GetInt("target_probe_rate_per_second"),
 		FlowLabelRotationPeriodSec: v.GetUint32("flow_label_rotation_period_sec"),
+		AnalysisReportEnabled:      v.GetBool("analysis_report_enabled"),
+		AnalysisWindowSec:          v.GetUint32("analysis_window_sec"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -156,6 +174,12 @@ func (c *AgentConfig) Validate() error {
 		return fmt.Errorf("flow_label_rotation_period_sec must be > 0, got: %d", c.FlowLabelRotationPeriodSec)
 	}
 
+	// When analysis reporting is on, the window drives a time.Ticker and the
+	// aggregator's window alignment, both of which require a positive length.
+	if c.AnalysisReportEnabled && c.AnalysisWindowSec == 0 {
+		return fmt.Errorf("analysis_window_sec must be > 0 when analysis_report_enabled, got: %d", c.AnalysisWindowSec)
+	}
+
 	return nil
 }
 
@@ -174,4 +198,6 @@ func BindAgentFlags(flags *pflag.FlagSet) {
 	flags.Uint32("pinglist-update-interval-sec", 300, "Pinglist update interval in seconds")
 	flags.Int("target-probe-rate-per-second", DefaultTargetProbeRatePerSecond, "Probe rate per second per target")
 	flags.Uint32("flow-label-rotation-period-sec", DefaultFlowLabelRotationPeriodSec, "Period (seconds) over which the rotating ~20% of each target's ECMP flow-label set is refreshed")
+	flags.Bool("analysis-report-enabled", true, "Enable per-path window aggregation and SLA reporting to the controller")
+	flags.Uint32("analysis-window-sec", DefaultAnalysisWindowSec, "Per-path aggregation window length in seconds")
 }

--- a/rebuild/internal/config/controller_config.go
+++ b/rebuild/internal/config/controller_config.go
@@ -45,6 +45,20 @@ const (
 	// target carry a ~1M-entry label set/map and stall or OOM the agent. The
 	// agent enforces the same 4096 clamp as defense in depth.
 	MaxEcmpFlowLabels = 4096
+
+	// DefaultAnalyzerSLALossRatio is the default per-path loss ratio
+	// (probe_failed / probe_total) above which the analyzer flags a window as
+	// a loss SLA violation.
+	DefaultAnalyzerSLALossRatio = 0.02
+	// DefaultAnalyzerSLANetworkRTTP99Ns is the default per-path p99 network-RTT
+	// threshold (ns) above which the analyzer flags an RTT SLA violation.
+	DefaultAnalyzerSLANetworkRTTP99Ns = 500_000
+	// DefaultAnalyzerWindowRetention is the default number of distinct windows
+	// the analyzer retains in its in-memory ring.
+	DefaultAnalyzerWindowRetention = 20
+	// DefaultControllerOtelCollectorAddr is the default OTLP gRPC collector
+	// endpoint the analyzer exports its metrics to.
+	DefaultControllerOtelCollectorAddr = "localhost:4317"
 )
 
 // ControllerConfig holds all configuration for the controller.
@@ -61,6 +75,17 @@ type ControllerConfig struct {
 	EcmpPathsAssumed        int     `mapstructure:"ecmp_paths_assumed"`
 	EcmpCoverageProbability float64 `mapstructure:"ecmp_coverage_probability"`
 	EcmpMaxFlowLabels       int     `mapstructure:"ecmp_max_flow_labels"`
+
+	// Analyzer (Phase 1) settings. AnalyzerEnabled turns on ingestion of
+	// agent-reported per-path summaries and SLA-violation detection.
+	AnalyzerEnabled            bool    `mapstructure:"analyzer_enabled"`
+	AnalyzerSLALossRatio       float64 `mapstructure:"analyzer_sla_loss_ratio"`
+	AnalyzerSLANetworkRTTP99Ns uint64  `mapstructure:"analyzer_sla_network_rtt_p99_ns"`
+	AnalyzerWindowRetention    int     `mapstructure:"analyzer_window_retention"`
+	// OtelCollectorAddr is the OTLP gRPC endpoint the analyzer exports its
+	// metrics to (service.name=rpingmesh-analyzer). Only used when the analyzer
+	// is enabled; export is best-effort.
+	OtelCollectorAddr string `mapstructure:"otel_collector_addr"`
 }
 
 // LoadControllerConfig loads controller configuration from a YAML file,
@@ -83,6 +108,11 @@ func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerC
 	v.SetDefault("ecmp_paths_assumed", DefaultEcmpPathsAssumed)
 	v.SetDefault("ecmp_coverage_probability", DefaultEcmpCoverageProbability)
 	v.SetDefault("ecmp_max_flow_labels", DefaultEcmpMaxFlowLabels)
+	v.SetDefault("analyzer_enabled", true)
+	v.SetDefault("analyzer_sla_loss_ratio", DefaultAnalyzerSLALossRatio)
+	v.SetDefault("analyzer_sla_network_rtt_p99_ns", DefaultAnalyzerSLANetworkRTTP99Ns)
+	v.SetDefault("analyzer_window_retention", DefaultAnalyzerWindowRetention)
+	v.SetDefault("otel_collector_addr", DefaultControllerOtelCollectorAddr)
 
 	// Enable environment variable override with RPINGMESH_ prefix
 	v.SetEnvPrefix("RPINGMESH")
@@ -128,6 +158,12 @@ func LoadControllerConfig(configPath string, flags *pflag.FlagSet) (*ControllerC
 		EcmpPathsAssumed:        v.GetInt("ecmp_paths_assumed"),
 		EcmpCoverageProbability: v.GetFloat64("ecmp_coverage_probability"),
 		EcmpMaxFlowLabels:       v.GetInt("ecmp_max_flow_labels"),
+
+		AnalyzerEnabled:            v.GetBool("analyzer_enabled"),
+		AnalyzerSLALossRatio:       v.GetFloat64("analyzer_sla_loss_ratio"),
+		AnalyzerSLANetworkRTTP99Ns: v.GetUint64("analyzer_sla_network_rtt_p99_ns"),
+		AnalyzerWindowRetention:    v.GetInt("analyzer_window_retention"),
+		OtelCollectorAddr:          v.GetString("otel_collector_addr"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -207,6 +243,20 @@ func (c *ControllerConfig) Validate() error {
 		return fmt.Errorf("ecmp_max_flow_labels must be <= %d, got: %d", MaxEcmpFlowLabels, c.EcmpMaxFlowLabels)
 	}
 
+	// Analyzer settings are only enforced when the analyzer is enabled.
+	if c.AnalyzerEnabled {
+		// A loss ratio is a probability in [0, 1]; outside that range the
+		// threshold is meaningless (a negative ratio flags everything, > 1
+		// flags nothing).
+		if c.AnalyzerSLALossRatio < 0 || c.AnalyzerSLALossRatio > 1 {
+			return fmt.Errorf("analyzer_sla_loss_ratio must be in [0, 1], got: %v", c.AnalyzerSLALossRatio)
+		}
+		// The window ring must retain at least one window.
+		if c.AnalyzerWindowRetention < 1 {
+			return fmt.Errorf("analyzer_window_retention must be >= 1, got: %d", c.AnalyzerWindowRetention)
+		}
+	}
+
 	return nil
 }
 
@@ -222,4 +272,9 @@ func BindControllerFlags(flags *pflag.FlagSet) {
 	flags.Int("ecmp-paths-assumed", DefaultEcmpPathsAssumed, "Assumed ECMP fabric width (m) for Eq.(1) flow-label coverage sizing")
 	flags.Float64("ecmp-coverage-probability", DefaultEcmpCoverageProbability, "Target probability (p, in (0,1)) that generated flow labels cover all ECMP paths")
 	flags.Int("ecmp-max-flow-labels", DefaultEcmpMaxFlowLabels, "Hard cap on the number of flow labels per target (bounds probe amplification)")
+	flags.Bool("analyzer-enabled", true, "Enable the Phase 1 analyzer (ingest agent summaries, detect SLA violations)")
+	flags.Float64("analyzer-sla-loss-ratio", DefaultAnalyzerSLALossRatio, "Per-path loss ratio (0..1) above which a window is an SLA violation")
+	flags.Uint64("analyzer-sla-network-rtt-p99-ns", DefaultAnalyzerSLANetworkRTTP99Ns, "Per-path p99 network-RTT threshold (ns) above which a window is an SLA violation (0 disables)")
+	flags.Int("analyzer-window-retention", DefaultAnalyzerWindowRetention, "Number of recent windows the analyzer retains in memory")
+	flags.String("otel-collector-addr", DefaultControllerOtelCollectorAddr, "OTLP gRPC collector endpoint for analyzer metrics")
 }

--- a/rebuild/internal/controller/analyzer/analyzer.go
+++ b/rebuild/internal/controller/analyzer/analyzer.go
@@ -1,0 +1,193 @@
+// Package analyzer implements the controller-side, Phase 1 R-Pingmesh analyzer:
+// it ingests per-path window summaries reported by agents, retains the most
+// recent windows in memory, and flags per-path SLA violations (loss ratio and
+// p99 network-RTT threshold breaches).
+//
+// It is deliberately in-process with the controller (a separate package so it
+// can later be split into a standalone binary): the topology needed for
+// cross-agent fault localization already lives in the controller's registry.
+// Phase 1 does no topology join; switch/link localization is Phase 2.
+package analyzer
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// Violation kinds, used as the "kind" metric attribute and in finding logs.
+const (
+	KindLoss = "loss"
+	KindRTT  = "rtt"
+)
+
+// Config holds the analyzer's SLA thresholds and retention.
+type Config struct {
+	// SLALossRatio is the per-path loss ratio (probe_failed / probe_total)
+	// above which a window is flagged as a loss violation.
+	SLALossRatio float64
+	// SLANetworkRTTP99Ns is the per-path p99 network-RTT threshold (ns) above
+	// which a window is flagged as an RTT violation. 0 disables the RTT check.
+	SLANetworkRTTP99Ns uint64
+	// WindowRetention is the number of distinct windows retained in the
+	// in-memory ring (oldest evicted first). Must be >= 1.
+	WindowRetention int
+}
+
+// windowBucket groups the summaries retained for one aggregation window,
+// identified by its wall-clock start. Kept for recency/retention and as the
+// substrate a future Phase 2 cross-agent localization pass would read.
+type windowBucket struct {
+	windowStartUnixNs uint64
+	summaries         []*controller_agent.PathSummary
+}
+
+// Analyzer ingests reported summaries, retains recent windows, and detects SLA
+// violations. It is safe for concurrent use (Ingest may be called from many
+// gRPC handler goroutines).
+type Analyzer struct {
+	cfg     Config
+	metrics *Metrics
+	logger  zerolog.Logger
+
+	mu sync.Mutex
+	// ring holds recent window buckets sorted ascending by windowStartUnixNs;
+	// its length is capped at cfg.WindowRetention.
+	ring []*windowBucket
+}
+
+// New creates an Analyzer with the given config and metrics (metrics may be
+// nil, in which case findings are logged but no OTLP metrics are emitted).
+// WindowRetention is clamped to at least 1.
+func New(cfg Config, metrics *Metrics) *Analyzer {
+	if cfg.WindowRetention < 1 {
+		cfg.WindowRetention = 1
+	}
+	return &Analyzer{
+		cfg:     cfg,
+		metrics: metrics,
+		logger:  log.With().Str("component", "analyzer").Logger(),
+	}
+}
+
+// Ingest processes one reported batch of per-path window summaries: it records
+// each summary, evaluates SLA thresholds, emits findings (logs + metrics), and
+// retains the summaries in the in-memory window ring. It returns the number of
+// summaries flagged with at least one SLA violation.
+func (a *Analyzer) Ingest(ctx context.Context, report *controller_agent.ProbeAnalysisReport) int {
+	if report == nil {
+		return 0
+	}
+
+	agentID := report.GetAgentId()
+	summaries := report.GetSummaries()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	violatingSummaries := 0
+	for _, s := range summaries {
+		if s == nil {
+			continue
+		}
+		a.metrics.recordSummary(ctx)
+		a.retainLocked(s)
+
+		if a.evaluate(ctx, agentID, s) {
+			violatingSummaries++
+		}
+	}
+	return violatingSummaries
+}
+
+// evaluate checks a single summary against the SLA thresholds, emitting a
+// finding (log + metric) for each breach. It returns true if the summary
+// breached at least one threshold.
+func (a *Analyzer) evaluate(ctx context.Context, agentID string, s *controller_agent.PathSummary) bool {
+	sourceTor := s.GetSourceTorId()
+	targetTor := s.GetTargetTorId()
+	violated := false
+
+	// Loss violation: probe_failed / probe_total over the threshold. Guarded
+	// by probe_total > 0 to avoid a spurious ratio on an empty window.
+	if total := s.GetProbeTotal(); total > 0 {
+		loss := float64(s.GetProbeFailed()) / float64(total)
+		if loss > a.cfg.SLALossRatio {
+			violated = true
+			a.metrics.recordViolation(ctx, sourceTor, targetTor, KindLoss)
+			a.logFinding(agentID, s, KindLoss).
+				Float64("loss_ratio", loss).
+				Float64("threshold", a.cfg.SLALossRatio).
+				Msg("SLA violation: packet loss")
+		}
+	}
+
+	// RTT violation: p99 network RTT over the threshold (0 disables the check).
+	if a.cfg.SLANetworkRTTP99Ns > 0 && s.GetNetworkRttP99Ns() > a.cfg.SLANetworkRTTP99Ns {
+		violated = true
+		a.metrics.recordViolation(ctx, sourceTor, targetTor, KindRTT)
+		a.logFinding(agentID, s, KindRTT).
+			Uint64("p99_rtt_ns", s.GetNetworkRttP99Ns()).
+			Uint64("threshold_ns", a.cfg.SLANetworkRTTP99Ns).
+			Msg("SLA violation: high p99 network RTT")
+	}
+
+	return violated
+}
+
+// logFinding builds a Warn-level event pre-populated with the identifying
+// fields common to every finding. GID-level detail is included here (findings
+// logs), never as a metric attribute.
+func (a *Analyzer) logFinding(agentID string, s *controller_agent.PathSummary, kind string) *zerolog.Event {
+	return a.logger.Warn().
+		Str("kind", kind).
+		Str("agent_id", agentID).
+		Str("source_gid", s.GetSourceGid()).
+		Str("source_tor", s.GetSourceTorId()).
+		Str("target_gid", s.GetTargetGid()).
+		Str("target_tor", s.GetTargetTorId()).
+		Uint32("probe_total", s.GetProbeTotal()).
+		Uint32("probe_failed", s.GetProbeFailed()).
+		Uint64("window_start_unix_ns", s.GetWindowStartUnixNs())
+}
+
+// retainLocked inserts a summary into the window ring under its window-start
+// bucket, creating the bucket if needed and evicting the oldest window when the
+// distinct-window count exceeds cfg.WindowRetention. Caller must hold a.mu.
+func (a *Analyzer) retainLocked(s *controller_agent.PathSummary) {
+	ws := s.GetWindowStartUnixNs()
+
+	// Locate an existing bucket for this window (ring is small: retention count).
+	for _, b := range a.ring {
+		if b.windowStartUnixNs == ws {
+			b.summaries = append(b.summaries, s)
+			return
+		}
+	}
+
+	// New window: insert keeping the ring sorted ascending by window start.
+	b := &windowBucket{windowStartUnixNs: ws, summaries: []*controller_agent.PathSummary{s}}
+	idx := sort.Search(len(a.ring), func(i int) bool {
+		return a.ring[i].windowStartUnixNs >= ws
+	})
+	a.ring = append(a.ring, nil)
+	copy(a.ring[idx+1:], a.ring[idx:])
+	a.ring[idx] = b
+
+	// Evict oldest windows beyond the retention cap.
+	if len(a.ring) > a.cfg.WindowRetention {
+		a.ring = a.ring[len(a.ring)-a.cfg.WindowRetention:]
+	}
+}
+
+// RetainedWindows returns the number of distinct windows currently retained in
+// the ring. Exposed for tests and diagnostics.
+func (a *Analyzer) RetainedWindows() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.ring)
+}

--- a/rebuild/internal/controller/analyzer/analyzer_test.go
+++ b/rebuild/internal/controller/analyzer/analyzer_test.go
@@ -1,0 +1,146 @@
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+func testConfig() Config {
+	return Config{
+		SLALossRatio:       0.02,
+		SLANetworkRTTP99Ns: 500_000,
+		WindowRetention:    3,
+	}
+}
+
+func summary(sourceTor, targetTor string, total, failed uint32, p99 uint64, windowStart uint64) *controller_agent.PathSummary {
+	return &controller_agent.PathSummary{
+		SourceGid:         "fe80::1",
+		SourceTorId:       sourceTor,
+		TargetGid:         "fe80::2",
+		TargetTorId:       targetTor,
+		ProbeTotal:        total,
+		ProbeFailed:       failed,
+		ProbeSuccess:      total - failed,
+		NetworkRttP99Ns:   p99,
+		WindowStartUnixNs: windowStart,
+	}
+}
+
+func report(summaries ...*controller_agent.PathSummary) *controller_agent.ProbeAnalysisReport {
+	return &controller_agent.ProbeAnalysisReport{
+		AgentId:   "agent-1",
+		Summaries: summaries,
+	}
+}
+
+func TestAnalyzer_LossViolationThreshold(t *testing.T) {
+	a := New(testConfig(), nil)
+	ctx := context.Background()
+
+	// loss = 2/100 = 0.02 == threshold: NOT a violation (strictly greater).
+	if v := a.Ingest(ctx, report(summary("tor-a", "tor-b", 100, 2, 0, 1))); v != 0 {
+		t.Errorf("loss exactly at threshold: got %d violations, want 0", v)
+	}
+	// loss = 3/100 = 0.03 > 0.02: violation.
+	if v := a.Ingest(ctx, report(summary("tor-a", "tor-b", 100, 3, 0, 2))); v != 1 {
+		t.Errorf("loss above threshold: got %d violations, want 1", v)
+	}
+	// loss = 1/100 = 0.01 < threshold: no violation.
+	if v := a.Ingest(ctx, report(summary("tor-a", "tor-b", 100, 1, 0, 3))); v != 0 {
+		t.Errorf("loss below threshold: got %d violations, want 0", v)
+	}
+}
+
+func TestAnalyzer_RTTViolationThreshold(t *testing.T) {
+	a := New(testConfig(), nil)
+	ctx := context.Background()
+
+	// p99 == threshold: not a violation (strictly greater).
+	if v := a.Ingest(ctx, report(summary("tor-a", "tor-b", 100, 0, 500_000, 1))); v != 0 {
+		t.Errorf("p99 at threshold: got %d, want 0", v)
+	}
+	// p99 above threshold: violation.
+	if v := a.Ingest(ctx, report(summary("tor-a", "tor-b", 100, 0, 500_001, 2))); v != 1 {
+		t.Errorf("p99 above threshold: got %d, want 1", v)
+	}
+}
+
+func TestAnalyzer_BothViolationsCountSummaryOnce(t *testing.T) {
+	a := New(testConfig(), nil)
+	ctx := context.Background()
+
+	// A single summary breaching BOTH loss and RTT counts as one violating
+	// summary (the ack reports violating summaries, not per-kind breaches).
+	s := summary("tor-a", "tor-b", 100, 50, 1_000_000, 1)
+	if v := a.Ingest(ctx, report(s)); v != 1 {
+		t.Errorf("summary breaching both thresholds: got %d, want 1", v)
+	}
+}
+
+func TestAnalyzer_RTTCheckDisabledWhenThresholdZero(t *testing.T) {
+	cfg := testConfig()
+	cfg.SLANetworkRTTP99Ns = 0 // disable RTT check
+	a := New(cfg, nil)
+
+	// Huge p99 but no loss: with the RTT check disabled, no violation.
+	if v := a.Ingest(context.Background(), report(summary("tor-a", "tor-b", 100, 0, 9_000_000, 1))); v != 0 {
+		t.Errorf("RTT check disabled: got %d violations, want 0", v)
+	}
+}
+
+func TestAnalyzer_ZeroTotalNoDivideByZero(t *testing.T) {
+	a := New(testConfig(), nil)
+	// Empty window (total 0) must not panic nor be flagged as loss.
+	if v := a.Ingest(context.Background(), report(summary("tor-a", "tor-b", 0, 0, 0, 1))); v != 0 {
+		t.Errorf("empty window: got %d violations, want 0", v)
+	}
+}
+
+func TestAnalyzer_MultipleSummariesInReport(t *testing.T) {
+	a := New(testConfig(), nil)
+	ctx := context.Background()
+
+	// Two violating (loss, rtt) + one clean summary in one report.
+	v := a.Ingest(ctx, report(
+		summary("tor-a", "tor-b", 100, 10, 0, 1),      // loss violation
+		summary("tor-a", "tor-c", 100, 0, 800_000, 1), // rtt violation
+		summary("tor-a", "tor-d", 100, 0, 100_000, 1), // clean
+	))
+	if v != 2 {
+		t.Errorf("got %d violating summaries, want 2", v)
+	}
+}
+
+func TestAnalyzer_WindowRetentionRing(t *testing.T) {
+	cfg := testConfig()
+	cfg.WindowRetention = 3
+	a := New(cfg, nil)
+	ctx := context.Background()
+
+	// Ingest 5 distinct windows; only the last 3 must be retained.
+	for w := uint64(1); w <= 5; w++ {
+		a.Ingest(ctx, report(summary("tor-a", "tor-b", 100, 0, 0, w)))
+	}
+	if got := a.RetainedWindows(); got != 3 {
+		t.Errorf("RetainedWindows = %d, want 3 (ring capped at retention)", got)
+	}
+
+	// Summaries sharing a window start coalesce into one retained window.
+	a.Ingest(ctx, report(
+		summary("tor-a", "tor-b", 100, 0, 0, 5),
+		summary("tor-a", "tor-c", 100, 0, 0, 5),
+	))
+	if got := a.RetainedWindows(); got != 3 {
+		t.Errorf("RetainedWindows = %d, want 3 after same-window ingest", got)
+	}
+}
+
+func TestAnalyzer_NilReportSafe(t *testing.T) {
+	a := New(testConfig(), nil)
+	if v := a.Ingest(context.Background(), nil); v != 0 {
+		t.Errorf("nil report: got %d, want 0", v)
+	}
+}

--- a/rebuild/internal/controller/analyzer/metrics.go
+++ b/rebuild/internal/controller/analyzer/metrics.go
@@ -1,0 +1,67 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Metrics holds the analyzer's OTLP instruments. All attributes are ToR-level
+// only (source_tor, target_tor, kind), matching the project-wide convention of
+// never using GID-level cardinality on metrics; GID detail goes to findings
+// logs. A nil *Metrics is a valid no-op, so the analyzer can run (logs only)
+// when metrics export is unavailable.
+type Metrics struct {
+	slaViolations metric.Int64Counter
+	pathSummaries metric.Int64Counter
+}
+
+// NewMetrics registers the analyzer instruments on the given meter. The meter
+// is expected to come from a MeterProvider tagged service.name=rpingmesh-analyzer.
+func NewMetrics(meter metric.Meter) (*Metrics, error) {
+	pathSummaries, err := meter.Int64Counter(
+		"rpingmesh.analyzer.path_summaries_total",
+		metric.WithDescription("Total number of per-path window summaries ingested by the analyzer"),
+		metric.WithUnit("{summary}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create path_summaries_total counter: %w", err)
+	}
+
+	slaViolations, err := meter.Int64Counter(
+		"rpingmesh.analyzer.sla_violations_total",
+		metric.WithDescription("Total number of SLA violations detected (by kind: loss or rtt)"),
+		metric.WithUnit("{violation}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create sla_violations_total counter: %w", err)
+	}
+
+	return &Metrics{
+		slaViolations: slaViolations,
+		pathSummaries: pathSummaries,
+	}, nil
+}
+
+// recordSummary increments the ingested-summary counter.
+func (m *Metrics) recordSummary(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.pathSummaries.Add(ctx, 1)
+}
+
+// recordViolation increments the SLA-violation counter for the given ToR pair
+// and violation kind.
+func (m *Metrics) recordViolation(ctx context.Context, sourceTor, targetTor, kind string) {
+	if m == nil {
+		return
+	}
+	m.slaViolations.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("source_tor", sourceTor),
+		attribute.String("target_tor", targetTor),
+		attribute.String("kind", kind),
+	))
+}

--- a/rebuild/internal/controller/service.go
+++ b/rebuild/internal/controller/service.go
@@ -22,6 +22,14 @@ type registryClient interface {
 	RegisterRNICs(ctx context.Context, agentID, agentIP string, rnics []*controller_agent.RnicInfo) error
 }
 
+// probeAnalyzer is the subset of the analyzer used by ReportProbeAnalysis,
+// declared at the point of use so the service can be unit tested against a
+// fake and so the controller package does not hard-depend on the analyzer's
+// concrete type. Ingest returns the number of SLA-violating summaries.
+type probeAnalyzer interface {
+	Ingest(ctx context.Context, report *controller_agent.ProbeAnalysisReport) int
+}
+
 // ControllerService implements the gRPC ControllerService defined in
 // controller_agent.proto. It handles agent registration and pinglist
 // distribution.
@@ -29,6 +37,10 @@ type ControllerService struct {
 	controller_agent.UnimplementedControllerServiceServer
 	registry registryClient
 	pinglist *pinglist.PinglistGenerator
+	// analyzer ingests reported per-path summaries and detects SLA violations.
+	// nil when the analyzer is disabled, in which case ReportProbeAnalysis
+	// accepts-and-drops.
+	analyzer probeAnalyzer
 }
 
 // NewControllerService creates a new ControllerService backed by the given
@@ -40,6 +52,13 @@ func NewControllerService(reg registryClient, ecmp pinglist.ECMPConfig) *Control
 		registry: reg,
 		pinglist: pinglist.NewPinglistGenerator(reg, ecmp),
 	}
+}
+
+// SetAnalyzer wires an analyzer into the service so ReportProbeAnalysis ingests
+// reported summaries. It is optional: with no analyzer set, ReportProbeAnalysis
+// accepts-and-drops. Call before serving.
+func (s *ControllerService) SetAnalyzer(a probeAnalyzer) {
+	s.analyzer = a
 }
 
 // RegisterAgent registers an agent and all of its RNICs with the controller.
@@ -146,5 +165,40 @@ func (s *ControllerService) GetPinglist(
 	return &controller_agent.PinglistResponse{
 		Targets: targets,
 		Type:    req.GetType(),
+	}, nil
+}
+
+// ReportProbeAnalysis ingests a batch of per-path window summaries reported by
+// an agent and returns an ack carrying the number of SLA-violating summaries
+// the analyzer detected. When no analyzer is configured, it accepts-and-drops
+// (Accepted=false) so agents (which treat reporting as best-effort) are not
+// forced to error.
+func (s *ControllerService) ReportProbeAnalysis(
+	ctx context.Context,
+	req *controller_agent.ProbeAnalysisReport,
+) (*controller_agent.ProbeAnalysisAck, error) {
+	if req.GetAgentId() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "agent_id is required")
+	}
+
+	if s.analyzer == nil {
+		log.Debug().
+			Str("agentID", req.GetAgentId()).
+			Int("summaryCount", len(req.GetSummaries())).
+			Msg("ReportProbeAnalysis received but analyzer is disabled; dropping")
+		return &controller_agent.ProbeAnalysisAck{Accepted: false}, nil
+	}
+
+	violations := s.analyzer.Ingest(ctx, req)
+
+	log.Debug().
+		Str("agentID", req.GetAgentId()).
+		Int("summaryCount", len(req.GetSummaries())).
+		Int("slaViolations", violations).
+		Msg("Ingested probe analysis report")
+
+	return &controller_agent.ProbeAnalysisAck{
+		Accepted:      true,
+		SlaViolations: uint32(violations),
 	}, nil
 }

--- a/rebuild/internal/controller/service_analysis_test.go
+++ b/rebuild/internal/controller/service_analysis_test.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+	"google.golang.org/grpc/codes"
+)
+
+// fakeAnalyzer records ingest calls and returns a scripted violation count so
+// the ReportProbeAnalysis handler can be tested without the real analyzer.
+type fakeAnalyzer struct {
+	calls      int
+	lastReport *controller_agent.ProbeAnalysisReport
+	violations int
+}
+
+func (f *fakeAnalyzer) Ingest(_ context.Context, r *controller_agent.ProbeAnalysisReport) int {
+	f.calls++
+	f.lastReport = r
+	return f.violations
+}
+
+func TestReportProbeAnalysis_WithAnalyzer(t *testing.T) {
+	svc := newTestService(&fakeRegistry{})
+	az := &fakeAnalyzer{violations: 2}
+	svc.SetAnalyzer(az)
+
+	report := &controller_agent.ProbeAnalysisReport{
+		AgentId: "agent-1",
+		Summaries: []*controller_agent.PathSummary{
+			summaryFixture("tor-a", "tor-b", 100, 50),
+		},
+	}
+	ack, err := svc.ReportProbeAnalysis(context.Background(), report)
+	if err != nil {
+		t.Fatalf("ReportProbeAnalysis: %v", err)
+	}
+	if !ack.GetAccepted() {
+		t.Errorf("Accepted = false, want true")
+	}
+	if ack.GetSlaViolations() != 2 {
+		t.Errorf("SlaViolations = %d, want 2", ack.GetSlaViolations())
+	}
+	if az.calls != 1 {
+		t.Errorf("analyzer.Ingest calls = %d, want 1", az.calls)
+	}
+	if got := len(az.lastReport.GetSummaries()); got != 1 {
+		t.Errorf("analyzer saw %d summaries, want 1", got)
+	}
+}
+
+func TestReportProbeAnalysis_NoAnalyzer(t *testing.T) {
+	svc := newTestService(&fakeRegistry{})
+
+	ack, err := svc.ReportProbeAnalysis(context.Background(), &controller_agent.ProbeAnalysisReport{
+		AgentId: "agent-1",
+	})
+	if err != nil {
+		t.Fatalf("ReportProbeAnalysis: %v", err)
+	}
+	if ack.GetAccepted() {
+		t.Errorf("Accepted = true, want false when analyzer disabled")
+	}
+}
+
+func TestReportProbeAnalysis_EmptyAgentID(t *testing.T) {
+	svc := newTestService(&fakeRegistry{})
+	svc.SetAnalyzer(&fakeAnalyzer{})
+
+	_, err := svc.ReportProbeAnalysis(context.Background(), &controller_agent.ProbeAnalysisReport{})
+	if err == nil {
+		t.Fatal("expected InvalidArgument for empty agent_id, got nil")
+	}
+	if code := statusCode(t, err); code != codes.InvalidArgument {
+		t.Errorf("status code = %v, want InvalidArgument", code)
+	}
+}
+
+func summaryFixture(sourceTor, targetTor string, total, failed uint32) *controller_agent.PathSummary {
+	return &controller_agent.PathSummary{
+		SourceGid:    "fe80::1",
+		SourceTorId:  sourceTor,
+		TargetGid:    "fe80::2",
+		TargetTorId:  targetTor,
+		ProbeTotal:   total,
+		ProbeFailed:  failed,
+		ProbeSuccess: total - failed,
+	}
+}

--- a/rebuild/internal/probe/aggregator.go
+++ b/rebuild/internal/probe/aggregator.go
@@ -1,0 +1,280 @@
+package probe
+
+import (
+	"sort"
+	"sync"
+)
+
+// PathKey identifies a single probe path: the source RNIC (this agent) and the
+// target RNIC. Aggregation is keyed by (source, target) rather than by target
+// alone so that a multi-rail host, where several local RNICs probe the same
+// target, keeps each source RNIC's path distinct.
+type PathKey struct {
+	SourceGID [16]byte
+	TargetGID [16]byte
+}
+
+// PathSummary is a window-aggregated summary of one probe path. It mirrors the
+// controller_agent.PathSummary proto but lives in the RDMA-independent probe
+// package so aggregation stays pure Go and unit-testable. SourceTorID is not
+// carried here: it is an agent-wide constant that the analysis reporter stamps
+// when translating to proto.
+type PathSummary struct {
+	SourceGID         [16]byte
+	TargetGID         [16]byte
+	TargetTorID       string
+	TargetQPN         uint32
+	WindowStartUnixNs uint64
+	WindowDurationMs  uint32
+	ProbeTotal        uint32
+	ProbeSuccess      uint32
+	ProbeFailed       uint32
+	InvalidRTTCount   uint32
+	NetworkRTTMinNs   uint64
+	NetworkRTTMaxNs   uint64
+	NetworkRTTP50Ns   uint64
+	NetworkRTTP99Ns   uint64
+}
+
+// rttBucketBoundariesNs are the upper bounds (nanoseconds) of the fixed
+// histogram buckets used to estimate RTT percentiles without retaining every
+// sample. They span 100ns to 10ms, the datacenter-RDMA RTT range, matching the
+// telemetry package's histogram boundaries. A value greater than the last
+// boundary falls into an implicit overflow bucket whose representative value is
+// the last boundary (percentiles are conservative upper-bound estimates). Exact
+// min/max are tracked separately, so extremes are never lost to bucketing.
+var rttBucketBoundariesNs = []uint64{
+	100, 250, 500, 1_000, 2_500, 5_000, 10_000,
+	25_000, 50_000, 100_000, 250_000, 500_000,
+	1_000_000, 2_500_000, 5_000_000, 10_000_000,
+}
+
+// pathAccumulator accumulates probe outcomes for one path within one window.
+type pathAccumulator struct {
+	windowStartNs uint64
+	targetTorID   string
+	targetQPN     uint32
+
+	total      uint32
+	success    uint32
+	failed     uint32
+	invalidRTT uint32
+
+	hasRTT bool
+	minRTT uint64
+	maxRTT uint64
+	// buckets[i] counts valid RTT samples whose value is <=
+	// rttBucketBoundariesNs[i] and > the previous boundary; the final element
+	// (len == len(boundaries)+1) is the overflow bucket.
+	buckets []uint64
+}
+
+func newPathAccumulator(windowStartNs uint64, targetTorID string, targetQPN uint32) *pathAccumulator {
+	return &pathAccumulator{
+		windowStartNs: windowStartNs,
+		targetTorID:   targetTorID,
+		targetQPN:     targetQPN,
+		buckets:       make([]uint64, len(rttBucketBoundariesNs)+1),
+	}
+}
+
+// observeRTT records one valid network-RTT sample (nanoseconds).
+func (a *pathAccumulator) observeRTT(v uint64) {
+	if !a.hasRTT || v < a.minRTT {
+		a.minRTT = v
+	}
+	if !a.hasRTT || v > a.maxRTT {
+		a.maxRTT = v
+	}
+	a.hasRTT = true
+
+	idx := sort.Search(len(rttBucketBoundariesNs), func(i int) bool {
+		return v <= rttBucketBoundariesNs[i]
+	})
+	a.buckets[idx]++
+}
+
+// quantile returns the estimated q-quantile (0..1) of the observed valid RTTs,
+// as the upper boundary of the bucket containing the target rank. Returns 0
+// when no valid RTT was observed. The exact min/max clamp the estimate so a
+// coarse bucket never reports a value outside the observed range.
+func (a *pathAccumulator) quantile(q float64) uint64 {
+	if !a.hasRTT || a.success == 0 {
+		return 0
+	}
+	// rank is 1-based: the smallest index whose cumulative count reaches it.
+	rank := uint64(float64(a.success)*q + 0.5)
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > uint64(a.success) {
+		rank = uint64(a.success)
+	}
+
+	var cum uint64
+	for i, c := range a.buckets {
+		cum += c
+		if cum >= rank {
+			var est uint64
+			if i < len(rttBucketBoundariesNs) {
+				est = rttBucketBoundariesNs[i]
+			} else {
+				// Overflow bucket: best available upper bound is the observed max.
+				est = a.maxRTT
+			}
+			if est < a.minRTT {
+				est = a.minRTT
+			}
+			if est > a.maxRTT {
+				est = a.maxRTT
+			}
+			return est
+		}
+	}
+	return a.maxRTT
+}
+
+// summary finalizes the accumulator into a PathSummary for the given path key
+// and window duration.
+func (a *pathAccumulator) summary(key PathKey, windowDurationMs uint32) PathSummary {
+	return PathSummary{
+		SourceGID:         key.SourceGID,
+		TargetGID:         key.TargetGID,
+		TargetTorID:       a.targetTorID,
+		TargetQPN:         a.targetQPN,
+		WindowStartUnixNs: a.windowStartNs,
+		WindowDurationMs:  windowDurationMs,
+		ProbeTotal:        a.total,
+		ProbeSuccess:      a.success,
+		ProbeFailed:       a.failed,
+		InvalidRTTCount:   a.invalidRTT,
+		NetworkRTTMinNs:   a.minRTT,
+		NetworkRTTMaxNs:   a.maxRTT,
+		NetworkRTTP50Ns:   a.quantile(0.50),
+		NetworkRTTP99Ns:   a.quantile(0.99),
+	}
+}
+
+// PathAggregator groups probe results into fixed, wall-clock-aligned windows
+// per path key and emits one PathSummary per (path, completed window). It is
+// pure Go and safe for concurrent use: AddResult (called from the fan-in feed)
+// and Collect/Flush (called by the reporter) may run on different goroutines.
+//
+// Windows are aligned to multiples of windowNs so that every path shares the
+// same window boundaries, which makes cross-path comparison at the controller
+// straightforward. A path that stops probing is pruned automatically: once its
+// current window elapses, Collect finalizes and removes it, so the internal map
+// never grows without bound under path churn.
+type PathAggregator struct {
+	windowNs uint64
+
+	mu    sync.Mutex
+	paths map[PathKey]*pathAccumulator
+	// ready holds summaries for windows that rolled over inside AddResult
+	// (a result arrived for a newer window than the path's open accumulator)
+	// before Collect had a chance to harvest them, so no window is ever lost.
+	ready []PathSummary
+}
+
+// NewPathAggregator creates a PathAggregator with the given window length in
+// nanoseconds. A non-positive windowNs is clamped to 1ns to avoid a divide by
+// zero; callers should pass a sane value (e.g. 30s).
+func NewPathAggregator(windowNs uint64) *PathAggregator {
+	if windowNs == 0 {
+		windowNs = 1
+	}
+	return &PathAggregator{
+		windowNs: windowNs,
+		paths:    make(map[PathKey]*pathAccumulator),
+	}
+}
+
+// windowStart returns the aligned start of the window containing tsNs.
+func (p *PathAggregator) windowStart(tsNs uint64) uint64 {
+	return (tsNs / p.windowNs) * p.windowNs
+}
+
+// AddResult folds one probe result into the accumulator for its path and the
+// window containing recvUnixNs (the wall-clock ingestion time; probe timestamps
+// are CLOCK_MONOTONIC and must not be used for windowing). A result whose path
+// jumps to a newer window finalizes the path's previous window into the ready
+// list first.
+func (p *PathAggregator) AddResult(r *ProbeResult, recvUnixNs uint64) {
+	if r == nil {
+		return
+	}
+	key := PathKey{SourceGID: r.SourceGID, TargetGID: r.TargetGID}
+	ws := p.windowStart(recvUnixNs)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	acc := p.paths[key]
+	if acc != nil && acc.windowStartNs != ws {
+		// The path moved to a different window; finalize the old one so its
+		// data is not overwritten, then start fresh.
+		p.ready = append(p.ready, acc.summary(key, p.windowDurationMs()))
+		acc = nil
+	}
+	if acc == nil {
+		acc = newPathAccumulator(ws, r.TargetTorID, r.TargetQPN)
+		p.paths[key] = acc
+	}
+
+	acc.total++
+	if !r.Success {
+		acc.failed++
+		return
+	}
+	rtt := CalculateRTT(r)
+	if !rtt.Valid {
+		acc.invalidRTT++
+		return
+	}
+	acc.success++
+	acc.observeRTT(uint64(rtt.NetworkRTT))
+}
+
+func (p *PathAggregator) windowDurationMs() uint32 {
+	return uint32(p.windowNs / 1_000_000)
+}
+
+// Collect finalizes and returns summaries for every window that has fully
+// elapsed as of nowUnixNs, removing those accumulators. Paths still within
+// their current window are left untouched. Summaries buffered by a window
+// rollover in AddResult are always returned. The returned slice is nil when
+// nothing is ready.
+func (p *PathAggregator) Collect(nowUnixNs uint64) []PathSummary {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	out := p.ready
+	p.ready = nil
+
+	dur := p.windowDurationMs()
+	for key, acc := range p.paths {
+		if acc.windowStartNs+p.windowNs <= nowUnixNs {
+			out = append(out, acc.summary(key, dur))
+			delete(p.paths, key)
+		}
+	}
+	return out
+}
+
+// Flush finalizes and returns summaries for ALL accumulators regardless of
+// whether their window has elapsed, clearing the aggregator. It is intended for
+// shutdown, so a final partial window is not silently dropped.
+func (p *PathAggregator) Flush() []PathSummary {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	out := p.ready
+	p.ready = nil
+
+	dur := p.windowDurationMs()
+	for key, acc := range p.paths {
+		out = append(out, acc.summary(key, dur))
+		delete(p.paths, key)
+	}
+	return out
+}

--- a/rebuild/internal/probe/aggregator.go
+++ b/rebuild/internal/probe/aggregator.go
@@ -1,6 +1,7 @@
 package probe
 
 import (
+	"math"
 	"sort"
 	"sync"
 )
@@ -102,8 +103,14 @@ func (a *pathAccumulator) quantile(q float64) uint64 {
 	if !a.hasRTT || a.success == 0 {
 		return 0
 	}
-	// rank is 1-based: the smallest index whose cumulative count reaches it.
-	rank := uint64(float64(a.success)*q + 0.5)
+	// Nearest-rank method (1-indexed): rank = ceil(q * n). Round-half-up
+	// (q*n + 0.5) is wrong -- it can pick a rank one below ceil(q*n) and so
+	// miss a rare slow tail. E.g. n=151, q=0.99: ceil(0.99*151)=ceil(149.49)=150,
+	// but round-half-up gives round(149.99)=149, landing one rank too low (in
+	// the fast bucket) and hiding a 2-of-151 p99 breach. The small epsilon
+	// absorbs float error so an integer-valued q*n (e.g. from q=0.9) is not
+	// nudged up a whole rank by a representation like 9.0000000000000002.
+	rank := uint64(math.Ceil(q*float64(a.success) - 1e-9))
 	if rank < 1 {
 		rank = 1
 	}

--- a/rebuild/internal/probe/aggregator_test.go
+++ b/rebuild/internal/probe/aggregator_test.go
@@ -1,0 +1,272 @@
+package probe
+
+import (
+	"testing"
+)
+
+const (
+	testWindowNs = uint64(1_000_000_000) // 1s windows
+	// recvNs anchors for two adjacent windows.
+	win0Recv = uint64(500_000_000)   // in [0, 1e9)
+	win1Recv = uint64(1_500_000_000) // in [1e9, 2e9)
+)
+
+func gid(b byte) [16]byte {
+	var g [16]byte
+	g[15] = b
+	return g
+}
+
+// validResult builds a Success result whose 6 timestamps yield exactly
+// networkRTTNs of NetworkRTT (with a fixed, valid ResponderDelay=500 and
+// ProberDelay=100), so tests can drive specific RTT samples through the
+// bucketed quantile estimator.
+func validResult(src, tgt [16]byte, tor string, qpn uint32, networkRTTNs uint64) *ProbeResult {
+	return &ProbeResult{
+		SourceGID:   src,
+		TargetGID:   tgt,
+		TargetTorID: tor,
+		TargetQPN:   qpn,
+		Success:     true,
+		T1:          1000,
+		T2:          2000,
+		T3:          3000,
+		T4:          3500,
+		T5:          networkRTTNs + 2500,
+		T6:          networkRTTNs + 1600,
+	}
+}
+
+func failedResult(src, tgt [16]byte, tor string) *ProbeResult {
+	return &ProbeResult{
+		SourceGID:    src,
+		TargetGID:    tgt,
+		TargetTorID:  tor,
+		Success:      false,
+		ErrorMessage: "timed out waiting for ACKs",
+	}
+}
+
+// invalidRTTResult is Success (all 6 timestamps present) but the RTT fails
+// validation (negative NetworkRTT), so it counts as invalid_rtt, not loss.
+func invalidRTTResult(src, tgt [16]byte, tor string) *ProbeResult {
+	return &ProbeResult{
+		SourceGID:   src,
+		TargetGID:   tgt,
+		TargetTorID: tor,
+		Success:     true,
+		T1:          1000,
+		T2:          2000,
+		T3:          3000,
+		T4:          3500,
+		T5:          2100, // NetworkRTT = (2100-2000)-500 = -400 -> invalid
+		T6:          3000,
+	}
+}
+
+func TestPathAggregator_CountsAndLoss(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	// 6 valid, 3 failed, 1 invalid -> total 10, loss 3/10.
+	for i := 0; i < 6; i++ {
+		agg.AddResult(validResult(src, tgt, "tor-b", 42, 1000), win0Recv)
+	}
+	for i := 0; i < 3; i++ {
+		agg.AddResult(failedResult(src, tgt, "tor-b"), win0Recv)
+	}
+	agg.AddResult(invalidRTTResult(src, tgt, "tor-b"), win0Recv)
+
+	summaries := agg.Collect(win1Recv) // window0 is complete at 1.5e9
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	s := summaries[0]
+
+	if s.ProbeTotal != 10 {
+		t.Errorf("ProbeTotal = %d, want 10", s.ProbeTotal)
+	}
+	if s.ProbeSuccess != 6 {
+		t.Errorf("ProbeSuccess = %d, want 6", s.ProbeSuccess)
+	}
+	if s.ProbeFailed != 3 {
+		t.Errorf("ProbeFailed = %d, want 3", s.ProbeFailed)
+	}
+	if s.InvalidRTTCount != 1 {
+		t.Errorf("InvalidRTTCount = %d, want 1", s.InvalidRTTCount)
+	}
+	if s.TargetTorID != "tor-b" || s.TargetQPN != 42 {
+		t.Errorf("target metadata not carried: tor=%q qpn=%d", s.TargetTorID, s.TargetQPN)
+	}
+	if s.SourceGID != src || s.TargetGID != tgt {
+		t.Errorf("path key not carried on summary")
+	}
+	if s.WindowStartUnixNs != 0 {
+		t.Errorf("WindowStartUnixNs = %d, want 0 (aligned window0 start)", s.WindowStartUnixNs)
+	}
+	if s.WindowDurationMs != 1000 {
+		t.Errorf("WindowDurationMs = %d, want 1000", s.WindowDurationMs)
+	}
+}
+
+func TestPathAggregator_RTTStats(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	// Samples: 1us x many small, plus one large 8ms max, one small 100ns min.
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 100), win0Recv) // min
+	for i := 0; i < 98; i++ {
+		agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv) // 1us cluster
+	}
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 8_000_000), win0Recv) // max, drives p99
+
+	summaries := agg.Collect(win1Recv)
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	s := summaries[0]
+
+	if s.ProbeSuccess != 100 {
+		t.Fatalf("ProbeSuccess = %d, want 100", s.ProbeSuccess)
+	}
+	if s.NetworkRTTMinNs != 100 {
+		t.Errorf("min = %d, want 100", s.NetworkRTTMinNs)
+	}
+	if s.NetworkRTTMaxNs != 8_000_000 {
+		t.Errorf("max = %d, want 8000000", s.NetworkRTTMaxNs)
+	}
+	// p50 should land in the 1us cluster's bucket (<= 1000ns boundary).
+	if s.NetworkRTTP50Ns != 1000 {
+		t.Errorf("p50 = %d, want 1000 (1us bucket upper bound)", s.NetworkRTTP50Ns)
+	}
+	// p99: rank = ceil(0.99*100) = 99, still inside the 1us cluster (99 of the
+	// first 99 samples are <= 1us); the single 8ms sample is rank 100. So p99
+	// estimates the 1us bucket, and must never exceed the observed max.
+	if s.NetworkRTTP99Ns < 1000 || s.NetworkRTTP99Ns > s.NetworkRTTMaxNs {
+		t.Errorf("p99 = %d, want in [1000, %d]", s.NetworkRTTP99Ns, s.NetworkRTTMaxNs)
+	}
+}
+
+func TestPathAggregator_P99CapturesTail(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	// 90 fast (1us) + 10 slow (5ms): p99 must reflect the slow tail.
+	for i := 0; i < 90; i++ {
+		agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv)
+	}
+	for i := 0; i < 10; i++ {
+		agg.AddResult(validResult(src, tgt, "tor-b", 1, 5_000_000), win0Recv)
+	}
+
+	s := agg.Collect(win1Recv)[0]
+	// rank for p99 = 99 -> falls in the slow cluster (ranks 91..100).
+	if s.NetworkRTTP99Ns < 1_000_000 {
+		t.Errorf("p99 = %d, want >= 1ms (tail captured)", s.NetworkRTTP99Ns)
+	}
+	// p50 = rank 50 -> fast cluster.
+	if s.NetworkRTTP50Ns != 1000 {
+		t.Errorf("p50 = %d, want 1000", s.NetworkRTTP50Ns)
+	}
+}
+
+func TestPathAggregator_WindowBoundary(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	// Two probes in window0, three in window1 for the same path.
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv)
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv)
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win1Recv)
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win1Recv)
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win1Recv)
+
+	// Collect only window0 (now=1.5e9): window1 is still open.
+	first := agg.Collect(win1Recv)
+	if len(first) != 1 {
+		t.Fatalf("expected 1 window0 summary, got %d", len(first))
+	}
+	if first[0].ProbeTotal != 2 || first[0].WindowStartUnixNs != 0 {
+		t.Errorf("window0 summary wrong: total=%d start=%d", first[0].ProbeTotal, first[0].WindowStartUnixNs)
+	}
+
+	// Now collect window1 (now=2.5e9).
+	second := agg.Collect(2_500_000_000)
+	if len(second) != 1 {
+		t.Fatalf("expected 1 window1 summary, got %d", len(second))
+	}
+	if second[0].ProbeTotal != 3 || second[0].WindowStartUnixNs != testWindowNs {
+		t.Errorf("window1 summary wrong: total=%d start=%d", second[0].ProbeTotal, second[0].WindowStartUnixNs)
+	}
+}
+
+func TestPathAggregator_RolloverPreservesOldWindow(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	// A result in window0, then a later result for the SAME path in window1
+	// (before any Collect). The rollover must preserve window0's data.
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv)
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win1Recv)
+
+	// Collecting at a time past window1 yields BOTH windows.
+	got := agg.Collect(2_500_000_000)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 summaries (window0 rolled over + window1), got %d", len(got))
+	}
+}
+
+func TestPathAggregator_ChurnPruning(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv)
+
+	// Collect the completed window: the path must be removed from the map so a
+	// path that goes silent does not accumulate memory.
+	if got := agg.Collect(win1Recv); len(got) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(got))
+	}
+	// A second collect (nothing new added) must be empty: the path was pruned.
+	if got := agg.Collect(2_500_000_000); len(got) != 0 {
+		t.Errorf("expected 0 summaries after pruning, got %d", len(got))
+	}
+	// Flush must also be empty.
+	if got := agg.Flush(); len(got) != 0 {
+		t.Errorf("expected 0 summaries from Flush after pruning, got %d", len(got))
+	}
+}
+
+func TestPathAggregator_MultiPathDistinctKeys(t *testing.T) {
+	agg := NewPathAggregator(testWindowNs)
+
+	srcA, srcB := gid(1), gid(2)
+	tgt := gid(9)
+
+	// Two source RNICs probing the same target (multi-rail): distinct paths.
+	agg.AddResult(validResult(srcA, tgt, "tor-b", 1, 1000), win0Recv)
+	agg.AddResult(validResult(srcB, tgt, "tor-b", 1, 1000), win0Recv)
+	// Same source, different target: another distinct path.
+	agg.AddResult(validResult(srcA, gid(10), "tor-c", 1, 1000), win0Recv)
+
+	got := agg.Collect(win1Recv)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 distinct path summaries, got %d", len(got))
+	}
+}
+
+func TestPathAggregator_Flush(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	// Add to an OPEN (not yet complete) window; Collect must not return it, but
+	// Flush must.
+	agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv)
+
+	if got := agg.Collect(win0Recv); len(got) != 0 {
+		t.Fatalf("Collect returned an in-progress window: %d summaries", len(got))
+	}
+	if got := agg.Flush(); len(got) != 1 {
+		t.Fatalf("Flush should return the in-progress window, got %d", len(got))
+	}
+}

--- a/rebuild/internal/probe/aggregator_test.go
+++ b/rebuild/internal/probe/aggregator_test.go
@@ -170,6 +170,75 @@ func TestPathAggregator_P99CapturesTail(t *testing.T) {
 	}
 }
 
+// TestPathAggregator_P99NearestRankCapturesRareTail is the Codex counterexample
+// for the off-by-one in the old round-half-up rank: 151 valid samples with only
+// 2 slow ones. Nearest-rank p99 = ceil(0.99*151) = ceil(149.49) = 150, which
+// lands on a slow sample; round-half-up gives round(149.99) = 149 (the fast
+// bucket) and would hide the SLA breach.
+func TestPathAggregator_P99NearestRankCapturesRareTail(t *testing.T) {
+	src, tgt := gid(1), gid(2)
+	agg := NewPathAggregator(testWindowNs)
+
+	for i := 0; i < 149; i++ {
+		agg.AddResult(validResult(src, tgt, "tor-b", 1, 1000), win0Recv) // fast (1us)
+	}
+	for i := 0; i < 2; i++ {
+		agg.AddResult(validResult(src, tgt, "tor-b", 1, 5_000_000), win0Recv) // slow (5ms)
+	}
+
+	s := agg.Collect(win1Recv)[0]
+	if s.ProbeSuccess != 151 {
+		t.Fatalf("ProbeSuccess = %d, want 151", s.ProbeSuccess)
+	}
+	if s.NetworkRTTP99Ns < 5_000_000 {
+		t.Errorf("p99 = %d, want >= 5000000: nearest-rank must capture the 2-of-151 slow tail",
+			s.NetworkRTTP99Ns)
+	}
+	// The median stays firmly in the fast bucket.
+	if s.NetworkRTTP50Ns != 1000 {
+		t.Errorf("p50 = %d, want 1000", s.NetworkRTTP50Ns)
+	}
+}
+
+// TestPathAggregator_P50NearestRank pins p50 (q=0.5) nearest-rank behavior for
+// odd and even sample counts: rank = ceil(n/2). p50 is unchanged by the fix
+// (round-half-up equals ceil at q=0.5), so these must stay consistent with the
+// other percentile tests.
+func TestPathAggregator_P50NearestRank(t *testing.T) {
+	const (
+		fastNs = uint64(1000)      // 1us -> "fast" bucket
+		slowNs = uint64(5_000_000) // 5ms -> "slow" bucket
+	)
+	cases := []struct {
+		name       string
+		fast, slow int
+		wantP50    uint64
+	}{
+		// even n=4: rank ceil(2)=2, among the 2 fast -> fast bucket.
+		{"even_n4_rank2_fast", 2, 2, fastNs},
+		// odd n=3: rank ceil(1.5)=2, 2nd smallest of [fast, slow, slow] -> slow.
+		{"odd_n3_rank2_slow", 1, 2, slowNs},
+		// odd n=5: rank ceil(2.5)=3, 3rd smallest of [fast x3, slow x2] -> fast.
+		{"odd_n5_rank3_fast", 3, 2, fastNs},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src, tgt := gid(1), gid(2)
+			agg := NewPathAggregator(testWindowNs)
+			for i := 0; i < tc.fast; i++ {
+				agg.AddResult(validResult(src, tgt, "tor-b", 1, fastNs), win0Recv)
+			}
+			for i := 0; i < tc.slow; i++ {
+				agg.AddResult(validResult(src, tgt, "tor-b", 1, slowNs), win0Recv)
+			}
+			s := agg.Collect(win1Recv)[0]
+			if s.NetworkRTTP50Ns != tc.wantP50 {
+				t.Errorf("p50 = %d, want %d", s.NetworkRTTP50Ns, tc.wantP50)
+			}
+		})
+	}
+}
+
 func TestPathAggregator_WindowBoundary(t *testing.T) {
 	src, tgt := gid(1), gid(2)
 	agg := NewPathAggregator(testWindowNs)

--- a/rebuild/internal/probe/probe.go
+++ b/rebuild/internal/probe/probe.go
@@ -40,7 +40,14 @@ const (
 // ProbeResult contains the complete 6-timestamp probe measurement.
 // Timestamps are in nanoseconds (CLOCK_MONOTONIC or HW timestamps).
 type ProbeResult struct {
-	SequenceNum    uint64
+	SequenceNum uint64
+	// SourceGID is the GID of the local RNIC that sent this probe. It is set
+	// by the Prober from its bound device so that downstream consumers (in
+	// particular the per-path PathAggregator) can key results by
+	// (source, target) even after every device's results are merged into one
+	// fan-in stream. Zero when the emitting Prober has no bound device (test
+	// fakes), which is harmless: such results are never aggregated.
+	SourceGID      [16]byte
 	TargetGID      [16]byte
 	TargetQPN      uint32
 	FlowLabel      uint32

--- a/rebuild/internal/telemetry/otel_metrics.go
+++ b/rebuild/internal/telemetry/otel_metrics.go
@@ -156,6 +156,32 @@ func NewMetricsCollector(ctx context.Context, collectorAddr string, opts ...Opti
 		opt(&options)
 	}
 
+	provider, err := NewMeterProvider(ctx, collectorAddr, options.serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	mc, err := registerInstruments(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	mc.logger.Info().
+		Str("collector_addr", collectorAddr).
+		Dur("flush_interval", periodicReaderInterval).
+		Msg("MetricsCollector initialized")
+
+	return mc, nil
+}
+
+// NewMeterProvider builds an OTLP-exporting MeterProvider tagged with the
+// given service.name and a periodic reader flushing every periodicReaderInterval.
+// It centralizes the OTLP exporter + resource + reader wiring so that any
+// in-process metric producer can reuse it: the agent's MetricsCollector, and
+// the controller-side analyzer (service.name="rpingmesh-analyzer"), which
+// registers its own instruments on the returned provider. The caller owns the
+// provider's lifecycle (Shutdown).
+func NewMeterProvider(ctx context.Context, collectorAddr, serviceName string) (*sdkmetric.MeterProvider, error) {
 	// Create OTLP gRPC exporter targeting the collector.
 	exporter, err := otlpmetricgrpc.New(
 		ctx,
@@ -167,7 +193,7 @@ func NewMetricsCollector(ctx context.Context, collectorAddr string, opts ...Opti
 	}
 
 	// Build the OTel resource identifying this service.
-	res, err := buildResource(options.serviceName)
+	res, err := buildResource(serviceName)
 	if err != nil {
 		return nil, err
 	}
@@ -183,18 +209,7 @@ func NewMetricsCollector(ctx context.Context, collectorAddr string, opts ...Opti
 			),
 		),
 	)
-
-	mc, err := registerInstruments(provider)
-	if err != nil {
-		return nil, err
-	}
-
-	mc.logger.Info().
-		Str("collector_addr", collectorAddr).
-		Dur("flush_interval", periodicReaderInterval).
-		Msg("MetricsCollector initialized")
-
-	return mc, nil
+	return provider, nil
 }
 
 // NewMetricsCollectorWithProvider creates a MetricsCollector using the given

--- a/rebuild/proto/controller_agent/controller_agent.proto
+++ b/rebuild/proto/controller_agent/controller_agent.proto
@@ -11,6 +11,10 @@ service ControllerService {
     rpc RegisterAgent(AgentRegistrationRequest) returns (AgentRegistrationResponse);
     // GetPinglist returns the list of targets for an agent to probe.
     rpc GetPinglist(PinglistRequest) returns (PinglistResponse);
+    // ReportProbeAnalysis reports per-path, window-aggregated probe summaries
+    // from an agent so the controller-side analyzer can detect SLA violations
+    // (and, in a future phase, localize switch/link faults across agents).
+    rpc ReportProbeAnalysis(ProbeAnalysisReport) returns (ProbeAnalysisAck);
 }
 
 // RnicInfo describes an RDMA NIC.
@@ -85,4 +89,50 @@ message PingTarget {
 message PinglistResponse {
     repeated PingTarget targets = 1;
     PinglistType type = 2;
+}
+
+// PathSummary is a window-aggregated summary of one probe path
+// (source RNIC -> target RNIC), produced by the agent-side PathAggregator.
+// Reporting summaries instead of raw per-probe results cuts the controller's
+// ingest volume by roughly three orders of magnitude (see analyzer design).
+//
+// RTT statistics are summary statistics only (min/max plus p50/p99 estimated
+// from fixed histogram buckets); no full histogram is carried, to keep the
+// message small. All RTT fields are network RTT in nanoseconds.
+message PathSummary {
+    string source_gid           = 1;   // source RNIC GID (this agent)
+    string source_tor_id        = 2;   // source RNIC ToR (this agent)
+    string target_gid           = 3;   // target RNIC GID
+    string target_tor_id        = 4;   // target RNIC ToR
+    uint32 target_qpn           = 5;
+    uint64 window_start_unix_ns = 6;   // wall-clock start of the aggregation window
+    uint32 window_duration_ms   = 7;
+    uint32 probe_total          = 8;   // = probe_success + probe_failed + invalid_rtt_count
+    uint32 probe_success        = 9;   // completed with a valid RTT (feeds the RTT stats)
+    uint32 probe_failed         = 10;  // send failure or ACK timeout (counts as loss)
+    uint64 network_rtt_min_ns   = 11;
+    uint64 network_rtt_max_ns   = 12;
+    uint64 network_rtt_p50_ns   = 13;
+    uint64 network_rtt_p99_ns   = 14;
+    // invalid_rtt_count: probes that completed all 6 timestamps (Success) but
+    // whose RTT failed validation (e.g. clock-skew/SW-timestamp noise). Not
+    // counted as loss.
+    uint32 invalid_rtt_count    = 15;
+}
+
+// ProbeAnalysisReport is a batch of window summaries reported by one agent.
+message ProbeAnalysisReport {
+    string agent_id = 1;
+    repeated PathSummary summaries = 2;
+}
+
+// ProbeAnalysisAck acknowledges a ProbeAnalysisReport.
+message ProbeAnalysisAck {
+    bool accepted = 1;
+    // sla_violations is the number of summaries in the acked report that the
+    // controller-side analyzer flagged as SLA violations (loss and/or p99 RTT
+    // threshold breaches). It gives the reporting agent operational feedback
+    // and makes the ingest+detection path observable end-to-end without an
+    // OTLP collector. 0 when the analyzer is disabled.
+    uint32 sla_violations = 2;
 }

--- a/rebuild/scripts/run-e2e.sh
+++ b/rebuild/scripts/run-e2e.sh
@@ -336,7 +336,7 @@ log "Starting RDMA e2e tests..."
 # Temporarily disable exit-on-error so post-test diagnostics always run.
 set +e
 env RDMA_E2E_ENABLED=1 \
-    go test -v -timeout 120s -run "^(TestRDMAE2E|TestProbeToOTelMetrics|TestMultiRNICBothDevicesProbe|TestECMPMultiFlowLabel)" ./e2e/
+    go test -v -timeout 120s -run "^(TestRDMAE2E|TestProbeToOTelMetrics|TestProbeToPathAggregator|TestMultiRNICBothDevicesProbe|TestECMPMultiFlowLabel)" ./e2e/
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
## Summary

Implements the minimal R-Pingmesh **Analyzer (Phase 1)**: per-path window aggregation on the agent, a new `ReportProbeAnalysis` RPC, and controller-side SLA-violation detection. This closes the paper's largest missing piece — cross-agent probe analysis — with the smallest viable footprint, leaving topology-aware fault localization (Phase 2) as future work on top of the summaries this phase collects.

Data flow:

```
Prober -> ProbeResult -> [fan-in tee] -+-> MetricsCollector (existing, ToR OTLP)
                                        +-> PathAggregator (window aggregation) -> PathSummary
                                             -> AnalysisReporter -> ReportProbeAnalysis RPC
                                                -> controller analyzer (ingest + SLA detect)
                                                   -> findings: logs + OTLP (rpingmesh.analyzer.*)
```

## What changed

- **proto** (`controller_agent.proto`): new `ReportProbeAnalysis` RPC and `PathSummary` / `ProbeAnalysisReport` / `ProbeAnalysisAck` messages (design field numbers). `ProbeAnalysisAck` also carries `sla_violations` (field 2) — a per-report violation count that gives the agent operational feedback and makes the ingest+detection path observable end-to-end without an OTLP collector.
- **probe** (`aggregator.go`): `PathAggregator` groups results by `(source_gid, target_gid)` into fixed, wall-clock-aligned windows; emits loss counts, min/max, and bucketed p50/p99. Pure Go, no RDMA dependency. `ProbeResult` gains `SourceGID`, stamped by the `Prober` at a single emit chokepoint so merged fan-in results stay path-keyed on multi-rail hosts.
- **agent**: new `AnalysisReporter` drives the aggregator and ships completed-window summaries via `ReportProbeAnalysis` (best-effort: drops on failure, never blocks probing). `createResultsFanIn` tees each result onto a secondary analysis branch with a **non-blocking** send, preserving the existing `resultsDone` / non-blocking / `Destroy(sync.Once)` contract; `stopResultsFanIn` closes the branch and `Stop` waits for the reporter before closing the gRPC client.
- **controller** (`analyzer/`): ingests summaries, retains recent windows in a bounded in-memory ring, and flags per-path loss / p99-RTT SLA violations to logs (with GID detail) and OTLP metrics (`rpingmesh.analyzer.*`, **ToR-level attributes only**). Wired into `ControllerService.ReportProbeAnalysis` and `cmd/controller`. `telemetry` gains a shared `NewMeterProvider` so the analyzer reuses the `WithServiceName("rpingmesh-analyzer")` machinery.
- **config**: agent `analysis_report_enabled` / `analysis_window_sec`; controller `analyzer_enabled` / `analyzer_sla_loss_ratio` / `analyzer_sla_network_rtt_p99_ns` / `analyzer_window_retention` / `otel_collector_addr`, with validation.
- **docs**: README Configuration tables, analyzer metrics, Architecture note, and Limitations updated.

## Design notes / deviations from the design doc

- **`ProbeAnalysisAck.sla_violations` added (field 2).** The design listed `ProbeAnalysisAck { bool accepted = 1; }`. Adding a violation count (no renumbering) is the least-intrusive way to assert SLA detection in the RDMA-free controller e2e without standing up an OTLP collector, and it usefully feeds back to the agent.
- **`otel_collector_addr` added to controller config.** The controller had no telemetry wiring; the analyzer needs an OTLP endpoint to emit `rpingmesh.analyzer.*`. Export is best-effort — a failed provider degrades to log-only findings.
- **`ProbeResult.SourceGID` added.** Path aggregation keys on `(source, target)`, but results from every device are merged into one fan-in stream and `ProbeResult` carried no source identity. The `Prober` stamps its parsed device GID at `emitResult` (single writer, before any consumer sees the result).
- **Tee direction that matters:** the analysis send is non-blocking (drops when its buffer is full) so a slow/backed-up aggregator can never stall the primary metrics path; the metrics send keeps its exact prior blocking-with-`resultsDone`-escape semantics.

## Testing

Target `x` / `Test*` all green:

- **Unit (local + Linux container, incl. `-race`)**: `PathAggregator` (window boundaries, loss, min/max, p50/p99, tail capture, rollover, churn pruning, multi-path keys, flush); analyzer (loss/RTT thresholds at the boundary, both-kinds, RTT-check-disabled, zero-total, retention ring); `AnalysisReporter` (final flush on input close, ctx-cancel stop, best-effort drop on error, batch splitting); fan-in tee (delivers to both branches; slow analysis does not stall metrics; branch closed on shutdown); `controller_client.ReportProbeAnalysis`; `service.ReportProbeAnalysis` (with/without analyzer, empty agent_id).
- **`go build ./...` (pure-Go) + `go vet ./...`**: pass.
- **RDMA-free controller e2e** (`docker-compose.e2e-controller.yml`): new `TestReportProbeAnalysisSLADetection` reports 3 summaries → `accepted=true, sla_violations=2`; `TestReportProbeAnalysisNoViolations` → `sla_violations=0`. Full suite PASS.
- **soft-RoCE e2e** (`make test-e2e`): new `TestProbeToPathAggregator` drives real probes through the aggregator (`total=28 success=10 failed=0 invalid=18`, non-zero SourceGID, counts partition). Full suite PASS. `run-e2e.sh` `-run` filter updated.
- **Full non-e2e suite in the Linux CGO/RDMA container** (`go test $(go list ./... | grep -v /e2e)`, incl. `-race`): all packages PASS (the agent package's tee/reporter tests link `librdmabridge.a` and only run here, not on macOS).

## Notes

- Rebased onto current `main` (merged **#34** sl/traffic_class); the merged `OpenDeviceByName(sl, tc)` signature is reflected in the new soft-RoCE e2e. Config keys from both features coexist.
- Generated `.pb.go` are gitignored per repo policy; regenerated via `make generate-proto` (also done in the e2e Dockerfiles).
- **Not merging** per instructions.
