### PR TITLE
feat(rebuild): differentiate probe rate by pinglist type

### DIFF
--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -214,7 +214,9 @@ via Cgo (`CGO_ENABLED=1`).
 | `tor_id` | *(required)* | Top-of-Rack switch identifier |
 | `controller_addr` | `localhost:50051` | Controller gRPC address |
 | `probe_interval_ms` | `500` | Milliseconds between probe rounds |
-| `target_probe_rate_per_second` | `10` | Max probes per second **per target** (a target's ECMP flow labels share this budget) |
+| `target_probe_rate_per_second` | `10` | Legacy **uniform** per-target probe-rate cap. Used as the fallback for whichever per-type cap below is `0`, so a config that only sets this keeps a single uniform rate (a target's ECMP flow labels share this budget) |
+| `tor_mesh_probe_rate_per_second` | `0`† | Per-target probe-rate cap for **ToR-mesh** targets (`0` = inherit `target_probe_rate_per_second`) |
+| `inter_tor_probe_rate_per_second` | `0`† | Per-target probe-rate cap for **inter-ToR** targets (`0` = inherit `target_probe_rate_per_second`) |
 | `pinglist_update_interval_sec` | `300` | Seconds between pinglist refreshes |
 | `flow_label_rotation_period_sec` | `3600` | Period over which the rotating ~20% of each target's ECMP flow-label set is refreshed |
 | `gid_index` | `0` | GID table index on RDMA devices (0-255; see note below) |
@@ -231,6 +233,11 @@ via Cgo (`CGO_ENABLED=1`).
 | `tls_key_file` | `""` | Client private key file (required when `tls_mode=mtls`) |
 | `tls_ca_file` | `""` | CA file used to verify the controller's certificate (required when `tls_mode` is `tls` or `mtls`) |
 | `tls_server_name` | `""` | Overrides the name used for TLS SNI/verification; needed when `controller_addr` is an IP literal that doesn't match the server certificate's subject |
+
+† The built-in default for both per-type rates is `0`, which inherits
+`target_probe_rate_per_second` (effectively `10`) so an upgrade preserves the
+prior uniform behavior. The shipped `configs/agent.yaml` overrides them with the
+paper-style differentiated caps (ToR-mesh `10`, inter-ToR `1`).
 
 `gid_index` selects which entry of the RNIC's GID table to use for RDMA
 traffic; the correct value depends on the device and is not portable across
@@ -452,6 +459,31 @@ debug logs, but deliberately **not** as an OTel metric attribute — per-label
 cardinality would explode the metric space, so aggregate metrics stay
 ToR-level.
 
+### Differentiated per-pinglist-type probe rates
+
+R-Pingmesh probes the ToR-mesh more aggressively than inter-ToR. The controller
+knows which pinglist a target belongs to, so it stamps `pinglist_type` into
+every `PingTarget` (`GenerateTorMeshPinglist` / `GenerateInterTorPinglist`). The
+agent merges the two lists into one target list but keeps the stamp, and the
+Prober holds **one rate limiter per type**: each limiter's aggregate rate is
+`rate_type × (number of targets of that type)`, recomputed on every pinglist
+update so the per-target cadence survives churn. `sendProbes` selects the
+limiter matching each target's `pinglist_type`.
+
+The rates are configured with `tor_mesh_probe_rate_per_second` and
+`inter_tor_probe_rate_per_second`; either left at `0` inherits the legacy
+uniform `target_probe_rate_per_second`, so existing single-rate deployments are
+unaffected on upgrade.
+
+The two limiters cap their types independently. Note that probes are still sent
+from a single per-round loop, so in the (uncommon) regime where the caps
+actually bind — i.e. `probe_interval_ms` is short enough that a round would
+otherwise exceed the caps — the per-round pacing of the two types is sequential
+rather than concurrent. At the default `probe_interval_ms: 500` the caps do not
+bind (the interval, not the cap, sets the cadence), so this coupling is not
+observable; fully decoupling it would require a separate send loop per type and
+is deferred.
+
 ### ToR-Level Metric Cardinality
 
 OpenTelemetry histogram attributes use ToR IDs (`source_tor`, `target_tor`)
@@ -593,12 +625,6 @@ sudo rdma link add rxe0 type rxe netdev eth0
   default `tls_mode: disabled` still uses plaintext gRPC for backward compatibility.
   Production deployments should set `tls_mode: mtls` on both sides. Certificate
   loading is static (no hot-reload) and rotation is not a goal of this implementation.
-
-- **Only a single, uniform probe rate cap.** The Prober enforces
-  `target_probe_rate_per_second` as a per-target cap (the aggregate limit
-  scales with the pinglist size). The paper's per-probe-type differentiated
-  rates (e.g. ToR-mesh probes at 10pps, with a separate rate for inter-ToR
-  probes) are not implemented.
 
 - **Inter-ToR *ToR selection* is a fixed-size random sample.** ECMP *path*
   coverage per target is now sized probabilistically via Eq.(1) (see

--- a/rebuild/configs/agent.yaml
+++ b/rebuild/configs/agent.yaml
@@ -10,7 +10,15 @@ controller_addr: "localhost:50051"
 
 # Probing settings
 probe_interval_ms: 500           # Probe interval in milliseconds
-target_probe_rate_per_second: 10 # Max probes per second PER TARGET (shared across a target's flow labels)
+# Per-target probe-rate caps (probes/sec PER TARGET; a target's ECMP flow labels
+# share this budget, they do not multiply it). R-Pingmesh probes the ToR-mesh
+# more aggressively than inter-ToR, so the two pinglist types have separate caps.
+# target_probe_rate_per_second is the legacy uniform cap: it is used as the
+# fallback for whichever per-type cap below is left at 0, so an existing config
+# that only sets it keeps a single uniform rate.
+target_probe_rate_per_second: 10   # Fallback cap for any per-type rate left at 0
+tor_mesh_probe_rate_per_second: 10 # ToR-mesh targets (0 = inherit target_probe_rate_per_second)
+inter_tor_probe_rate_per_second: 1 # Inter-ToR targets (0 = inherit target_probe_rate_per_second)
 pinglist_update_interval_sec: 300 # Pinglist refresh interval
 
 # ECMP flow-label rotation

--- a/rebuild/e2e/controller/agent_controller_e2e_test.go
+++ b/rebuild/e2e/controller/agent_controller_e2e_test.go
@@ -251,6 +251,12 @@ func TestPinglistTorMesh(t *testing.T) {
 		if tgt.GetFlowLabelSeed() == 0 {
 			t.Errorf("PingTarget %s has zero flow_label_seed", tgt.GetTargetGid())
 		}
+		// The controller must stamp the pinglist type so the agent can apply a
+		// differentiated per-type probe rate after merging the two lists.
+		if tgt.GetPinglistType() != controller_agent.PinglistType_TOR_MESH {
+			t.Errorf("PingTarget %s: PinglistType = %v, want TOR_MESH",
+				tgt.GetTargetGid(), tgt.GetPinglistType())
+		}
 	}
 }
 
@@ -288,6 +294,14 @@ func TestPinglistInterTor(t *testing.T) {
 	}
 	if !containsTorID(targets, "tor-C") {
 		t.Errorf("expected tor-C in INTER_TOR results")
+	}
+	// The controller must stamp INTER_TOR so the agent applies the inter-ToR
+	// probe rate to these targets.
+	for _, tgt := range targets {
+		if tgt.GetPinglistType() != controller_agent.PinglistType_INTER_TOR {
+			t.Errorf("PingTarget %s: PinglistType = %v, want INTER_TOR",
+				tgt.GetTargetGid(), tgt.GetPinglistType())
+		}
 	}
 }
 

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -186,13 +186,16 @@ func (a *Agent) Initialize(ctx context.Context) error {
 			return fmt.Errorf("failed to create prober for device %s: %w",
 				dev.Info.DeviceName, err)
 		}
-		if a.cfg.TargetProbeRatePerSecond > 0 {
-			// Per-target rate cap; the prober scales the aggregate limit with the
-			// pinglist size. Differentiated per-pinglist-type rates are a
-			// documented limitation (see README Limitations). Note the cap is
-			// per TARGET, not per flow label: a target's ECMP label set shares
-			// this budget, bounding probe amplification.
-			prober.SetPerTargetRateLimit(float64(a.cfg.TargetProbeRatePerSecond))
+		torMeshRate := a.cfg.EffectiveTorMeshProbeRate()
+		interTorRate := a.cfg.EffectiveInterTorProbeRate()
+		if torMeshRate > 0 || interTorRate > 0 {
+			// Per-target rate caps, differentiated by pinglist type (the prober
+			// scales each type's aggregate limit with that type's target count).
+			// When both per-type keys are unset they inherit the legacy
+			// target_probe_rate_per_second, reproducing a single uniform cap.
+			// Note the cap is per TARGET, not per flow label: a target's ECMP
+			// label set shares this budget, bounding probe amplification.
+			prober.SetPerTypeRateLimit(float64(torMeshRate), float64(interTorRate))
 		}
 		// Configure the ECMP flow-label rotation period (time-based rotation of
 		// the rotating ~20% of each target's label set).

--- a/rebuild/internal/agent/cluster_monitor.go
+++ b/rebuild/internal/agent/cluster_monitor.go
@@ -190,6 +190,15 @@ func (m *ClusterMonitor) fetchPinglists(ctx context.Context) []*controller_agent
 			Msg("Failed to fetch INTER_TOR pinglist, reusing cached targets")
 		interTorTargets = m.lastInterTorTargets
 	} else {
+		// Backward compatibility: an older controller does not set
+		// PingTarget.pinglist_type, so inter-ToR targets arrive with the
+		// proto3-default TOR_MESH and the prober would rate-limit them as
+		// ToR-mesh, ignoring inter_tor_probe_rate_per_second. The agent knows
+		// these came from an INTER_TOR request, so stamp the type where it is
+		// unset. A newer controller's explicit INTER_TOR value is left as-is.
+		// ToR-mesh targets need no correction: their correct type equals the
+		// proto3 default, so an unstamped ToR-mesh target is already right.
+		stampUnsetPinglistType(interTorTargets, controller_agent.PinglistType_INTER_TOR)
 		m.lastInterTorTargets = interTorTargets
 	}
 
@@ -209,4 +218,25 @@ func (m *ClusterMonitor) fetchPinglists(ctx context.Context) []*controller_agent
 		Msg("Fetched pinglists from controller")
 
 	return combined
+}
+
+// stampUnsetPinglistType sets ptype on every target whose pinglist_type is
+// still the proto3 default (TOR_MESH / 0), leaving already-stamped targets
+// untouched. It backfills the type for targets returned by an older controller
+// that predates the pinglist_type field, using the request type the agent knows
+// it asked for. It mutates the targets in place, which is safe because they are
+// freshly deserialized and owned by this agent.
+func stampUnsetPinglistType(targets []*controller_agent.PingTarget, ptype controller_agent.PinglistType) {
+	for _, t := range targets {
+		if t == nil {
+			continue
+		}
+		// TOR_MESH is the zero value, so this matches both "explicitly TOR_MESH"
+		// and "unset". That is exactly what we want: only unset (or already-
+		// ToR-mesh) targets are (re)stamped; a controller that explicitly set
+		// INTER_TOR leaves t.GetPinglistType() != TOR_MESH and is preserved.
+		if t.GetPinglistType() == controller_agent.PinglistType_TOR_MESH {
+			t.PinglistType = ptype
+		}
+	}
 }

--- a/rebuild/internal/agent/cluster_monitor_test.go
+++ b/rebuild/internal/agent/cluster_monitor_test.go
@@ -161,6 +161,43 @@ func TestClusterMonitor_FetchPinglists_BothFail_ReusesCache(t *testing.T) {
 	}
 }
 
+// TestClusterMonitor_FetchPinglists_BackfillsInterTorType verifies that when an
+// older controller returns inter-ToR targets without stamping pinglist_type
+// (proto3 default TOR_MESH), the monitor backfills INTER_TOR -- which the agent
+// knows from having issued an INTER_TOR request -- while leaving ToR-mesh
+// targets and any explicitly-stamped value untouched. Without this, the prober
+// would rate-limit those targets as ToR-mesh and ignore the inter-ToR rate.
+func TestClusterMonitor_FetchPinglists_BackfillsInterTorType(t *testing.T) {
+	client := newMockControllerClient()
+	// ToR-mesh target: unstamped (default TOR_MESH), must stay TOR_MESH.
+	client.enqueue(controller_agent.PinglistType_TOR_MESH,
+		[]*controller_agent.PingTarget{targetWithGID("tor-a")}, nil)
+	// Inter-ToR list as an OLD controller would send it: one unstamped target
+	// (default TOR_MESH) plus one a newer controller stamped INTER_TOR.
+	explicit := targetWithGID("inter-explicit")
+	explicit.PinglistType = controller_agent.PinglistType_INTER_TOR
+	client.enqueue(controller_agent.PinglistType_INTER_TOR,
+		[]*controller_agent.PingTarget{targetWithGID("inter-unstamped"), explicit}, nil)
+
+	monitor := newTestClusterMonitor(client, newTestProber())
+	combined := monitor.fetchPinglists(context.Background())
+
+	byGID := make(map[string]controller_agent.PinglistType, len(combined))
+	for _, tgt := range combined {
+		byGID[tgt.GetTargetGid()] = tgt.GetPinglistType()
+	}
+
+	if got := byGID["tor-a"]; got != controller_agent.PinglistType_TOR_MESH {
+		t.Errorf("ToR-mesh target type = %v, want TOR_MESH (unchanged)", got)
+	}
+	if got := byGID["inter-unstamped"]; got != controller_agent.PinglistType_INTER_TOR {
+		t.Errorf("unstamped inter-ToR target type = %v, want INTER_TOR (backfilled)", got)
+	}
+	if got := byGID["inter-explicit"]; got != controller_agent.PinglistType_INTER_TOR {
+		t.Errorf("explicitly-stamped inter-ToR target type = %v, want INTER_TOR (preserved)", got)
+	}
+}
+
 func TestClusterMonitor_UpdateTargets_PushesToProber(t *testing.T) {
 	client := newMockControllerClient()
 	client.enqueue(controller_agent.PinglistType_TOR_MESH, []*controller_agent.PingTarget{targetWithGID("tor-a")}, nil)

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -226,11 +226,21 @@ type Prober struct {
 	// second close(resultChan) panics.
 	destroyOnce sync.Once
 
-	// rateMu guards the send-rate limiter, which SetPerTargetRateLimit may update from
-	// a different goroutine than the probe loop.
-	rateMu       sync.Mutex // guards limiter and perTargetPPS; lock order: targetsMu -> rateMu
-	limiter      probe.RateLimiter
-	perTargetPPS float64
+	// rateMu guards the per-pinglist-type send-rate limiters, which
+	// SetPerTypeRateLimit / SetPerTargetRateLimit may update from a different
+	// goroutine than the probe loop. Lock order: targetsMu -> rateMu.
+	//
+	// There is one limiter per pinglist type (ToR-mesh, inter-ToR) so the two
+	// types can be capped at independent per-target rates (R-Pingmesh probes
+	// ToR-mesh more aggressively than inter-ToR). Each limiter's aggregate rate
+	// is pps * (number of targets of that type), recomputed on every
+	// UpdateTargets so the configured per-target cadence survives pinglist
+	// churn -- exactly as the single aggregate limiter did before, but scoped
+	// per type. sendProbes selects the limiter matching each target's
+	// PinglistType.
+	rateMu       sync.Mutex
+	torMeshRate  perTypeRate
+	interTorRate perTypeRate
 
 	// flowLabelRotationPeriodSec is the period over which the rotating subset
 	// of each target's flow-label set is refreshed. Read only by the probe-loop
@@ -250,6 +260,17 @@ type Prober struct {
 	labelCache map[string]*labelSet
 
 	logger zerolog.Logger
+}
+
+// perTypeRate couples the configured per-target probe rate (pps) for one
+// pinglist type with the aggregate RateLimiter that enforces it. The limiter's
+// rate is pps * (number of targets of that type); pps is retained so
+// UpdateTargets can recompute the aggregate rate when the pinglist size
+// changes. The zero value is a disabled limiter (pps 0), which is what a
+// struct-literal Prober in tests starts with.
+type perTypeRate struct {
+	pps     float64
+	limiter probe.RateLimiter
 }
 
 // labelSet is a cached flow-label set plus the inputs that produced it, so the
@@ -359,29 +380,74 @@ func (p *Prober) Stop() {
 }
 
 // SetPerTargetRateLimit caps the probe send rate to at most pps packets per
-// second per target. The aggregate limiter rate is recomputed as
-// pps * len(targets) here and on every UpdateTargets call, so the configured
-// per-target cadence is preserved as the pinglist grows or shrinks. A
-// non-positive pps disables rate limiting. Safe to call while running.
+// second per target, applying the SAME cap to both pinglist types. It is the
+// backward-compatible single-rate entry point (differentiated rates go through
+// SetPerTypeRateLimit). Each type's aggregate limiter rate is recomputed as
+// pps * (targets of that type) here and on every UpdateTargets call, so the
+// configured per-target cadence is preserved as the pinglist grows or shrinks.
+// A non-positive pps disables rate limiting. Safe to call while running.
 func (p *Prober) SetPerTargetRateLimit(pps float64) {
+	p.SetPerTypeRateLimit(pps, pps)
+}
+
+// SetPerTypeRateLimit caps the probe send rate per target at torMeshPPS for
+// ToR-mesh targets and interTorPPS for inter-ToR targets, independently. Each
+// type's aggregate limiter is set to pps * (number of targets of that type) so
+// the per-target cadence is preserved as the pinglist changes; a non-positive
+// pps disables limiting for that type. Safe to call while running.
+func (p *Prober) SetPerTypeRateLimit(torMeshPPS, interTorPPS float64) {
 	// Hold targetsMu across the whole rate update, taking rateMu nested. This
 	// matches UpdateTargets' lock order (targetsMu -> rateMu) and closes a
-	// TOCTOU window: reading len(targets) and recomputing the aggregate rate
-	// must be atomic w.r.t. a concurrent UpdateTargets, otherwise the two could
-	// interleave and leave the limiter with a rate computed from a stale count.
+	// TOCTOU window: reading the per-type target counts and recomputing the
+	// aggregate rates must be atomic w.r.t. a concurrent UpdateTargets,
+	// otherwise the two could interleave and leave a limiter with a rate
+	// computed from a stale count.
 	p.targetsMu.RLock()
 	defer p.targetsMu.RUnlock()
-	n := len(p.targets)
+	nTorMesh, nInterTor := countTargetsByType(p.targets)
 
 	p.rateMu.Lock()
-	p.perTargetPPS = pps
-	p.limiter.SetRate(pps * float64(n))
+	p.torMeshRate.pps = torMeshPPS
+	p.torMeshRate.limiter.SetRate(torMeshPPS * float64(nTorMesh))
+	p.interTorRate.pps = interTorPPS
+	p.interTorRate.limiter.SetRate(interTorPPS * float64(nInterTor))
 	p.rateMu.Unlock()
 
 	p.logger.Info().
-		Float64("per_target_pps", pps).
-		Int("targets", n).
-		Msg("Probe send rate limit updated")
+		Float64("tor_mesh_pps", torMeshPPS).
+		Int("tor_mesh_targets", nTorMesh).
+		Float64("inter_tor_pps", interTorPPS).
+		Int("inter_tor_targets", nInterTor).
+		Msg("Probe send rate limits updated")
+}
+
+// countTargetsByType counts how many targets belong to each pinglist type. A
+// nil target and any type other than INTER_TOR count as ToR-mesh, which also
+// makes the (proto3-default) zero PinglistType read as TOR_MESH -- the
+// backward-compatible reading of targets from a controller that never stamped
+// the field.
+func countTargetsByType(targets []*controller_agent.PingTarget) (nTorMesh, nInterTor int) {
+	for _, t := range targets {
+		if t == nil {
+			continue
+		}
+		if t.GetPinglistType() == controller_agent.PinglistType_INTER_TOR {
+			nInterTor++
+		} else {
+			nTorMesh++
+		}
+	}
+	return nTorMesh, nInterTor
+}
+
+// rateForType returns the limiter state governing the given pinglist type.
+// INTER_TOR maps to the inter-ToR limiter; everything else (TOR_MESH and the
+// proto3 default) maps to the ToR-mesh limiter. Callers must hold rateMu.
+func (p *Prober) rateForType(ptype controller_agent.PinglistType) *perTypeRate {
+	if ptype == controller_agent.PinglistType_INTER_TOR {
+		return &p.interTorRate
+	}
+	return &p.torMeshRate
 }
 
 // SetFlowLabelRotationPeriod sets the period over which the rotating subset of
@@ -441,17 +507,24 @@ func (p *Prober) UpdateTargets(targets []*controller_agent.PingTarget) {
 	defer p.targetsMu.Unlock()
 	p.targets = targets
 
-	// Keep the aggregate limiter in sync with the per-target rate so the
-	// per-target cadence survives pinglist size changes. Lock order is
-	// always targetsMu -> rateMu.
+	// Keep each type's aggregate limiter in sync with its per-target rate so the
+	// per-target cadence survives pinglist size changes (a type whose count
+	// shrinks must slow its aggregate, and vice versa). Lock order is always
+	// targetsMu -> rateMu.
+	nTorMesh, nInterTor := countTargetsByType(targets)
 	p.rateMu.Lock()
-	if p.perTargetPPS > 0 {
-		p.limiter.SetRate(p.perTargetPPS * float64(len(targets)))
+	if p.torMeshRate.pps > 0 {
+		p.torMeshRate.limiter.SetRate(p.torMeshRate.pps * float64(nTorMesh))
+	}
+	if p.interTorRate.pps > 0 {
+		p.interTorRate.limiter.SetRate(p.interTorRate.pps * float64(nInterTor))
 	}
 	p.rateMu.Unlock()
 
 	p.logger.Info().
 		Int("count", len(targets)).
+		Int("tor_mesh_count", nTorMesh).
+		Int("inter_tor_count", nInterTor).
 		Msg("Probe targets updated")
 }
 
@@ -536,9 +609,10 @@ func (p *Prober) sendProbes(ctx context.Context) {
 			continue
 		}
 
-		// Apply the optional send-rate limit, spacing sends across targets.
-		// The wait is interruptible so Stop() is not delayed by the limiter.
-		if !p.rateLimitWait(ctx) {
+		// Apply the optional send-rate limit for this target's pinglist type,
+		// spacing sends across targets of the same type. The wait is
+		// interruptible so Stop() is not delayed by the limiter.
+		if !p.rateLimitWait(ctx, target.GetPinglistType()) {
 			return
 		}
 
@@ -710,13 +784,13 @@ func (p *Prober) pruneLabelRotation(targets []*controller_agent.PingTarget) {
 }
 
 // rateLimitWait blocks for the duration required by the configured send-rate
-// limit before the next probe may be sent. It returns false if the wait was
-// interrupted by ctx cancellation or Stop(), in which case the caller should
-// abandon the current send batch. When rate limiting is disabled it returns
-// true immediately.
-func (p *Prober) rateLimitWait(ctx context.Context) bool {
+// limit for the given pinglist type before the next probe of that type may be
+// sent. It returns false if the wait was interrupted by ctx cancellation or
+// Stop(), in which case the caller should abandon the current send batch. When
+// rate limiting is disabled for the type it returns true immediately.
+func (p *Prober) rateLimitWait(ctx context.Context, ptype controller_agent.PinglistType) bool {
 	p.rateMu.Lock()
-	wait := p.limiter.Reserve(time.Now())
+	wait := p.rateForType(ptype).limiter.Reserve(time.Now())
 	p.rateMu.Unlock()
 
 	if wait <= 0 {

--- a/rebuild/internal/agent/prober_flowlabel_test.go
+++ b/rebuild/internal/agent/prober_flowlabel_test.go
@@ -261,13 +261,15 @@ func TestPerTargetRateLimit_IndependentOfFlowLabelCount(t *testing.T) {
 	// per-target flow-label count, i.e. a 50ms minimum spacing.
 	wantInterval := time.Duration(float64(time.Second) / (pps * float64(len(targets))))
 
+	// Both targets carry the proto3-default PinglistType (TOR_MESH), so their
+	// aggregate rate lands on the ToR-mesh limiter.
 	base := time.Now()
-	if w := p.limiter.Reserve(base); w != 0 {
+	if w := p.torMeshRate.limiter.Reserve(base); w != 0 {
 		t.Fatalf("first Reserve wait = %v, want 0", w)
 	}
 	// The next send, requested at the same instant, must wait exactly one
 	// aggregate interval -- proving n (=64) did not inflate the rate.
-	if w := p.limiter.Reserve(base); w != wantInterval {
+	if w := p.torMeshRate.limiter.Reserve(base); w != wantInterval {
 		t.Fatalf("second Reserve wait = %v, want %v (rate independent of flow_label_count)", w, wantInterval)
 	}
 }

--- a/rebuild/internal/agent/prober_ratelimit_test.go
+++ b/rebuild/internal/agent/prober_ratelimit_test.go
@@ -1,0 +1,220 @@
+// Tests for the prober's differentiated, per-pinglist-type send-rate limiting:
+// each pinglist type (ToR-mesh, inter-ToR) is capped at its own per-target rate
+// by an independent limiter whose aggregate rate tracks that type's target
+// count, the legacy single-rate entry point applies one rate to both types, and
+// the targetsMu -> rateMu lock order holds under concurrent updates.
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// typedTargets builds n targets of the given pinglist type. GIDs are unique
+// across a call so the prober's per-target maps do not collide, but the tests
+// here only exercise counting and rate resolution.
+func typedTargets(ptype controller_agent.PinglistType, prefix string, n int) []*controller_agent.PingTarget {
+	targets := make([]*controller_agent.PingTarget, 0, n)
+	for i := 0; i < n; i++ {
+		targets = append(targets, &controller_agent.PingTarget{
+			TargetGid:    prefix + string(rune('a'+i)),
+			PinglistType: ptype,
+		})
+	}
+	return targets
+}
+
+// wantInterval computes the minimum inter-send interval a limiter set to
+// pps*n aggregate pps reports. It mirrors RateLimiter.SetRate's own
+// computation (including its truncation to time.Duration) exactly, and takes n
+// as a runtime int so the division is not a constant expression (a constant
+// non-integer conversion to time.Duration is a compile error).
+func wantInterval(pps float64, n int) time.Duration {
+	return time.Duration(float64(time.Second) / (pps * float64(n)))
+}
+
+// reserveInterval returns the spacing a fresh limiter reports: the second
+// Reserve at the same instant is the configured minimum inter-send interval,
+// which encodes the limiter's rate (interval = 1 / rate).
+func reserveInterval(rl interface {
+	Reserve(time.Time) time.Duration
+}) time.Duration {
+	now := time.Now()
+	_ = rl.Reserve(now) // first send: no prior schedule, no wait
+	return rl.Reserve(now)
+}
+
+// TestPerTypeRateLimit_Independent verifies that a pinglist with many ToR-mesh
+// targets and few inter-ToR targets yields two independent aggregate rates:
+// each type's limiter is torPPS*nTor / interPPS*nInter, and neither type's
+// count or rate leaks into the other's limiter.
+func TestPerTypeRateLimit_Independent(t *testing.T) {
+	const (
+		torPPS   = 10.0
+		interPPS = 1.0
+		nTor     = 5
+		nInter   = 2
+	)
+
+	targets := append(
+		typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", nTor),
+		typedTargets(controller_agent.PinglistType_INTER_TOR, "int", nInter)...,
+	)
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(targets)
+	p.SetPerTypeRateLimit(torPPS, interPPS)
+
+	wantTor := wantInterval(torPPS, nTor)       // 20ms
+	wantInter := wantInterval(interPPS, nInter) // 500ms
+
+	if got := reserveInterval(&p.torMeshRate.limiter); got != wantTor {
+		t.Errorf("ToR-mesh limiter interval = %v, want %v (%d targets @ %.0f pps)", got, wantTor, nTor, torPPS)
+	}
+	if got := reserveInterval(&p.interTorRate.limiter); got != wantInter {
+		t.Errorf("inter-ToR limiter interval = %v, want %v (%d targets @ %.0f pps)", got, wantInter, nInter, interPPS)
+	}
+}
+
+// TestPerTypeRateLimit_FollowsPinglistSize verifies that each type's aggregate
+// rate is recomputed on UpdateTargets, so a change in one type's target count
+// re-scales only that type's limiter while the other stays put.
+func TestPerTypeRateLimit_FollowsPinglistSize(t *testing.T) {
+	const (
+		torPPS   = 10.0
+		interPPS = 2.0
+	)
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(append(
+		typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", 2),
+		typedTargets(controller_agent.PinglistType_INTER_TOR, "int", 3)...,
+	))
+	p.SetPerTypeRateLimit(torPPS, interPPS)
+
+	// Grow ToR-mesh to 4, shrink inter-ToR to 1; the limiters must follow.
+	p.UpdateTargets(append(
+		typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", 4),
+		typedTargets(controller_agent.PinglistType_INTER_TOR, "int", 1)...,
+	))
+
+	wantTor := wantInterval(torPPS, 4)
+	wantInter := wantInterval(interPPS, 1)
+
+	if got := reserveInterval(&p.torMeshRate.limiter); got != wantTor {
+		t.Errorf("ToR-mesh limiter interval after resize = %v, want %v", got, wantTor)
+	}
+	if got := reserveInterval(&p.interTorRate.limiter); got != wantInter {
+		t.Errorf("inter-ToR limiter interval after resize = %v, want %v", got, wantInter)
+	}
+}
+
+// TestSetPerTargetRateLimit_Fallback verifies the backward-compatible entry
+// point applies one uniform rate to both pinglist types, each scaled by that
+// type's own target count -- the single-rate behavior deployments had before
+// differentiated rates existed.
+func TestSetPerTargetRateLimit_Fallback(t *testing.T) {
+	const pps = 10.0
+	const nTor = 3
+	const nInter = 2
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(append(
+		typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", nTor),
+		typedTargets(controller_agent.PinglistType_INTER_TOR, "int", nInter)...,
+	))
+	p.SetPerTargetRateLimit(pps)
+
+	wantTor := wantInterval(pps, nTor)
+	wantInter := wantInterval(pps, nInter)
+
+	if got := reserveInterval(&p.torMeshRate.limiter); got != wantTor {
+		t.Errorf("ToR-mesh limiter interval = %v, want %v", got, wantTor)
+	}
+	if got := reserveInterval(&p.interTorRate.limiter); got != wantInter {
+		t.Errorf("inter-ToR limiter interval = %v, want %v", got, wantInter)
+	}
+}
+
+// TestPerTypeRateLimit_UnstampedTargetsAreTorMesh verifies that targets with
+// the proto3-default PinglistType (0 = TOR_MESH), as an older controller would
+// send, all count toward the ToR-mesh limiter -- the backward-compatible
+// classification.
+func TestPerTypeRateLimit_UnstampedTargetsAreTorMesh(t *testing.T) {
+	const pps = 4.0
+	// Targets built without setting PinglistType default to TOR_MESH.
+	targets := []*controller_agent.PingTarget{
+		{TargetGid: "fe80::1"},
+		{TargetGid: "fe80::2"},
+	}
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(targets)
+	p.SetPerTypeRateLimit(pps, pps)
+
+	wantTor := wantInterval(pps, 2)
+	if got := reserveInterval(&p.torMeshRate.limiter); got != wantTor {
+		t.Errorf("ToR-mesh limiter interval = %v, want %v (unstamped targets)", got, wantTor)
+	}
+	// No inter-ToR targets, so its limiter stays disabled (Reserve == 0).
+	if p.interTorRate.limiter.Enabled() {
+		t.Error("inter-ToR limiter should be disabled with zero inter-ToR targets")
+	}
+}
+
+// TestPerTypeRateLimit_LockOrderRace hammers UpdateTargets, SetPerTypeRateLimit,
+// and the rateMu-guarded limiter read path concurrently. Run under -race, it
+// guards against a data race or a lock-order regression (all writers take
+// targetsMu -> rateMu; the reader takes only rateMu) that would deadlock.
+func TestPerTypeRateLimit_LockOrderRace(t *testing.T) {
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", 4))
+
+	// A pre-cancelled context makes rateLimitWait return immediately on any
+	// non-zero reservation instead of sleeping, so the reader still hits the
+	// rateMu-guarded Reserve every iteration without slowing the test.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var wg sync.WaitGroup
+	const iters = 500
+
+	// Writer 1: resize the pinglist (targetsMu -> rateMu).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.UpdateTargets(append(
+				typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", 1+i%6),
+				typedTargets(controller_agent.PinglistType_INTER_TOR, "int", 1+i%3)...,
+			))
+		}
+	}()
+
+	// Writer 2: change the per-type rates (targetsMu -> rateMu).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.SetPerTypeRateLimit(float64(1+i%10), float64(1+i%4))
+		}
+	}()
+
+	// Reader: the send path's rate check (rateMu only). A cancelled context
+	// makes any non-zero wait return immediately without a real sleep.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.rateLimitWait(ctx, controller_agent.PinglistType_TOR_MESH)
+			p.rateLimitWait(ctx, controller_agent.PinglistType_INTER_TOR)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -9,8 +9,23 @@ import (
 	"github.com/spf13/viper"
 )
 
-// DefaultTargetProbeRatePerSecond is the default number of probes per second per target.
+// DefaultTargetProbeRatePerSecond is the default number of probes per second
+// per target. It is the backward-compatible uniform rate: when neither
+// tor_mesh_probe_rate_per_second nor inter_tor_probe_rate_per_second is set
+// (both 0), this rate applies to targets of both pinglist types, reproducing
+// the pre-differentiation single-rate behavior.
 const DefaultTargetProbeRatePerSecond = 10
+
+// DefaultTorMeshProbeRatePerSecond and DefaultInterTorProbeRatePerSecond are
+// the defaults for the per-pinglist-type probe rates. They are 0, meaning
+// "inherit target_probe_rate_per_second" so that a deployment which only ever
+// set the legacy single rate keeps its uniform behavior after upgrading. Set
+// them to positive values (see the recommended configs/agent.yaml: ToR-mesh
+// 10pps, inter-ToR 1pps) to get the paper's differentiated per-type rates.
+const (
+	DefaultTorMeshProbeRatePerSecond  = 0
+	DefaultInterTorProbeRatePerSecond = 0
+)
 
 // DefaultFlowLabelRotationPeriodSec is the default period (seconds) over which
 // the rotating subset (~20%) of a target's ECMP flow-label set is refreshed,
@@ -55,7 +70,17 @@ type AgentConfig struct {
 	// target DSCP value D maps to traffic_class = D << 2.
 	TrafficClass              int    `mapstructure:"traffic_class"`
 	PinglistUpdateIntervalSec uint32 `mapstructure:"pinglist_update_interval_sec"`
-	TargetProbeRatePerSecond  int    `mapstructure:"target_probe_rate_per_second"`
+	// TargetProbeRatePerSecond is the legacy uniform per-target probe rate. It
+	// is the fallback for whichever per-pinglist-type rate below is left unset
+	// (0). See EffectiveTorMeshProbeRate / EffectiveInterTorProbeRate.
+	TargetProbeRatePerSecond int `mapstructure:"target_probe_rate_per_second"`
+	// TorMeshProbeRatePerSecond and InterTorProbeRatePerSecond are the
+	// differentiated per-target probe rates for ToR-mesh and inter-ToR targets
+	// respectively (R-Pingmesh probes ToR-mesh more aggressively than inter-ToR).
+	// A value of 0 means "inherit TargetProbeRatePerSecond" for backward
+	// compatibility; a positive value overrides it for that pinglist type.
+	TorMeshProbeRatePerSecond  int `mapstructure:"tor_mesh_probe_rate_per_second"`
+	InterTorProbeRatePerSecond int `mapstructure:"inter_tor_probe_rate_per_second"`
 	// FlowLabelRotationPeriodSec is the period over which the rotating subset
 	// of each target's ECMP flow-label set is refreshed (time-based ECMP path
 	// rotation). See DefaultFlowLabelRotationPeriodSec.
@@ -106,6 +131,8 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	v.SetDefault("traffic_class", 0)
 	v.SetDefault("pinglist_update_interval_sec", 300)
 	v.SetDefault("target_probe_rate_per_second", DefaultTargetProbeRatePerSecond)
+	v.SetDefault("tor_mesh_probe_rate_per_second", DefaultTorMeshProbeRatePerSecond)
+	v.SetDefault("inter_tor_probe_rate_per_second", DefaultInterTorProbeRatePerSecond)
 	v.SetDefault("flow_label_rotation_period_sec", DefaultFlowLabelRotationPeriodSec)
 	v.SetDefault("analysis_report_enabled", true)
 	v.SetDefault("analysis_window_sec", DefaultAnalysisWindowSec)
@@ -181,6 +208,8 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 		TrafficClass:               v.GetInt("traffic_class"),
 		PinglistUpdateIntervalSec:  v.GetUint32("pinglist_update_interval_sec"),
 		TargetProbeRatePerSecond:   v.GetInt("target_probe_rate_per_second"),
+		TorMeshProbeRatePerSecond:  v.GetInt("tor_mesh_probe_rate_per_second"),
+		InterTorProbeRatePerSecond: v.GetInt("inter_tor_probe_rate_per_second"),
 		FlowLabelRotationPeriodSec: v.GetUint32("flow_label_rotation_period_sec"),
 		AnalysisReportEnabled:      v.GetBool("analysis_report_enabled"),
 		AnalysisWindowSec:          v.GetUint32("analysis_window_sec"),
@@ -233,6 +262,17 @@ func (c *AgentConfig) Validate() error {
 		return fmt.Errorf("flow_label_rotation_period_sec must be > 0, got: %d", c.FlowLabelRotationPeriodSec)
 	}
 
+	// Per-pinglist-type probe rates must be non-negative; 0 selects the
+	// backward-compatible fallback to target_probe_rate_per_second. A negative
+	// value is meaningless (the limiter treats <=0 as "disabled", which would
+	// silently defeat the intended cap), so reject it up front.
+	if c.TorMeshProbeRatePerSecond < 0 {
+		return fmt.Errorf("tor_mesh_probe_rate_per_second must be >= 0, got: %d", c.TorMeshProbeRatePerSecond)
+	}
+	if c.InterTorProbeRatePerSecond < 0 {
+		return fmt.Errorf("inter_tor_probe_rate_per_second must be >= 0, got: %d", c.InterTorProbeRatePerSecond)
+	}
+
 	// When analysis reporting is on, the window drives a time.Ticker and the
 	// aggregator's window alignment, both of which require a positive length.
 	if c.AnalysisReportEnabled && c.AnalysisWindowSec == 0 {
@@ -247,6 +287,27 @@ func (c *AgentConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// EffectiveTorMeshProbeRate returns the per-target probe rate (probes/sec) to
+// apply to ToR-mesh targets. TorMeshProbeRatePerSecond takes effect when it is
+// positive; otherwise it falls back to TargetProbeRatePerSecond so a deployment
+// that only set the legacy uniform rate keeps its behavior unchanged.
+func (c *AgentConfig) EffectiveTorMeshProbeRate() int {
+	if c.TorMeshProbeRatePerSecond > 0 {
+		return c.TorMeshProbeRatePerSecond
+	}
+	return c.TargetProbeRatePerSecond
+}
+
+// EffectiveInterTorProbeRate returns the per-target probe rate (probes/sec) to
+// apply to inter-ToR targets, using the same fallback rule as
+// EffectiveTorMeshProbeRate.
+func (c *AgentConfig) EffectiveInterTorProbeRate() int {
+	if c.InterTorProbeRatePerSecond > 0 {
+		return c.InterTorProbeRatePerSecond
+	}
+	return c.TargetProbeRatePerSecond
 }
 
 // BindAgentFlags binds common agent CLI flags to a pflag.FlagSet.
@@ -264,7 +325,9 @@ func BindAgentFlags(flags *pflag.FlagSet) {
 	flags.Int("service-level", 0, "Service Level (SL, PFC priority) for Address Handles (0-7)")
 	flags.Int("traffic-class", 0, "GRH traffic class (DSCP << 2) for Address Handles (0-255)")
 	flags.Uint32("pinglist-update-interval-sec", 300, "Pinglist update interval in seconds")
-	flags.Int("target-probe-rate-per-second", DefaultTargetProbeRatePerSecond, "Probe rate per second per target")
+	flags.Int("target-probe-rate-per-second", DefaultTargetProbeRatePerSecond, "Legacy uniform probe rate per second per target (fallback for the per-type rates below when they are 0)")
+	flags.Int("tor-mesh-probe-rate-per-second", DefaultTorMeshProbeRatePerSecond, "Probe rate per second per ToR-mesh target (0 = inherit target-probe-rate-per-second)")
+	flags.Int("inter-tor-probe-rate-per-second", DefaultInterTorProbeRatePerSecond, "Probe rate per second per inter-ToR target (0 = inherit target-probe-rate-per-second)")
 	flags.Uint32("flow-label-rotation-period-sec", DefaultFlowLabelRotationPeriodSec, "Period (seconds) over which the rotating ~20% of each target's ECMP flow-label set is refreshed")
 	flags.Bool("analysis-report-enabled", true, "Enable per-path window aggregation and SLA reporting to the controller")
 	flags.Uint32("analysis-window-sec", DefaultAnalysisWindowSec, "Per-path aggregation window length in seconds")

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -324,6 +324,101 @@ func TestLoadAgentConfig_Defaults(t *testing.T) {
 	}
 }
 
+// TestEffectiveProbeRates verifies the per-pinglist-type rate resolution,
+// including the backward-compatible fallback: when a type-specific rate is 0
+// (unset) it inherits the legacy target_probe_rate_per_second.
+func TestEffectiveProbeRates(t *testing.T) {
+	cases := []struct {
+		name         string
+		target       int
+		torMesh      int
+		interTor     int
+		wantTorMesh  int
+		wantInterTor int
+	}{
+		{
+			name:         "both_unset_falls_back_to_target",
+			target:       10,
+			torMesh:      0,
+			interTor:     0,
+			wantTorMesh:  10,
+			wantInterTor: 10,
+		},
+		{
+			name:         "differentiated_paper_rates",
+			target:       10,
+			torMesh:      10,
+			interTor:     1,
+			wantTorMesh:  10,
+			wantInterTor: 1,
+		},
+		{
+			name:         "only_inter_tor_set_tor_mesh_inherits",
+			target:       8,
+			torMesh:      0,
+			interTor:     5,
+			wantTorMesh:  8,
+			wantInterTor: 5,
+		},
+		{
+			name:         "only_tor_mesh_set_inter_tor_inherits",
+			target:       7,
+			torMesh:      12,
+			interTor:     0,
+			wantTorMesh:  12,
+			wantInterTor: 7,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &AgentConfig{
+				TargetProbeRatePerSecond:   tc.target,
+				TorMeshProbeRatePerSecond:  tc.torMesh,
+				InterTorProbeRatePerSecond: tc.interTor,
+			}
+			if got := cfg.EffectiveTorMeshProbeRate(); got != tc.wantTorMesh {
+				t.Errorf("EffectiveTorMeshProbeRate() = %d, want %d", got, tc.wantTorMesh)
+			}
+			if got := cfg.EffectiveInterTorProbeRate(); got != tc.wantInterTor {
+				t.Errorf("EffectiveInterTorProbeRate() = %d, want %d", got, tc.wantInterTor)
+			}
+		})
+	}
+}
+
+// TestValidate_RejectsNegativePerTypeProbeRates verifies that a negative
+// per-type probe rate is rejected (a negative rate would be silently read as
+// "disabled" by the limiter, defeating the intended cap).
+func TestValidate_RejectsNegativePerTypeProbeRates(t *testing.T) {
+	base := func() *AgentConfig {
+		return &AgentConfig{
+			ProbeIntervalMS:            500,
+			FlowLabelRotationPeriodSec: 3600,
+			TLSMode:                    TLSModeDisabled,
+		}
+	}
+
+	neg := base()
+	neg.TorMeshProbeRatePerSecond = -1
+	if err := neg.Validate(); err == nil {
+		t.Error("Validate() accepted negative tor_mesh_probe_rate_per_second, want error")
+	}
+
+	neg = base()
+	neg.InterTorProbeRatePerSecond = -1
+	if err := neg.Validate(); err == nil {
+		t.Error("Validate() accepted negative inter_tor_probe_rate_per_second, want error")
+	}
+
+	ok := base()
+	ok.TorMeshProbeRatePerSecond = 10
+	ok.InterTorProbeRatePerSecond = 1
+	if err := ok.Validate(); err != nil {
+		t.Errorf("Validate() rejected valid per-type rates: %v", err)
+	}
+}
+
 func TestLoadAgentConfig_FlagOverridesEnvAndFile(t *testing.T) {
 	path := writeYAML(t, "agent.yaml", "controller_addr: \"file-addr:1\"\n")
 	t.Setenv("RPINGMESH_CONTROLLER_ADDR", "env-addr:2")

--- a/rebuild/internal/controller/pinglist/generate_test.go
+++ b/rebuild/internal/controller/pinglist/generate_test.go
@@ -108,6 +108,50 @@ func TestGenerateInterTorPinglist_Success(t *testing.T) {
 	}
 }
 
+// TestGeneratePinglist_StampsPinglistType verifies that the generator stamps
+// each PingTarget with the pinglist type it was generated for, so the agent can
+// apply a differentiated per-type probe rate after merging the two lists.
+func TestGeneratePinglist_StampsPinglistType(t *testing.T) {
+	src := &fakeRnicSource{
+		torMesh: []*controller_agent.RnicInfo{
+			{Gid: "fe80::11", Qpn: 100, TorId: "tor-1"},
+			{Gid: "fe80::12", Qpn: 101, TorId: "tor-1"},
+		},
+		interTor: []*controller_agent.RnicInfo{
+			{Gid: "fe80::21", Qpn: 200, TorId: "tor-2"},
+		},
+	}
+	gen := newTestGenerator(src)
+
+	torMesh, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateTorMeshPinglist: %v", err)
+	}
+	if len(torMesh) == 0 {
+		t.Fatal("expected ToR-mesh targets")
+	}
+	for _, tgt := range torMesh {
+		if tgt.GetPinglistType() != controller_agent.PinglistType_TOR_MESH {
+			t.Errorf("ToR-mesh target %s: PinglistType = %v, want TOR_MESH",
+				tgt.GetTargetGid(), tgt.GetPinglistType())
+		}
+	}
+
+	interTor, err := gen.GenerateInterTorPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateInterTorPinglist: %v", err)
+	}
+	if len(interTor) == 0 {
+		t.Fatal("expected inter-ToR targets")
+	}
+	for _, tgt := range interTor {
+		if tgt.GetPinglistType() != controller_agent.PinglistType_INTER_TOR {
+			t.Errorf("inter-ToR target %s: PinglistType = %v, want INTER_TOR",
+				tgt.GetTargetGid(), tgt.GetPinglistType())
+		}
+	}
+}
+
 // TestGenerateInterTorPinglist_Empty verifies that no sampled RNICs (e.g. a
 // single-ToR cluster where every other ToR is empty) yields an empty,
 // non-nil target slice.

--- a/rebuild/internal/controller/pinglist/pinglist.go
+++ b/rebuild/internal/controller/pinglist/pinglist.go
@@ -60,7 +60,7 @@ func (g *PinglistGenerator) GenerateTorMeshPinglist(
 			continue
 		}
 
-		targets = append(targets, g.buildPingTarget(requesterGID, rnic))
+		targets = append(targets, g.buildPingTarget(requesterGID, rnic, controller_agent.PinglistType_TOR_MESH))
 	}
 
 	log.Info().
@@ -85,7 +85,7 @@ func (g *PinglistGenerator) GenerateInterTorPinglist(
 
 	targets := make([]*controller_agent.PingTarget, 0, len(rnics))
 	for _, rnic := range rnics {
-		targets = append(targets, g.buildPingTarget(requesterGID, rnic))
+		targets = append(targets, g.buildPingTarget(requesterGID, rnic, controller_agent.PinglistType_INTER_TOR))
 	}
 
 	log.Info().
@@ -100,7 +100,9 @@ func (g *PinglistGenerator) GenerateInterTorPinglist(
 // buildPingTarget creates a PingTarget from an RnicInfo with deterministic
 // 5-tuple values based on the requester-target GID pair, plus the ECMP
 // flow-label set sizing (seed + count) the agent expands into concrete labels.
-func (g *PinglistGenerator) buildPingTarget(requesterGID string, rnic *controller_agent.RnicInfo) *controller_agent.PingTarget {
+// ptype records which pinglist the target came from so the agent can apply a
+// differentiated, per-pinglist-type probe rate.
+func (g *PinglistGenerator) buildPingTarget(requesterGID string, rnic *controller_agent.RnicInfo, ptype controller_agent.PinglistType) *controller_agent.PingTarget {
 	targetGID := rnic.GetGid()
 	seed := flowLabelSeed(requesterGID, targetGID)
 	return &controller_agent.PingTarget{
@@ -110,6 +112,7 @@ func (g *PinglistGenerator) buildPingTarget(requesterGID string, rnic *controlle
 		TargetHostname:   rnic.GetHostName(),
 		TargetTorId:      rnic.GetTorId(),
 		TargetDeviceName: rnic.GetDeviceName(),
+		PinglistType:     ptype,
 		// FlowLabel is the legacy base label (low 20 bits of the seed), kept
 		// for backward compatibility and used verbatim when FlowLabelCount<=1.
 		FlowLabel: seed & 0xFFFFF,

--- a/rebuild/proto/controller_agent/controller_agent.proto
+++ b/rebuild/proto/controller_agent/controller_agent.proto
@@ -83,6 +83,15 @@ message PingTarget {
     // message (seed + count is far smaller than a repeated list). The agent
     // derives label i from a hash of (seed, i, rotation_epoch).
     fixed32 flow_label_seed = 11;
+    // pinglist_type records which pinglist this target belongs to (ToR-mesh vs
+    // inter-ToR). The controller stamps it in GenerateTorMeshPinglist /
+    // GenerateInterTorPinglist -- the only place the classification is known --
+    // so the agent can apply a differentiated, per-pinglist-type probe rate
+    // (e.g. ToR-mesh at 10pps, inter-ToR at 1pps) without re-deriving the type
+    // after the two lists are merged into a single target list. It defaults to
+    // TOR_MESH (0), which is also the backward-compatible reading of targets
+    // from an older controller that did not stamp the field.
+    PinglistType pinglist_type = 12;
 }
 
 // PinglistResponse contains the list of targets to probe.


### PR DESCRIPTION
## Summary

R-Pingmesh probes the ToR-mesh more aggressively than inter-ToR (paper), but the rebuild merged the two pinglists into one target list and drove a **single aggregate rate limiter**, so the per-type distinction was lost. This PR carries the pinglist type end to end and caps each type independently.

## Changes

- **proto**: add `PingTarget.pinglist_type` (field 12). The controller stamps it in `GenerateTorMeshPinglist` / `GenerateInterTorPinglist` — the only place the classification is known — so the agent keeps it after merging the two lists. (`.pb.go` is gitignored / regenerated.)
- **config (agent)**: add `tor_mesh_probe_rate_per_second` and `inter_tor_probe_rate_per_second`. Either left at `0` **inherits `target_probe_rate_per_second`**, so existing single-rate deployments are unchanged on upgrade. `EffectiveTorMeshProbeRate` / `EffectiveInterTorProbeRate` resolve the fallback; `Validate()` rejects negative per-type rates. The shipped `configs/agent.yaml` demonstrates the paper-style split (ToR-mesh 10, inter-ToR 1).
- **prober**: replace the single aggregate limiter with **one limiter per pinglist type**. `UpdateTargets` counts targets per type and sets each limiter to `pps_type * n_type`; `sendProbes` selects the limiter by the target's type. `SetPerTargetRateLimit` becomes a backward-compatible wrapper over the new `SetPerTypeRateLimit`.
- **README**: new config keys documented; the "single, uniform probe rate cap" limitation is replaced by a "Differentiated per-pinglist-type probe rates" design note (including the sequential-loop caveat below).

## Design decisions

- **Backward compatibility over paper defaults.** The per-type keys default to `0` (= inherit the legacy uniform rate), not to 10/1. A non-zero default would silently override an existing `target_probe_rate_per_second` on upgrade. Differentiated rates are opt-in via the (shipped) example config.
- **Contract preserved.** The `targetsMu -> rateMu` lock order (and the `SetPerTargetRateLimit` TOCTOU fix from the previous round) and the per-**target** (not per-flow-label) cap semantics are unchanged; only the limiter is now scoped per type.
- **Sequential-loop caveat.** The two limiters cap their types independently, but probes are still sent from one per-round loop, so in the uncommon regime where the caps actually **bind** (i.e. `probe_interval_ms` short enough that a round would otherwise exceed the caps) the two types are paced sequentially, not concurrently. At the default `probe_interval_ms: 500` the caps do not bind, so this is not observable. Fully decoupling would need a send loop per type and is deferred.

## Testing

- `go test -race` (Linux container, full CGO/RDMA build env): `internal/agent` (per-type independence, aggregate follow on pinglist resize, backward-compat fallback, unstamped-targets-are-ToR-mesh, `-race` lock-order regression), `internal/config`, `internal/controller/...`, `internal/probe` — all pass.
- Controller e2e (`make test-e2e-controller`, no RDMA): passes, including new assertions that the controller stamps `pinglist_type` (TOR_MESH / INTER_TOR) in `GetPinglist` responses.
- `go build ./...` + `go vet` (Linux): pass (incl. cgo `cmd/agent` link).
- soft-RoCE e2e (`make test-e2e`): regression check.

**Do not merge** — for review.