### PR TITLE
docs(rebuild): P3 design docs — Phase 2 localization, RNIC reinit, eBPF service tracing

### DIFF
--- a/rebuild/docs/design/analyzer-phase2-localization.md
+++ b/rebuild/docs/design/analyzer-phase2-localization.md
@@ -1,0 +1,528 @@
+# Analyzer Phase 2 — Topology-Aware Switch/Link Fault Localization
+
+Status: Design only (P3-H). No implementation is proposed here; this document
+specifies what a later implementation round will build on top of the Phase 1
+analyzer merged in PR #36.
+
+## Goals
+
+- Turn the per-path SLA violations produced by Phase 1 into **actionable fault
+  localization**: identify the specific ToR switch (and, as a topology-gated
+  extension, the specific fabric link/spine) most likely responsible for a
+  correlated set of degraded paths.
+- Do this **across agents**: a single agent only sees its own probes and cannot
+  tell "my uplink is bad" from "the target ToR is bad". Localization is
+  inherently a cross-agent intersection problem, exactly as in the SIGCOMM 2024
+  R-Pingmesh paper.
+- Reuse the Phase 1 substrate unchanged where possible: the in-memory window
+  ring in `internal/controller/analyzer/analyzer.go`, the ToR-granularity OTLP
+  convention, and the `PathSummary` proto.
+- Keep all metric output at **ToR granularity** (`source_tor` / `target_tor` /
+  `suspect_tor`), consistent with the project-wide cardinality rule. GID detail
+  stays in findings logs only.
+
+## Non-Goals
+
+- No new probing mechanism, no change to the 6-timestamp protocol or the
+  agent-side `PathAggregator` windowing.
+- No claim to localize below the granularity the available topology supports.
+  With today's registry (a flat GID→ToR map) the achievable granularity is the
+  **ToR switch and its adjacent link tier**. Per-spine / per-link localization
+  is specified but explicitly gated on a topology model that does not exist yet
+  (see "Topology extension").
+- No real-time alerting/paging pipeline. Findings are emitted as structured logs
+  and OTLP metrics; downstream alerting is out of scope.
+- No historical/forensic query API. rqlite persistence is specified as an
+  optional, additive capability, not a query surface.
+
+## Current State (verified against code)
+
+- **Phase 1 analyzer** (`internal/controller/analyzer/analyzer.go`): ingests
+  `ProbeAnalysisReport` batches via `Analyzer.Ingest`, retains the most recent
+  `WindowRetention` (default 20, `DefaultAnalyzerWindowRetention`) windows in an
+  in-memory ring of `windowBucket{windowStartUnixNs, summaries}`, and flags
+  per-summary SLA violations in `evaluate` (loss ratio and p99 RTT). It already
+  keeps every summary of the retained windows around — the comment on
+  `windowBucket` explicitly calls this "the substrate a future Phase 2
+  cross-agent localization pass would read." Phase 2 is that pass.
+- **Retention ring** is keyed and sorted by `windowStartUnixNs`. Because agent
+  windows are wall-clock aligned (`PathAggregator.windowStart` floors to
+  multiples of `windowNs`), summaries from different agents for the same real
+  window land in the **same bucket** — this is what makes cross-agent
+  intersection possible without extra bookkeeping.
+- **`PathSummary`** (`proto/controller_agent/controller_agent.proto`) carries
+  `source_gid`, `source_tor_id`, `target_gid`, `target_tor_id`, `target_qpn`,
+  window bounds, `probe_total/success/failed`, `invalid_rtt_count`, and RTT
+  `min/max/p50/p99` in ns. RTT percentiles are agent-side estimates from a fixed
+  bucket ladder (`rttBucketBoundariesNs` in `internal/probe/aggregator.go`); the
+  raw bucket histogram is **not** currently on the wire.
+- **Topology source of truth** is the `rnics` table
+  (`internal/controller/registry/registry.go`): columns `rnic_gid, qpn,
+  agent_id, agent_ip, rnic_ip, tor_id, hostname, device_name,
+  last_updated_epoch`. The controller therefore knows **GID→ToR** and
+  **ToR→{GIDs}** for active RNICs, and nothing about the aggregation/spine tier:
+  there is no switch table, no link table, no path→link mapping.
+- **OTLP**: `analyzer/metrics.go` exposes `rpingmesh.analyzer.path_summaries_total`
+  and `rpingmesh.analyzer.sla_violations_total{source_tor,target_tor,kind}`. The
+  P1 design reserved `rpingmesh.analyzer.suspect_tor` for Phase 2.
+- **Controller metrics wiring**: `cmd/controller/main.go setupAnalyzer` builds a
+  `service.name=rpingmesh-analyzer` meter provider and calls `analyzer.New(...)`
+  + `svc.SetAnalyzer(az)`. Phase 2 metrics register on the same meter.
+
+The decisive consequence of the current state: **localization granularity is
+bounded by topology knowledge, and today that knowledge is ToR-flat.** The
+design below is split into a minimal pass that ships on the existing data and an
+advanced pass that is correct only once a fabric model is added.
+
+## Design
+
+### Overview
+
+Phase 2 adds a **localizer** that runs after each window is complete, reads the
+retained window buckets, aggregates per-path summaries up to **ToR-pair**
+granularity, applies a fault-localization pass, and emits ranked suspect ToRs
+(and, when topology permits, suspect links) as findings + OTLP gauges. It is a
+new file `internal/controller/analyzer/localizer.go` in the existing package;
+`Analyzer` gains a post-window hook that invokes it.
+
+```
+per-agent PathSummary (window W)
+        │  (already ingested + retained by Phase 1)
+        ▼
+window bucket W  ──► Localizer.Localize(W):
+        1. join summaries with registry topology (GID→ToR)   [already known]
+        2. fold to ToR-pair edges: loss/degraded per (S_tor,T_tor)
+        3. classify + score suspects (minimal heuristic)      [ships now]
+        4. [gated] map edges→links, run set-cover             [needs topology]
+        5. rank, apply finding hysteresis, emit logs+OTLP
+```
+
+### Step 1–2: ToR-pair edge model
+
+Define an **edge** as an ordered ToR pair `(S, T)`. For a completed window,
+merge every summary whose `(source_tor_id, target_tor_id) = (S, T)` — possibly
+from many agents and many GIDs — into an `EdgeStat`:
+
+```
+EdgeStat {
+    S, T            string          // source ToR, target ToR
+    probeTotal      uint64          // Σ probe_total
+    probeFailed     uint64          // Σ probe_failed
+    lossRatio       float64         // probeFailed / probeTotal
+    rttP99Ns        uint64          // see "Cross-agent quantile synthesis"
+    agentsReporting int             // distinct agent_id contributing
+    pathsReporting  int             // distinct (source_gid,target_gid) contributing
+    degraded        bool            // lossRatio > lossThresh OR rttP99Ns > rttThresh
+}
+```
+
+`S == T` is the **intra-ToR** edge (ToR-mesh probes stay inside one ToR).
+`S != T` is an **inter-ToR** edge whose physical path traverses S's uplinks, one
+or more spine/agg switches, and T's downlinks.
+
+Degradation reuses the Phase 1 thresholds (`Config.SLALossRatio`,
+`Config.SLANetworkRTTP99Ns`) so a window "degraded" at the edge level is
+consistent with the per-path violations already logged.
+
+### Step 3: Minimal localization — common-element heuristic (ships on current data)
+
+Intuition from the paper, reduced to what a ToR-flat topology can justify: a
+shared fabric fault makes **all edges through the faulty element** degrade
+together while edges avoiding it stay healthy. With only ToR identity we can
+reason about three shared elements a ToR participates in:
+
+- its **down side** (ToR↔host links + the ToR switch itself), exercised by every
+  edge with that ToR as target and by its intra-ToR edge;
+- its **up side** (ToR↔spine uplinks), exercised by every inter-ToR edge with
+  that ToR as source;
+- the **spine core** between two ToRs, exercised only by that specific inter-ToR
+  edge (not attributable to a single ToR without a spine model).
+
+For each ToR `X` over the set of edges in the window, compute:
+
+```
+inboundEdges(X)   = { (S,X) : S != X, EdgeStat exists }
+outboundEdges(X)  = { (X,T) : T != X, EdgeStat exists }
+intra(X)          = EdgeStat(X,X)  (may be absent if X has <2 RNICs)
+
+inFrac(X)   = degradedCount(inboundEdges(X))  / |inboundEdges(X)|
+outFrac(X)  = degradedCount(outboundEdges(X)) / |outboundEdges(X)|
+intraBad(X) = intra(X) != nil AND intra(X).degraded
+```
+
+Classification and suspicion score (all thresholds config-driven):
+
+- **DownSide/ToR fault** — `X` suspected when `inFrac(X) ≥ breadthFrac` AND
+  (`intraBad(X)` OR intra absent). Rationale: nearly everything converging on
+  `X` from distinct sources fails, and `X`'s own mesh fails too → the fault is
+  local to `X` (switch or its host-facing links), not any one source's uplink.
+- **UpSide fault** — `X` suspected when `outFrac(X) ≥ breadthFrac` AND those
+  target ToRs are **healthy when reached from other sources** (i.e. their
+  inbound-from-others is mostly healthy). Rationale: only traffic *originating*
+  at `X` is bad → `X`'s uplinks/egress.
+- **Spine/inter-ToR path fault** — a specific `(S,T)` degrades while
+  `outFrac(S)` and `inFrac(T)` are both low (S→others and others→T are healthy).
+  Not attributable to a single ToR; emitted as an inter-ToR *path* suspicion,
+  not a `suspect_tor` gauge.
+
+Suspicion score for ranking (monotone in breadth, evidence volume, and severity):
+
+```
+score(X) = w_breadth * max(inFrac(X), outFrac(X))
+         + w_intra   * (intraBad(X) ? 1 : 0)
+         + w_sev     * normalizedSeverity(X)      // mean loss over degraded edges
+   weighted-down by low evidence:
+         * confidence(X)                          // = 1 - 1/(1+agentsReporting)
+```
+
+`confidence` guards against declaring a suspect from a single agent's noise: a
+ToR reached by only one agent gets a low multiplier even if that one edge is
+badly degraded. This is the cross-agent requirement made explicit.
+
+Pseudocode:
+
+```text
+function Localize(window):
+    edges := buildEdgeStats(window.summaries, registrySnapshot)   # Step 1-2
+    tors  := distinctToRs(edges)
+    suspects := []
+    for X in tors:
+        in  := inboundEdges(edges, X)
+        out := outboundEdges(edges, X)
+        intra := intraEdge(edges, X)
+        inFrac  := degradedFraction(in)
+        outFrac := degradedFraction(out)
+        intraBad := intra != nil and intra.degraded
+
+        kind := NONE
+        if inFrac >= breadthFrac and (intraBad or intra == nil):
+            kind := DOWNSIDE
+        else if outFrac >= breadthFrac and targetsHealthyFromOthers(edges, out):
+            kind := UPSIDE
+        if kind != NONE:
+            suspects.append(Suspect{
+                tor: X, kind: kind,
+                score: scoreOf(X, inFrac, outFrac, intraBad, in, out),
+                confidence: 1 - 1/(1+distinctAgents(in ∪ out)),
+                evidence: summarize(in, out, intra),
+            })
+
+    pathSuspects := []
+    for (S,T) in degradedInterTorEdges(edges):
+        if outFrac(S) < breadthFrac and inFrac(T) < breadthFrac:
+            pathSuspects.append(PathSuspect{S, T, edges[S,T]})
+
+    return rank(suspects), pathSuspects
+```
+
+Correctness envelope (stated honestly): this heuristic is a **screening**
+localizer. It is right when faults are ToR-local or ToR-egress-local and shows
+up as breadth; it deliberately refuses to over-claim on spine-core faults,
+reporting them as path suspicions instead. False positives are bounded by
+`breadthFrac`, `confidence`, and the finding hysteresis below.
+
+### Advanced localization — set cover / hitting set (topology-gated)
+
+The paper's precise localization treats each probe path as a *set of traversed
+links* and finds the minimal set of components that **covers all degraded paths
+while being avoided by all healthy paths** (a hitting-set / set-cover
+formulation, in practice a greedy vote):
+
+```text
+function LocalizeSetCover(window, fabric):
+    # fabric: switches (ToR/Agg/Spine) + links + path model
+    suspectVotes := map[component]float64
+    exonerated   := set[component]
+    for path in window.paths:               # per (source_gid,target_gid,flow_label class)
+        comps := fabric.componentsOn(path)  # link sequence for this ECMP class
+        if path.degraded:
+            for c in comps: suspectVotes[c] += path.severity
+        else:
+            for c in comps: exonerated.add(c)
+    candidates := { c : suspectVotes[c] > 0 and c not in exonerated }
+    return greedyMinimalCover(candidates, degradedPaths)   # fewest comps explaining all
+```
+
+This requires three things the rebuild does not have today:
+
+1. **A fabric model**: switches and links as first-class entities, with tiers.
+2. **A path→component mapping**: which links a given (src RNIC, dst RNIC,
+   flow_label) actually traverses. ECMP hashing is generally not invertible
+   exactly; the paper approximates it by covering many flow labels (the rebuild
+   already rotates flow labels, sized by Eq.(1)) and by knowing the tiered
+   topology so a path's *candidate* link set is enumerable.
+3. **flow-label→path-class identity carried into the summary** so paths are
+   distinguishable at the controller. Today `PathAggregator` collapses all flow
+   labels of a (source,target) pair into one summary; per-flow-label
+   distinction would need either finer aggregation keys or a separate reporting
+   channel.
+
+Recommendation: **do not build the set-cover pass in the first Phase 2 round.**
+Ship the minimal heuristic (which needs no new data), and make the fabric model
++ path mapping a separately-scoped follow-up (see Implementation Plan). This is
+the highest-leverage sequencing: the minimal pass delivers ToR-granularity
+localization — which is exactly the metric granularity the system is allowed to
+emit anyway — without a schema migration.
+
+### Cross-agent quantile synthesis
+
+Phase 1 ships per-agent, per-path `p50/p99` estimated from the **fixed** bucket
+ladder `rttBucketBoundariesNs`. These per-agent percentiles **cannot be
+averaged** to get a ToR-pair percentile. Two options:
+
+1. **Loss and "degraded" flag**: exact by summation. `probe_total` and
+   `probe_failed` add across agents with no error; the edge loss ratio is exact.
+   This alone drives the minimal heuristic correctly, because the primary fault
+   signal is loss/breadth, not the precise tail latency.
+2. **Merged RTT tail**: to get a real ToR-pair p99, the recommended approach
+   **exploits the fact that all agents already share the same fixed bucket
+   ladder**. Add one additive field to `PathSummary` carrying the per-bucket
+   counts (`repeated uint32 rtt_bucket_counts = 16;`, length =
+   `len(rttBucketBoundariesNs)+1`). The controller then sums bucket counts per
+   ToR-pair and computes an **exact bucket-resolution** merged quantile — no
+   approximation-of-an-approximation, no per-agent percentile averaging.
+
+**t-digest decision criterion.** Do NOT introduce t-digest unless *both*: (a)
+the fixed bucket resolution is demonstrably too coarse for a latency SLO the
+operator actually sets (e.g. an SLO that lands between two bucket edges near the
+tail), AND (b) operators need to reconfigure RTT resolution per deployment
+without redeploying agents. Until then, bucket-count summation is strictly
+simpler, is exact at bucket resolution, requires no mergeable-sketch code on the
+agent, and reuses a ladder that already exists. t-digest's only real advantage —
+adaptive accuracy at the extreme tail — is not worth the agent-side complexity
+for a ToR-pair screening metric. If adopted later, t-digest centroids would be
+the new additive field instead of bucket counts, merged at the controller.
+
+Phase 2's first round should adopt **option 1 for detection** and **option 2
+(bucket-count histogram, additive field) for the emitted ToR-pair p99**, and
+leave t-digest unbuilt.
+
+### rqlite `path_summaries` table (additive, optional persistence)
+
+Localization itself runs on the **in-memory** window ring (recent windows are
+all it needs), so persistence is **not required** for Phase 2 to function. The
+table below is specified for optional forensic retention and to let a future
+standalone `rpingmesh-analyzer` binary read history. It is a **new table** — it
+does not alter `rnics` — so it is a purely additive, backward-compatible schema
+change.
+
+```sql
+CREATE TABLE IF NOT EXISTS path_summaries (
+    window_start_unix_ns INTEGER NOT NULL,   -- aligned window start (join key across agents)
+    agent_id             TEXT    NOT NULL,
+    source_gid           TEXT    NOT NULL,
+    source_tor_id        TEXT    NOT NULL,
+    target_gid           TEXT    NOT NULL,
+    target_tor_id        TEXT    NOT NULL,
+    target_qpn           INTEGER NOT NULL,
+    window_duration_ms   INTEGER NOT NULL,
+    probe_total          INTEGER NOT NULL,
+    probe_success        INTEGER NOT NULL,
+    probe_failed         INTEGER NOT NULL,
+    invalid_rtt_count    INTEGER NOT NULL,
+    network_rtt_min_ns   INTEGER NOT NULL,
+    network_rtt_max_ns   INTEGER NOT NULL,
+    network_rtt_p50_ns   INTEGER NOT NULL,
+    network_rtt_p99_ns   INTEGER NOT NULL,
+    PRIMARY KEY (window_start_unix_ns, source_gid, target_gid)
+);
+CREATE INDEX IF NOT EXISTS idx_ps_window     ON path_summaries (window_start_unix_ns);
+CREATE INDEX IF NOT EXISTS idx_ps_tor_pair   ON path_summaries (source_tor_id, target_tor_id, window_start_unix_ns);
+```
+
+If the bucket-count histogram (field 16) is adopted, persist it as a JSON/text
+column `rtt_bucket_counts TEXT` appended to the table (again additive).
+
+**Retention**: a periodic sweep mirroring `CleanupStaleEntries`
+(`DELETE FROM path_summaries WHERE window_start_unix_ns < (now - retentionNs)`).
+Default retention on the order of hours (e.g. 6h), config-driven
+(`analyzer_persist_retention_sec`). Localization does not read beyond the
+in-memory ring, so retention here is purely a forensic/disk-budget knob.
+
+**Write-rate estimate** (the reason persistence is opt-in and batched):
+`rows/s ≈ agents × pathsPerAgent × (1/windowSec)`.
+For 1000 agents × 50 paths / 30 s ≈ **1.7k rows/s**. rqlite commits go through
+Raft (an fsync per transaction), so per-row inserts are infeasible; each
+`ProbeAnalysisReport` (already batched to ≤256 summaries by
+`maxSummariesPerReport`) must be written as **one multi-row parameterized
+transaction**, giving ≈7 report-transactions/s at that scale. This is
+tolerable but is the dominant new write load on rqlite, which is why:
+persistence is **disabled by default** (`analyzer_persist_enabled: false`),
+localization never depends on it, and enabling it is an explicit operator
+decision with the write-rate documented.
+
+### Output: suspect ranking, OTLP, findings lifecycle
+
+**Suspect ranking** is emitted per completed window as a sorted list of
+`Suspect{tor, kind, score, confidence, evidence}` and `PathSuspect{S,T,...}`.
+
+**OTLP metrics** (registered on the existing `rpingmesh.analyzer` meter, ToR
+granularity only):
+
+| metric | type | attributes | meaning |
+|--------|------|-----------|---------|
+| `rpingmesh.analyzer.suspect_tor` | ObservableGauge (0/1) or Gauge | `tor`, `kind` (downside/upside) | 1 while a ToR has an open suspicion finding |
+| `rpingmesh.analyzer.suspect_tor_score` | Gauge | `tor`, `kind` | current suspicion score (0..1) for a suspected ToR |
+| `rpingmesh.analyzer.localization_runs_total` | Counter | — | windows processed by the localizer |
+| `rpingmesh.analyzer.inter_tor_path_suspect` | Gauge (0/1) | `source_tor`, `target_tor` | spine-path suspicion that is not attributable to one ToR |
+
+No GID attribute ever appears on a metric; GID-level evidence goes to findings
+logs (mirroring `logFinding` in `analyzer.go`).
+
+**Findings lifecycle** (hysteresis to avoid flapping): a suspicion for a given
+`(tor, kind)` is a state machine.
+
+```
+             score>=openThresh for K consecutive windows
+   CLEARED ─────────────────────────────────────────────► OPEN
+      ▲                                                     │
+      │      score<closeThresh for M consecutive windows    │
+      └─────────────────────────────────────────────────────┘
+```
+
+- **OPEN**: emit a Warn finding log (with GID/edge evidence and score) and set
+  the `suspect_tor` gauge to 1. Re-log at a throttled cadence while open.
+- **CLEARED**: emit a resolution log, set the gauge to 0.
+- `K` (open confirmation windows, e.g. 2–3), `M` (clear windows, e.g. 3–5),
+  `openThresh`, `closeThresh` (`closeThresh < openThresh` for hysteresis) are
+  config-driven. State lives next to the window ring in the `Analyzer` under the
+  existing mutex.
+
+This lifecycle is what makes the ToR-granularity output trustworthy: a single
+noisy window neither opens nor closes a finding.
+
+### Config additions (controller)
+
+Additive keys, defaults chosen conservatively:
+
+```yaml
+analyzer_localization_enabled: true
+analyzer_loc_breadth_frac: 0.6        # fraction of edges degraded to call a side "broad"
+analyzer_loc_open_score: 0.6          # score to open a suspicion
+analyzer_loc_close_score: 0.3         # score to clear (hysteresis)
+analyzer_loc_open_windows: 2          # K consecutive windows to open
+analyzer_loc_close_windows: 3         # M consecutive windows to clear
+analyzer_persist_enabled: false       # rqlite path_summaries persistence (opt-in)
+analyzer_persist_retention_sec: 21600 # 6h; only meaningful when persist enabled
+```
+
+## Alternatives Considered
+
+- **Localize on the agent.** Rejected on first principles: an agent sees only
+  its own source RNICs and cannot separate "my uplink" from "the target ToR".
+  Localization is a cross-agent intersection; it must be central. (This is the
+  same conclusion the Phase 1 design reached for aggregation.)
+- **Push localization into the OTel collector (OTTL/connector).** Rejected: the
+  collector has neither the fabric topology nor the cross-agent join, and this
+  would fight the deliberate ToR-only cardinality design. Localization belongs
+  where the registry lives.
+- **Average per-agent p99s for the ToR-pair tail.** Rejected as statistically
+  invalid. Chose exact loss summation for detection + shared-bucket histogram
+  summation for the emitted tail.
+- **Adopt t-digest immediately for cross-agent quantiles.** Rejected for the
+  first round: the fixed shared bucket ladder already permits exact
+  bucket-resolution merging with far less code and no agent-side sketch. t-digest
+  is held behind an explicit criterion.
+- **Build the paper's full set-cover localizer now.** Rejected as premature: it
+  requires a fabric model, a path→link mapping, and per-flow-label summary
+  identity, none of which exist. The minimal heuristic reaches ToR granularity —
+  the granularity the system may emit — without any of that. Set-cover is
+  designed but explicitly deferred.
+- **Persist every summary to rqlite and localize from SQL.** Rejected as the
+  primary path: localization needs only recent windows already held in memory,
+  and per-summary rqlite writes do not fit Raft's fsync-per-commit model.
+  Persistence is optional, batched, and off by default.
+
+## Test Plan
+
+All Phase 2 logic is pure Go operating on `[]*controller_agent.PathSummary` and
+a registry snapshot, so it is **deterministic and unit-testable without RDMA**,
+matching the Phase 1 analyzer tests.
+
+- **Topology fixtures**: define small deterministic clusters as fixtures — e.g.
+  4 ToRs × N RNICs, with a GID→ToR map — and hand-build `PathSummary` sets that
+  encode specific fault scenarios. Fixtures live beside `analyzer_test.go`.
+  - Scenario A (down-side/ToR fault): all inbound edges to ToR X degraded across
+    ≥3 source ToRs + intra-X degraded; assert X ranked suspect kind=downside,
+    others not suspected.
+  - Scenario B (up-side fault): all outbound edges from ToR Y degraded but the
+    same target ToRs healthy from other sources; assert Y kind=upside.
+  - Scenario C (spine path): single (S,T) degraded, S→others and others→T
+    healthy; assert **no** `suspect_tor`, one `inter_tor_path_suspect`.
+  - Scenario D (noise/no fault): random low loss below thresholds; assert no
+    suspects (guards false positives).
+  - Scenario E (single-agent noise): one agent reports a badly degraded edge to
+    X; assert low confidence keeps X below `openThresh` (no finding opens).
+- **Cross-agent aggregation**: two agents reporting summaries for the same
+  aligned window and same ToR-pair must fold into one `EdgeStat` with summed
+  totals; assert exact loss ratio and (with histogram field) exact merged p99.
+- **Findings lifecycle**: drive K windows above `openThresh` → assert OPEN
+  finding + gauge=1; then M windows below `closeThresh` → assert CLEARED +
+  gauge=0; assert a single dip below threshold does not close (hysteresis).
+- **Determinism**: ranking must be a total order (stable tie-break on ToR id) so
+  tests are reproducible.
+- **Metrics**: assert `suspect_tor` / `suspect_tor_score` carry only
+  `tor`/`kind` attributes (cardinality regression guard), reusing the pattern in
+  the Phase 1 metrics tests.
+- **rqlite persistence** (only if that PR is built): unit-test the multi-row
+  batch insert and the retention sweep against the `dbConn` fake already used by
+  the registry tests; assert one transaction per report.
+- **e2e (RDMA-free, controller path)**: extend the existing
+  `e2e/probe_analysis_e2e_test.go` style — a pseudo-agent posts crafted
+  `ProbeAnalysisReport`s encoding Scenario A across "multiple agents"; assert the
+  controller opens a suspect-ToR finding and emits the gauge end-to-end.
+
+## Implementation Plan (PR breakdown)
+
+Each PR is independently reviewable/mergeable. Ordering maximizes value-per-risk
+and keeps the schema-free work first.
+
+1. **P3-H.1 — Edge model + minimal localizer (no proto/schema change).**
+   `internal/controller/analyzer/localizer.go`: `EdgeStat`, edge folding from
+   retained window buckets, the common-element heuristic, ranking. `Analyzer`
+   gains a post-window hook (invoked when a window completes) that calls it.
+   Registry gains a read-only `TopologySnapshot()` (GID→ToR, ToR→GIDs) built
+   from `ListAllRNICs`. Findings logged only (no metrics yet). Fixtures +
+   Scenarios A–E as unit tests. This PR delivers working ToR-granularity
+   localization with zero migration.
+2. **P3-H.2 — Findings lifecycle + OTLP.** Add the hysteresis state machine and
+   the `suspect_tor` / `suspect_tor_score` / `inter_tor_path_suspect` /
+   `localization_runs_total` instruments on the existing analyzer meter. Config
+   keys for thresholds/windows. Lifecycle + metrics-cardinality tests. e2e
+   controller-path test.
+3. **P3-H.3 — Cross-agent exact tail (additive proto field).** Add
+   `repeated uint32 rtt_bucket_counts = 16;` to `PathSummary`; have
+   `pathAccumulator` expose its buckets and `analysis_reporter.toProto` populate
+   the field; controller sums buckets per ToR-pair for an exact merged p99. Fully
+   backward compatible (old agents simply omit the field; controller falls back
+   to loss-only detection + max(p99)). Aggregation/merge unit tests.
+4. **P3-H.4 (optional) — rqlite persistence.** `path_summaries` table +
+   batched multi-row insert on ingest + retention sweep, all behind
+   `analyzer_persist_enabled` (default false). Registry-fake unit tests.
+5. **P3-H.5 (deferred / separate track) — Fabric topology model + set-cover.**
+   New registry tables (switches, links) + a path→component mapping + per-flow
+   summary identity + the set-cover localizer. Large; specified here but
+   sequenced after H.1–H.3 prove out and only if per-link granularity is
+   actually required. Explicitly gated on operator-provided topology.
+
+## Open Questions
+
+- **Topology source for the advanced pass.** Per-link localization needs a
+  fabric model (spine/agg switches + links) that the agents cannot discover.
+  Would this come from an operator-provided topology file, an SNMP/LLDP feed, or
+  a controller config? This is a product decision that gates P3-H.5. *(User
+  input needed.)*
+- **Is ToR granularity sufficient for the operational goal?** If ToR-level
+  suspects satisfy the on-call workflow, H.5 may never be needed. *(User input
+  needed.)*
+- **Enable rqlite persistence by default?** Given the ≈1.7k rows/s at 1000
+  agents and Raft's fsync-per-commit, the recommendation is off-by-default. If
+  forensic history is a hard requirement, an external TSDB/OLAP sink (rather than
+  rqlite) may be the better target. *(User input needed.)*
+- **`breadthFrac` / threshold defaults** are first guesses; they should be tuned
+  against a real cluster's normal-noise floor before trusting auto-opened
+  findings.
+- **Window alignment across agents** assumes agent clocks are reasonably
+  synchronized (windows are wall-clock floored). Large clock skew would scatter
+  the same real window across adjacent buckets and weaken cross-agent
+  intersection. Is NTP-level sync a safe assumption in the target fleet?

--- a/rebuild/docs/design/analyzer-phase2-localization.md
+++ b/rebuild/docs/design/analyzer-phase2-localization.md
@@ -84,12 +84,55 @@ advanced pass that is correct only once a fabric model is added.
 
 ### Overview
 
-Phase 2 adds a **localizer** that runs after each window is complete, reads the
-retained window buckets, aggregates per-path summaries up to **ToR-pair**
-granularity, applies a fault-localization pass, and emits ranked suspect ToRs
-(and, when topology permits, suspect links) as findings + OTLP gauges. It is a
-new file `internal/controller/analyzer/localizer.go` in the existing package;
-`Analyzer` gains a post-window hook that invokes it.
+Phase 2 adds a **localizer** that runs once a window is **closed** (see the
+grace-period policy below), reads the retained window buckets, aggregates
+per-path summaries up to **ToR-pair** granularity, applies a fault-localization
+pass, and emits ranked suspect ToRs (and, when topology permits, suspect links)
+as findings + OTLP gauges. It is a new file
+`internal/controller/analyzer/localizer.go` in the existing package.
+
+**Localize on closed windows, not per report (the arrival-race fix).** A window's
+summaries arrive **asynchronously from many agents** — each agent reports on its
+own schedule after its window elapses, and network/retry jitter spreads those
+reports out. If the localizer ran as a naive `Analyzer.Ingest` post-hook (fire
+on every report), the first report for window W would trigger localization while
+almost no agents had reported yet: `agentsReporting`, breadth fractions, and
+`EdgeStat` totals would all be **under-counted**, producing spurious suspects and
+corrupting the finding hysteresis state machine. The localizer must therefore
+operate on a window only once it is considered **complete enough**, governed by a
+watermark:
+
+- A window with aligned start `Ws` (duration `D = windowNs`) has nominal end
+  `We = Ws + D`. It is declared **closed** at `We + grace`, where
+  `grace = expectedReportLag + margin`. `expectedReportLag` is bounded by the
+  agent report cadence — agents report at each window boundary
+  (`AnalysisReporter` ticks every `windowDur`), so a report for W is expected
+  within roughly one window plus RPC latency; a safe default is
+  `grace = windowNs + fixedMargin` (e.g. one extra window + a few seconds).
+- The `Analyzer` advances a monotonic **watermark** = `maxObservedWindowStart`
+  seen across all ingested reports (windows are wall-clock aligned and shared, so
+  this is well-defined). A window `Ws` is eligible for localization once
+  `now >= We + grace` **or** the watermark has advanced by ≥2 windows past `Ws`
+  (whichever comes first) — the latter lets a busy cluster close windows promptly
+  without waiting on wall-clock when later windows are already flowing in.
+- A **sweeper** (a ticker on the analyzer, period ≈ `windowNs`) picks the oldest
+  not-yet-localized closed window from the retained ring, runs `Localize(W)`
+  exactly once, and marks it localized. `Ingest` stays a pure ingest/retain/SLA
+  path; it no longer triggers localization directly. This keeps ingest cheap and
+  decouples localization cadence from report arrival.
+- **Late arrivals** (a report for an already-localized window) are **not**
+  re-localized — the window's finding contribution is fixed once evaluated, so a
+  straggler cannot flip a decision after the fact. Such a summary is still
+  retained/counted for SLA logging and metrics, but it is dropped from
+  localization with a counter (`rpingmesh.analyzer.late_summaries_total`) so
+  chronic lateness is observable and `grace` can be tuned. (Re-opening a window
+  for late data is rejected as it would make hysteresis non-deterministic and
+  reorder-sensitive.)
+
+Retention interaction: `WindowRetention` (default 20) must comfortably exceed the
+number of windows spanned by `grace` so a window is never evicted from the ring
+before it is localized; the sweeper asserts this and logs if retention is too
+small for the configured grace.
 
 ```
 per-agent PathSummary (window W)
@@ -395,7 +438,8 @@ granularity only):
 |--------|------|-----------|---------|
 | `rpingmesh.analyzer.suspect_tor` | ObservableGauge (0/1) or Gauge | `tor`, `kind` (downside/upside) | 1 while a ToR has an open suspicion finding |
 | `rpingmesh.analyzer.suspect_tor_score` | Gauge | `tor`, `kind` | current suspicion score (0..1) for a suspected ToR |
-| `rpingmesh.analyzer.localization_runs_total` | Counter | — | windows processed by the localizer |
+| `rpingmesh.analyzer.localization_runs_total` | Counter | — | closed windows processed by the localizer |
+| `rpingmesh.analyzer.late_summaries_total` | Counter | — | summaries arriving for an already-localized window (grace-tuning signal) |
 | `rpingmesh.analyzer.inter_tor_path_suspect` | Gauge (0/1) | `source_tor`, `target_tor` | spine-path suspicion that is not attributable to one ToR |
 
 No GID attribute ever appears on a metric; GID-level evidence goes to findings
@@ -429,6 +473,8 @@ Additive keys, defaults chosen conservatively:
 
 ```yaml
 analyzer_localization_enabled: true
+analyzer_loc_grace_sec: 40            # window-close grace = expectedReportLag + margin
+                                      # (>= agent analysis_window_sec + a few sec)
 analyzer_loc_breadth_frac: 0.6        # fraction of edges degraded to call a side "broad"
 analyzer_loc_open_score: 0.6          # score to open a suspicion
 analyzer_loc_close_score: 0.3         # score to clear (hysteresis)
@@ -488,6 +534,13 @@ matching the Phase 1 analyzer tests.
 - **Cross-agent aggregation**: two agents reporting summaries for the same
   aligned window and same ToR-pair must fold into one `EdgeStat` with summed
   totals; assert exact loss ratio and (with histogram field) exact merged p99.
+- **Window-close / late arrival** (injected clock via a `nowFn` seam, mirroring
+  `AnalysisReporter.nowFn`): a window is localized exactly once, only after
+  `We + grace`; asserting that reports trickling in before close do **not**
+  trigger localization and that the eventual single run sees the full
+  `agentsReporting`. A report arriving after the window is localized increments
+  `late_summaries_total` and does **not** re-run localization or alter the
+  already-emitted finding.
 - **Findings lifecycle**: drive K windows above `openThresh` → assert OPEN
   finding + gauge=1; then M windows below `closeThresh` → assert CLEARED +
   gauge=0; assert a single dip below threshold does not close (hysteresis).
@@ -517,7 +570,12 @@ and keeps the schema-free work first.
    must land within this PR before the localizer can use it. Then
    `internal/controller/analyzer/localizer.go`: `EdgeStat`, edge folding from the
    retained window buckets, the common-element heuristic, ranking. `Analyzer`
-   gains a post-window hook (invoked when a window completes) that calls it.
+   gains a **window-close sweeper** (a ticker + monotonic watermark) that runs
+   `Localize(W)` exactly once per window after `We + grace`, instead of a
+   per-report hook — this is what prevents localizing on a partially-reported
+   window (under-counted `agentsReporting`/breadth). Late summaries for an
+   already-localized window are counted (`late_summaries_total`) but not
+   re-localized. `analyzer_loc_grace_sec` config + a retention-vs-grace assertion.
    Registry gains a read-only `TopologySnapshot()` (GID→ToR, ToR→GIDs) built
    from `ListAllRNICs`. Findings logged only (no metrics yet). Fixtures +
    Scenarios A–E as unit tests (Scenario E specifically exercises the

--- a/rebuild/docs/design/analyzer-phase2-localization.md
+++ b/rebuild/docs/design/analyzer-phase2-localization.md
@@ -40,10 +40,16 @@ analyzer merged in PR #36.
 - **Phase 1 analyzer** (`internal/controller/analyzer/analyzer.go`): ingests
   `ProbeAnalysisReport` batches via `Analyzer.Ingest`, retains the most recent
   `WindowRetention` (default 20, `DefaultAnalyzerWindowRetention`) windows in an
-  in-memory ring of `windowBucket{windowStartUnixNs, summaries}`, and flags
-  per-summary SLA violations in `evaluate` (loss ratio and p99 RTT). It already
-  keeps every summary of the retained windows around — the comment on
-  `windowBucket` explicitly calls this "the substrate a future Phase 2
+  in-memory ring of `windowBucket{windowStartUnixNs, summaries}` where
+  `summaries` is `[]*controller_agent.PathSummary`, and flags per-summary SLA
+  violations in `evaluate` (loss ratio and p99 RTT). **Important gap for Phase
+  2**: `agent_id` lives only on the `ProbeAnalysisReport` envelope and is passed
+  to `evaluate` transiently — it is **not** a field of `PathSummary` and is
+  **not** stored in the ring. So the retained ring, as-is, cannot answer "how
+  many distinct agents reported this edge" (the cross-agent confidence signal).
+  Closing this needs a controller-internal retention change (below), not a proto
+  change. It already keeps every summary of the retained windows around — the
+  comment on `windowBucket` explicitly calls this "the substrate a future Phase 2
   cross-agent localization pass would read." Phase 2 is that pass.
 - **Retention ring** is keyed and sorted by `windowStartUnixNs`. Because agent
   windows are wall-clock aligned (`PathAggregator.windowStart` floors to
@@ -119,6 +125,32 @@ EdgeStat {
 `S == T` is the **intra-ToR** edge (ToR-mesh probes stay inside one ToR).
 `S != T` is an **inter-ToR** edge whose physical path traverses S's uplinks, one
 or more spine/agg switches, and T's downlinks.
+
+**Required Phase 1 retention change (controller-internal, no proto change).**
+`agentsReporting` / `distinctAgents(...)` — the cross-agent confidence signal —
+cannot be computed from the ring as it exists today, because the ring stores
+bare `[]*controller_agent.PathSummary` and `PathSummary` carries no `agent_id`
+(it lives only on the `ProbeAnalysisReport` envelope; see Current State). The fix
+is entirely inside the analyzer package: change what the ring retains from
+`*PathSummary` to a small wrapper that pairs each summary with the reporting
+agent id, e.g.
+
+```go
+// controller-internal; NOT a proto message.
+type retainedSummary struct {
+    AgentID string
+    Summary *controller_agent.PathSummary
+}
+```
+
+`windowBucket.summaries` becomes `[]*retainedSummary`, and `Analyzer.Ingest`
+(which already receives `report.GetAgentId()`) stamps the id when it calls
+`retainLocked`. This is a backward-compatible **internal** structural change: the
+wire `PathSummary` and `ProbeAnalysisReport` are untouched, so "no proto/schema
+change" still holds. `buildEdgeStats` then reads `AgentID` off each retained
+record to count distinct agents per edge. (It also generalizes cleanly if a
+future need arises to distinguish two agents reporting the same GID pair, though
+today `(source_gid, target_gid)` is effectively agent-unique.)
 
 Degradation reuses the Phase 1 thresholds (`Config.SLALossRatio`,
 `Config.SLANetworkRTTP99Ns`) so a window "degraded" at the edge level is
@@ -477,14 +509,20 @@ matching the Phase 1 analyzer tests.
 Each PR is independently reviewable/mergeable. Ordering maximizes value-per-risk
 and keeps the schema-free work first.
 
-1. **P3-H.1 — Edge model + minimal localizer (no proto/schema change).**
-   `internal/controller/analyzer/localizer.go`: `EdgeStat`, edge folding from
+1. **P3-H.1 — Retained-record change + edge model + minimal localizer (no
+   proto/schema change).** First, the controller-internal retention change: swap
+   `windowBucket.summaries` from `[]*controller_agent.PathSummary` to
+   `[]*retainedSummary` (agent id + summary), stamped in `Analyzer.Ingest` — this
+   is the prerequisite that makes cross-agent `agentsReporting` computable and
+   must land within this PR before the localizer can use it. Then
+   `internal/controller/analyzer/localizer.go`: `EdgeStat`, edge folding from the
    retained window buckets, the common-element heuristic, ranking. `Analyzer`
    gains a post-window hook (invoked when a window completes) that calls it.
    Registry gains a read-only `TopologySnapshot()` (GID→ToR, ToR→GIDs) built
    from `ListAllRNICs`. Findings logged only (no metrics yet). Fixtures +
-   Scenarios A–E as unit tests. This PR delivers working ToR-granularity
-   localization with zero migration.
+   Scenarios A–E as unit tests (Scenario E specifically exercises the
+   distinct-agent count off the new retained record). This PR delivers working
+   ToR-granularity localization with zero wire/schema migration.
 2. **P3-H.2 — Findings lifecycle + OTLP.** Add the hysteresis state machine and
    the `suspect_tor` / `suspect_tor_score` / `inter_tor_path_suspect` /
    `localization_runs_total` instruments on the existing analyzer meter. Config

--- a/rebuild/docs/design/ebpf-service-tracing.md
+++ b/rebuild/docs/design/ebpf-service-tracing.md
@@ -1,0 +1,364 @@
+# eBPF Service Tracing
+
+Status: Design only (P3-J). No implementation is proposed here. This document
+specifies how the agent should use eBPF to trace RDMA QP lifecycle so probe
+results can be attributed to the services actually using each RNIC — the
+"service-aware monitoring" of the SIGCOMM 2024 R-Pingmesh paper.
+
+## Goals
+
+- **Correlate probe results with services.** By observing which processes create
+  and use RDMA QPs on each local RNIC, the agent can answer "which application's
+  traffic shares the fabric path that a degraded probe just measured", turning a
+  ToR-pair anomaly into a service-impact statement.
+- **Enable service-aware probing later.** The same QP-lifecycle signal
+  identifies which RNICs are *actively serving* traffic, so probing effort can be
+  prioritized toward RNIC pairs that matter (a paper concept; out of scope to
+  *act* on in the first round, but the data model must support it).
+- **Do this without disturbing the data path.** The eBPF subsystem must be
+  cleanly separable from the Zig/Cgo RDMA bridge and must not affect the agent's
+  build or runtime on non-Linux / eBPF-incapable hosts.
+
+## Non-Goals
+
+- No packet-level or payload inspection. Only QP **lifecycle** metadata
+  (create/modify/destroy + owning process/cgroup) is traced.
+- No change to the probe protocol, the Zig library, or the analyzer's
+  localization. Service attribution is an *enrichment* layer.
+- No dependency on eBPF for core probing. If eBPF is unavailable the agent runs
+  exactly as today (graceful degradation).
+- First round does **not** implement service-aware probe prioritization or
+  controller-side aggregation of service data — those are explicitly later
+  scopes. The first round proves the tracer and exposes local signal.
+
+## Current State (verified against code)
+
+- **No eBPF anywhere.** `rebuild/CLAUDE.md` states the eBPF component is out of
+  scope; the Makefile confirms it ("there is no eBPF; `make generate-bpf` does
+  not exist"). The legacy top-level tree had eBPF ambitions but the rebuild has
+  none.
+- **Agent build**: `CGO_ENABLED=1 go build ./cmd/agent/` linking the Zig static
+  library `zig/zig-out/lib/librdmabridge.a` via Cgo LDFLAGS in
+  `internal/rdmabridge/bridge.go`. Controller is `CGO_ENABLED=0` pure Go. Any
+  eBPF addition must not perturb this: it goes in the agent only, and must not
+  add a second C-toolchain coupling that fights the existing Zig/Cgo link.
+- **Reporting RPCs**: `ControllerService` has `RegisterAgent`, `GetPinglist`,
+  and `ReportProbeAnalysis(ProbeAnalysisReport) -> ProbeAnalysisAck`
+  (`proto/controller_agent/controller_agent.proto`). The analysis-reporting
+  pattern — agent aggregates locally, batches, ships best-effort, never blocks
+  probing (`internal/agent/analysis_reporter.go`) — is the template a service
+  reporter would follow.
+- **Registry** maps GID→ToR and stores QPN per RNIC (`rnics` table). The QPN it
+  stores is the agent's **responder** QPN (from `responder.GetQueueInfo()` in
+  `buildRegistrationRequest`), i.e. rpingmesh's own probe QPs — *not* the
+  application QPs eBPF would trace. Service tracing observes a different QP
+  population (the workloads'), so it is additive, not a modification of registry
+  data.
+- **systemd unit** (`packaging/systemd/rpingmesh-agent.service`) is
+  deliberately hardened and grants only `CAP_IPC_LOCK`:
+  `CapabilityBoundingSet=CAP_IPC_LOCK`, `AmbientCapabilities=CAP_IPC_LOCK`,
+  `SystemCallFilter=@system-service`, `SystemCallErrorNumber=EPERM`,
+  `ProtectKernelModules=yes`, `ProtectKernelTunables=yes`,
+  `MemoryDenyWriteExecute=yes`, `RestrictNamespaces=yes`,
+  `LockPersonality=yes`, `RestrictAddressFamilies=... AF_NETLINK`. **Every one of
+  these interacts with eBPF loading** and must be revisited (see Security).
+- **nfpm packaging** (`packaging/nfpm/nfpm-agent.yaml`) ships the binary,
+  systemd unit, config; no kernel/BTF assets.
+
+## Design
+
+### Purpose model: what "service" means here
+
+An RDMA QP is created by a process via the userspace verbs library, which issues
+`ib_uverbs` ioctls handled in the kernel `ib_uverbs`/`ib_core` layer. By hooking
+the QP create/modify/destroy path, an eBPF program captures, per QP:
+
+- **owner identity**: `pid`, `tgid`, `comm`, and `cgroup_id` (the cgroup id is
+  the robust service key under systemd/k8s — `comm`/`pid` alone are not stable
+  service identities);
+- **local QP**: assigned `qpn`, and the local device/port;
+- **remote endpoint** (from `modify_qp` to RTR for connected QPs): destination
+  QPN and destination GID (`dgid`) — this is what ties a *local service* to a
+  *remote RNIC*, and thus to a ToR-pair that probes also traverse;
+- **lifecycle**: create timestamp, destroy timestamp → QP liveness.
+
+The agent maintains an in-memory **QP→service table** keyed by local QPN,
+enriched with the remote GID/QPN. That table is the join key back to probe
+results: a probe path `(source_gid, target_gid)` shares fabric with an
+application QP whose `(local device gid, dgid)` matches the same ToR-pair. Note
+UD (rpingmesh's own QPs) never modify to a single remote, so rpingmesh's probe
+QPs are naturally excluded/ignorable; the workloads' RC/UC QPs carry a remote.
+
+### Technology choice: cilium/ebpf (recommended) vs libbpf-go
+
+Recommendation: **`github.com/cilium/ebpf`** (pure-Go loader) with `bpf2go` for
+CO-RE object generation.
+
+Reasoning, from first principles against this codebase's constraints:
+
+- **Keep the eBPF subsystem free of a second C runtime.** `libbpf-go`
+  (`github.com/aquasecurity/libbpfgo`) requires CGO to link libbpf (a C library).
+  The agent is already `CGO_ENABLED=1` for Zig, so CGO per se is not blocked —
+  but adding a *libbpf* C dependency means a second, unrelated C link and a
+  runtime `.so`/static libbpf to ship, entangled with the Zig link. `cilium/ebpf`
+  is **pure Go**: it parses ELF and calls `bpf()` via syscalls directly, so the
+  eBPF loader has **zero** C-link coupling with the Zig bridge. That separation
+  is the whole point of the "non-interfering with CGO/Zig" requirement.
+- **CO-RE without a runtime clang.** `bpf2go` compiles the eBPF C **at build
+  time** with clang into a CO-RE object embedded via `go:embed`; the running
+  agent needs only kernel BTF (`/sys/kernel/btf/vmlinux`) to relocate, not a
+  clang on the target host. This keeps the *runtime* dependency to "a modern
+  kernel with BTF", nothing else.
+- **Maturity/ecosystem.** `cilium/ebpf` is the de-facto standard pure-Go loader
+  (used by Cilium, Tetragon), actively maintained, with good ring-buffer and
+  CO-RE support.
+
+libbpf-go's only real edge is closer parity with upstream libbpf helpers; not
+worth the C-link entanglement here.
+
+### Attach points and kernel requirements
+
+QP lifecycle is reachable in the kernel RDMA stack. Options, in order of
+preference:
+
+1. **`fentry`/`fexit` on `ib_core` functions** (e.g. the QP create/destroy paths
+   such as `ib_create_qp_user` / `ib_destroy_qp_user`, and `_ib_modify_qp` for
+   the RTR transition that carries the remote). `fentry` is lower-overhead than
+   kprobe and gives typed access via BTF, but requires a kernel new enough for
+   BPF trampolines (5.5+) and the symbol to be attachable.
+2. **`kprobe`/`kretprobe`** on the same functions as a fallback where `fentry`
+   isn't attachable. Broadest availability; function names are **not** a stable
+   ABI, so the program must tolerate missing symbols and select at load time.
+3. **Tracepoints** would be most stable, but the RDMA subsystem's tracepoints do
+   not cleanly cover the create/modify/destroy-with-remote data the model needs,
+   so they are not the primary mechanism.
+
+Because attach-point function names vary across kernels, the loader must **probe
+availability at startup** (is the symbol attachable? does BTF have the needed
+struct fields?) and degrade gracefully if not.
+
+**Kernel version requirement**: target **Linux 5.8+**. Rationale: BPF ring buffer
+(the event channel to userspace) landed in 5.8; `CAP_BPF`/`CAP_PERFMON` split
+landed in 5.8; CO-RE needs kernel BTF (`CONFIG_DEBUG_INFO_BTF=y`), common on
+distro kernels 5.4+ but reliably present alongside the 5.8 features. Below 5.8,
+service tracing is simply disabled (graceful degradation), agent unaffected.
+
+### Agent integration
+
+- **New package** `internal/agent/servicetrace/` (Linux-only), containing:
+  the embedded CO-RE object (`bpf_bpfel.go` etc. from `bpf2go`), the loader, a
+  ring-buffer reader goroutine, and the QP→service table.
+- **Build-tag isolation.** All eBPF-touching Go files carry `//go:build linux`.
+  A parallel `//go:build !linux` stub provides a no-op `Tracer` so the agent
+  compiles and runs on macOS/dev unchanged. The `bpf2go`-generated object and
+  its `go:embed` are also Linux-tagged. This guarantees **no build or runtime
+  impact off Linux** and keeps the eBPF C compile (clang→BPF) entirely separate
+  from the host Cgo/Zig compile — they never share a translation unit or linker
+  invocation.
+- **Runtime feature detection + graceful degradation.** At agent start, if
+  `service_tracing_enabled` is true, the tracer attempts: verify kernel ≥5.8 +
+  BTF present + required capability + attach points resolvable. Any failure →
+  **log a warning and continue without tracing** (mirroring how
+  `createMetricsCollector` degrades to no-metrics on failure). Tracing is never
+  load-bearing for probing.
+- **Lifecycle.** The tracer is created in `Initialize` (behind the config gate),
+  started in `Start` (its own goroutine reading the ring buffer, same
+  poll-in-a-goroutine spirit as the completion/async rings), and stopped in
+  `Stop` (detach programs, close maps, join goroutine) — slotting into the
+  existing ordered startup/shutdown without touching the RDMA teardown.
+
+### Collected data model
+
+```go
+// Linux-only. One row per observed application QP.
+type QPRecord struct {
+    LocalQPN    uint32
+    DeviceGID   string   // local RNIC GID (mapped from device/port)
+    RemoteQPN   uint32   // 0 until RTR modify observed
+    RemoteGID   string   // "" until RTR modify observed (UD stays empty)
+    PID         uint32
+    CgroupID    uint64   // service key
+    Comm        string
+    CreatedNs   uint64
+    DestroyedNs uint64   // 0 while live
+}
+```
+
+The kernel program emits compact fixed-layout events into the ring buffer
+(create / modify-RTR / destroy); the Go reader folds them into the table and
+resolves `DeviceGID` from the device/port index. Aggregation for reporting rolls
+QPs up to **service (cgroup) × remote ToR**, so nothing GID-level or PID-level
+reaches a metric.
+
+### Reporting path to the controller
+
+**Recommendation: a new RPC, not an extension of `ReportProbeAnalysis`.**
+Rationale: service data has a different shape, a different cadence (QP lifecycle
+is event-driven and far lower volume than probe windows), and a different
+consumer (it feeds service-impact correlation, not SLA/localization). Overloading
+`ProbeAnalysisReport` would couple two independent concerns and bloat a hot
+message. A separate `ReportServiceTracing(ServiceTracingReport) ->
+ServiceTracingAck` mirrors the existing best-effort reporter pattern.
+
+However, for the **first round, defer controller reporting entirely.** The
+minimal first PR keeps the QP→service table **local** and exposes it only as
+low-cardinality OTLP (e.g. `rpingmesh.agent.active_qps{}` — a count of live
+application QPs, no per-service attribute until a bounded service label is
+agreed). This proves the tracer end-to-end with the least surface area and no
+proto change. Controller reporting and service-impact join are the second round.
+
+### OTLP (first round, low cardinality)
+
+| metric | type | attributes | meaning |
+|--------|------|-----------|---------|
+| `rpingmesh.agent.service_trace_enabled` | Gauge (0/1) | — | tracer active vs degraded |
+| `rpingmesh.agent.active_qps` | UpDownCounter/Gauge | — | live application QPs observed |
+| `rpingmesh.agent.qp_events_total` | Counter | `kind` (create/modify/destroy) | traced lifecycle events |
+
+Per-service / per-remote-ToR attributes are withheld until the second round when
+a bounded service key (cgroup→service-name mapping) is defined; unbounded PID or
+GID attributes would violate the cardinality rule.
+
+## Security / privileges (and systemd impact)
+
+Loading eBPF programs and attaching fentry/kprobe requires elevated capability.
+On 5.8+: **`CAP_BPF`** (load programs/maps) **+ `CAP_PERFMON`** (attach
+kprobe/fentry via perf); pre-5.8 it collapses to `CAP_SYS_ADMIN`. Reading kernel
+BTF from `/sys/kernel/btf/vmlinux` needs read access to that path.
+
+The current hardened unit must change **only when tracing is enabled**. Concrete
+impacts on `packaging/systemd/rpingmesh-agent.service`:
+
+- **Capabilities**: add `CAP_BPF CAP_PERFMON` to `CapabilityBoundingSet` and
+  `AmbientCapabilities` (keeping `CAP_IPC_LOCK`). Do **not** add
+  `CAP_SYS_ADMIN` on 5.8+.
+- **Syscall filter**: `SystemCallFilter=@system-service` must permit `bpf()` and
+  `perf_event_open()`. These are not guaranteed in `@system-service` on all
+  systemd versions; add them explicitly (e.g. append a second
+  `SystemCallFilter=bpf perf_event_open` line, or use systemd's `@bpf` set where
+  available). Without this, the load fails with EPERM.
+- **`MemoryDenyWriteExecute=yes`**: this restricts *userspace* W^X mappings, not
+  the in-kernel BPF JIT, so it should not block loading — but it must be verified
+  on the target kernel; if a specific loader path trips it, MDWX may need
+  relaxing under the tracing profile.
+- **`RestrictNamespaces=yes` / `LockPersonality=yes`**: generally compatible with
+  eBPF loading; verify.
+- **`ProtectKernelTunables=yes`**: makes `/proc/sys` and parts of `/sys`
+  read-only but still readable — BTF read at `/sys/kernel/btf/vmlinux` is a read,
+  so it should be fine; verify the path is not hidden.
+- **kernel lockdown**: on a kernel with Lockdown LSM in "confidentiality" mode,
+  BPF is blocked outright regardless of capabilities — this is a host policy the
+  agent can only detect and degrade against, not override.
+
+**Packaging**: gate all of the above behind a **separate hardening profile** so
+the default (tracing-off) unit keeps its minimal `CAP_IPC_LOCK` posture. Options:
+ship a systemd **drop-in** (`rpingmesh-agent.service.d/10-ebpf.conf`) that the
+operator enables when turning tracing on, rather than loosening the base unit for
+everyone. The nfpm package can include the drop-in as a disabled/example file.
+This keeps least-privilege the default and makes enabling tracing an explicit,
+auditable capability grant.
+
+## Alternatives Considered
+
+- **libbpf-go instead of cilium/ebpf.** Rejected: it adds a libbpf C dependency
+  and a second C-link entangled with the Zig/Cgo build, contradicting the
+  "non-interfering" requirement. cilium/ebpf is pure Go and keeps the eBPF loader
+  C-free.
+- **Compile eBPF on the target with clang at runtime (BCC-style).** Rejected:
+  requires clang + kernel headers on every agent host, heavy and fragile. CO-RE +
+  `go:embed` needs only BTF at runtime.
+- **Extend `ReportProbeAnalysis` with service fields.** Rejected: couples two
+  independent concerns with different cadence/volume/consumers; a dedicated RPC
+  (in the second round) is cleaner and matches the existing reporter pattern.
+- **Parse `/sys/class/infiniband/*/ports/*/...` or netlink RDMA (`rdma
+  resource`) instead of eBPF.** Considered as a lighter alternative for QP
+  enumeration: `rdma resource show qp` (RDMA netlink) can list QPs with owning
+  PID and does not need eBPF/CAP_BPF. It is a legitimate **fallback for the
+  minimal "active QP count"** signal and could ship first with zero eBPF. But it
+  is a *poll* snapshot, misses short-lived QPs, and does not give create/destroy
+  events or the RTR-time remote binding as reliably. Recommendation: if the first
+  round's goal is only a liveness count, the RDMA-netlink poll is a strictly
+  simpler starting point; eBPF is warranted once event-accurate lifecycle and
+  remote binding are needed. This trade-off is called out as an Open Question.
+- **Trace at the mlx5 driver level.** Rejected as vendor-specific; the
+  `ib_uverbs`/`ib_core` path is vendor-neutral.
+- **Loosen the base systemd unit for everyone.** Rejected: keep least-privilege
+  default; gate capabilities behind an opt-in drop-in.
+
+## Test Plan
+
+eBPF is the least CI-friendly component (needs a real Linux kernel with BTF), so
+the plan is staged with most logic testable without loading a program.
+
+- **Pure-Go unit tests (no kernel)**: the QP→service table folding (create →
+  modify(RTR) → destroy transitions, device→GID resolution, cgroup keying) driven
+  by synthetic event structs; the graceful-degradation decision logic (kernel
+  too old / no BTF / no cap → disabled) with injected feature-probe results. The
+  `!linux` stub compiles and is a no-op.
+- **Loader/verifier test (Linux CI)**: assert the embedded CO-RE object **loads
+  and verifies** against the CI kernel's BTF (`cilium/ebpf` can load without
+  attaching). This catches verifier regressions without needing to generate real
+  QP traffic.
+- **Integration (Linux + rxe)**: on the soft-RoCE CI env, create an application
+  RC QP (a tiny rdma-core `ibv_rc_pingpong`-style helper, or `rdma resource`
+  cross-check), and assert the tracer observes create/modify/destroy and the
+  QP→service table reflects it. Gate as a Linux/privileged-only test, like the
+  existing `test-e2e`.
+- **systemd verification**: `systemd-analyze verify` on the base unit and the
+  eBPF drop-in; a manual/CI check that with the drop-in the load succeeds and
+  without it the agent degrades gracefully (EPERM handled, not crashed).
+- **Cardinality guard**: assert first-round metrics carry no per-PID/per-GID
+  attributes.
+
+## Implementation Plan (PR breakdown)
+
+Minimal first slice is explicit and small; controller integration is later.
+
+1. **P3-J.1 — Tracer skeleton + graceful degradation (no attach).** Add
+   `cilium/ebpf` + `bpf2go` to the build (agent only), the `servicetrace` package
+   with Linux/`!linux` split, feature detection (kernel/BTF/cap probing), the
+   `service_tracing_enabled` config gate, and the `service_trace_enabled` gauge.
+   No program attached yet — this lands the build plumbing and the
+   degrade-to-off path with zero risk to probing, and proves cilium/ebpf coexists
+   with the Zig/Cgo build.
+2. **P3-J.2 — Minimal QP-lifecycle program + local table.** The CO-RE eBPF C for
+   create/destroy (+ RTR modify for remote), ring-buffer reader, QP→service
+   table, and `active_qps` / `qp_events_total` metrics. Loader/verifier CI test +
+   rxe integration test. **This is the minimal useful first deliverable.**
+   Optionally, ship the **RDMA-netlink poll fallback** here first if the loader
+   work slips (see Alternatives).
+3. **P3-J.3 — systemd eBPF drop-in + packaging.** The
+   `rpingmesh-agent.service.d/10-ebpf.conf` drop-in (CAP_BPF/CAP_PERFMON, syscall
+   filter additions), nfpm inclusion as an opt-in example, README "Deployment
+   (systemd)" note. `systemd-analyze verify`.
+4. **P3-J.4 (second round) — Controller reporting + service-impact join.** New
+   `ReportServiceTracing` RPC, best-effort reporter mirroring
+   `analysis_reporter.go`, and the controller-side join of service (cgroup ×
+   remote ToR) against localization findings. Bounded service label for metrics.
+5. **P3-J.5 (later) — Service-aware probe prioritization.** Use QP liveness to
+   bias pinglist/rate toward actively-served RNIC pairs (a paper concept). Depends
+   on J.4's data reaching the controller/pinglist generation.
+
+## Open Questions
+
+- **eBPF vs RDMA-netlink poll for the first slice.** If the immediate goal is
+  only "how many application QPs are live per host", `rdma resource show qp`
+  (netlink, no CAP_BPF, no eBPF) is dramatically simpler and could ship first. Is
+  event-accurate lifecycle + RTR-time remote binding required from day one, or is
+  a poll-based liveness count an acceptable v1? *(User input needed — this decides
+  whether J.2 is eBPF or netlink.)*
+- **Service identity key.** Is cgroup id → service name resolvable in the target
+  environment (systemd slice / k8s pod), and who owns that mapping (agent config,
+  a sidecar, the controller)? This gates the bounded service label for metrics
+  and reporting. *(User input needed.)*
+- **Minimum kernel across the fleet.** The design targets 5.8+. If a meaningful
+  fraction of hosts run older kernels, service tracing is simply off there —
+  acceptable? *(User input helpful.)*
+- **Capability posture.** Is granting `CAP_BPF`+`CAP_PERFMON` to the agent
+  acceptable to the security owners, given the base unit's deliberately minimal
+  `CAP_IPC_LOCK`? The drop-in keeps it opt-in, but the policy call is theirs.
+  *(User input needed.)*
+- **Attach-point stability.** `ib_core` function names are not a stable ABI; the
+  loader must select/degrade per kernel. Which kernel versions must be supported
+  concretely determines how many attach candidates to carry. *(User input
+  helpful.)*

--- a/rebuild/docs/design/ebpf-service-tracing.md
+++ b/rebuild/docs/design/ebpf-service-tracing.md
@@ -82,12 +82,23 @@ the QP create/modify/destroy path, an eBPF program captures, per QP:
   *remote RNIC*, and thus to a ToR-pair that probes also traverse;
 - **lifecycle**: create timestamp, destroy timestamp → QP liveness.
 
-The agent maintains an in-memory **QP→service table** keyed by local QPN,
-enriched with the remote GID/QPN. That table is the join key back to probe
-results: a probe path `(source_gid, target_gid)` shares fabric with an
-application QP whose `(local device gid, dgid)` matches the same ToR-pair. Note
-UD (rpingmesh's own QPs) never modify to a single remote, so rpingmesh's probe
-QPs are naturally excluded/ignorable; the workloads' RC/UC QPs carry a remote.
+The agent maintains an in-memory **QP→service table**. **The key must be the
+composite `(device, LocalQPN)`, not `LocalQPN` alone.** A QPN is only unique
+*within one RDMA device's* QP-number namespace; on a multi-RNIC host (the norm
+for this system — the agent already opens one Prober/Responder per device) two
+different RNICs can legitimately hand out the **same** QPN to different
+applications. Keying on the bare QPN would collide those two QPs into one table
+entry and mis-attribute a service to the wrong RNIC (and thus the wrong ToR-pair,
+corrupting the probe join). The eBPF program therefore captures a device
+discriminator alongside the QPN — the kernel `ib_device`/uverbs file identity, or
+its port — and userspace resolves it to the local RNIC's `DeviceGID`; the map key
+is `(DeviceGID, LocalQPN)` (or `(device_id, port, LocalQPN)` before GID
+resolution). Entries are enriched with the remote GID/QPN. That table is the join
+key back to probe results: a probe path `(source_gid, target_gid)` shares fabric
+with an application QP whose `(local device gid, dgid)` matches the same ToR-pair.
+Note UD (rpingmesh's own QPs) never modify to a single remote, so rpingmesh's
+probe QPs are naturally excluded/ignorable; the workloads' RC/UC QPs carry a
+remote.
 
 ### Technology choice: cilium/ebpf (recommended) vs libbpf-go
 
@@ -171,9 +182,17 @@ service tracing is simply disabled (graceful degradation), agent unaffected.
 
 ```go
 // Linux-only. One row per observed application QP.
+// Table key is the composite QPKey below, NOT LocalQPN alone: QPNs are unique
+// only within a single device's namespace, so a multi-RNIC host can reuse the
+// same QPN on two RNICs.
+type QPKey struct {
+    DeviceGID string   // local RNIC identity (resolved from device/port)
+    LocalQPN  uint32
+}
+
 type QPRecord struct {
     LocalQPN    uint32
-    DeviceGID   string   // local RNIC GID (mapped from device/port)
+    DeviceGID   string   // local RNIC GID (mapped from device/port); part of the key
     RemoteQPN   uint32   // 0 until RTR modify observed
     RemoteGID   string   // "" until RTR modify observed (UD stays empty)
     PID         uint32
@@ -185,8 +204,11 @@ type QPRecord struct {
 ```
 
 The kernel program emits compact fixed-layout events into the ring buffer
-(create / modify-RTR / destroy); the Go reader folds them into the table and
-resolves `DeviceGID` from the device/port index. Aggregation for reporting rolls
+(create / modify-RTR / destroy), **each carrying the device discriminator**
+(uverbs file / `ib_device` identity, and port) alongside the QPN so the userspace
+reader can build the composite key. The Go reader resolves that discriminator to
+the local RNIC's `DeviceGID` and folds events into the `map[QPKey]*QPRecord`
+table. Aggregation for reporting rolls
 QPs up to **service (cgroup) × remote ToR**, so nothing GID-level or PID-level
 reaches a metric.
 
@@ -295,6 +317,10 @@ the plan is staged with most logic testable without loading a program.
   by synthetic event structs; the graceful-degradation decision logic (kernel
   too old / no BTF / no cap → disabled) with injected feature-probe results. The
   `!linux` stub compiles and is a no-op.
+- **Composite-key collision guard**: feed two synthetic create events with the
+  **same `LocalQPN` on two different devices** (distinct `DeviceGID`) and assert
+  they produce two distinct `QPKey` entries mapped to their respective services —
+  a regression test that the key is `(DeviceGID, LocalQPN)`, not the bare QPN.
 - **Loader/verifier test (Linux CI)**: assert the embedded CO-RE object **loads
   and verifies** against the CI kernel's BTF (`cilium/ebpf` can load without
   attaching). This catches verifier regressions without needing to generate real

--- a/rebuild/docs/design/rnic-runtime-reinit.md
+++ b/rebuild/docs/design/rnic-runtime-reinit.md
@@ -108,6 +108,12 @@ typedef struct {
     uint8_t  _pad[3];
 } rdma_async_event_t;
 
+/* New opaque handle, alongside the existing rdma_context_t/rdma_device_t/
+ * rdma_queue_t/rdma_event_ring_t in rdma_bridge.h. Kept distinct from
+ * rdma_event_ring_t so the async control ring cannot be mistakenly passed to a
+ * completion-ring API (they carry different event structs). */
+typedef void* rdma_async_ring_t;
+
 /* One watcher per device. The watcher owns a small SPSC ring Go polls. */
 int32_t  rdma_async_watch_start(rdma_device_t dev, rdma_async_ring_t* out_ring);
 int32_t  rdma_async_ring_poll(rdma_async_ring_t ring, rdma_async_event_t* out, int32_t max);

--- a/rebuild/docs/design/rnic-runtime-reinit.md
+++ b/rebuild/docs/design/rnic-runtime-reinit.md
@@ -183,13 +183,43 @@ reinit lock:
    freed inside those; then `proberRings[i].Destroy()`, `respRings[i].Destroy()`,
    `rdma_async_watch_stop(asyncRing[i])`, and finally `devices[i].Close()`.
    Order matches the header rule (queues before device; rings after queues).
-4. **Re-open the device** with the *same* parameters the agent used originally —
+4. **Refresh the device list, then re-open the device.**
+   **Stale-device-list hazard (must fix first).** The shared bridge context
+   caches the device list at startup: Zig `RdmaContext` (`types.zig`) stores
+   `device_list` and `num_devices` populated once by `ibv_get_device_list()`
+   inside `rdma_init()`, and both `rdma_get_device_count` and the open-by-
+   index/name paths read that cached array. After `rdma link delete` +
+   re-add (or a real hot-unplug/replug) the re-added device is a **new** entry
+   the cached list does not contain — so a naive re-open would fail to find it,
+   or worse, index into a freed/renamed slot. The reinit sequence must
+   re-enumerate before re-opening.
+
+   Two ways to re-enumerate, and why the surgical one is chosen:
+   - **Recreate the whole bridge context** (`rdma_destroy` + `rdma_init`):
+     rejected for per-device reinit. The header contract requires *all* devices
+     and queues be destroyed before `rdma_destroy`, so recreating the shared
+     context would force quiescing every *healthy* RNIC too — defeating the
+     per-device isolation this whole design is built on.
+   - **Add a device-list refresh C-ABI** (chosen): a new
+     `int32_t rdma_refresh_devices(rdma_context_t ctx)` that calls
+     `ibv_free_device_list()` on the cached array and re-runs
+     `ibv_get_device_list()`, updating `RdmaContext.device_list` /
+     `num_devices` in place. `ibv_free_device_list()` frees only the *list
+     array*, not the `ibv_context` of already-opened devices, so healthy RNICs
+     are untouched. Exposed to Go as `Context.RefreshDevices()`. Refresh must be
+     serialized with respect to any open/count call (the reinit already holds the
+     per-device reinit lock; document that device open/count/refresh on the
+     shared context are mutually exclusive).
+
+   Then **re-open** with the *same* parameters the agent used originally —
    by name if `AllowedDeviceNames` is set, else by index — passing the same
    `gidIndex`, `sl`, `tc` (already threaded through `openDevices` →
-   `OpenDevice(index, gidIndex, sl, tc)`). A removed-then-readded rxe device may
-   reappear at a different index; **prefer re-open by name** during reinit even
-   when the initial open was by index, keyed on `devices[i].Info.DeviceName`, to
-   survive index reshuffling.
+   `OpenDevice(index, gidIndex, sl, tc)`). Because a removed-then-readded device
+   commonly reappears at a **different index**, **prefer re-open by name** during
+   reinit even when the initial open was by index, keyed on
+   `devices[i].Info.DeviceName`, to survive index reshuffling. (After a refresh
+   the by-name lookup scans the freshly enumerated list, so the new device is
+   found regardless of its new index.)
 5. **Rebuild in creation order**: new `EventRing`s → new async watcher → new
    `Prober` (new QPN) → new `Responder` (new QPN) → new `ClusterMonitor` bound to
    the new prober. Re-apply per-target rate limit and flow-label rotation period
@@ -343,21 +373,32 @@ outcome may adjust the event→action table above.
    ring + stop-unblock. No agent behavior change yet (watcher can be started and
    its events logged only). **Includes the investigation** of rxe delete
    behavior.
-2. **P3-I.2 — Fan-in single-prober replace.** Refactor `createResultsFanIn` /
+2. **P3-I.2 — Device-list refresh C-ABI.** Add
+   `int32_t rdma_refresh_devices(rdma_context_t ctx)` in `zig/src/device.zig`
+   (`ibv_free_device_list` + re-run `ibv_get_device_list`, updating
+   `RdmaContext.device_list`/`num_devices` in place) and its `main.zig` export +
+   header entry; Go wrapper `Context.RefreshDevices()`. Zig unit test that a
+   refresh re-reads the count and does not disturb an already-open device's
+   handle. Independent of the async watcher; lands before reinit uses it, since
+   without it re-open cannot find a re-added device.
+3. **P3-I.3 — Fan-in single-prober replace.** Refactor `createResultsFanIn` /
    `stopResultsFanIn` to per-goroutine stop channels and a helper to
    detach/attach one prober's fan-in without closing the shared channels. Pure
    Go, unit-tested with fake probers. Lands and is proven **before** reinit uses
    it.
-3. **P3-I.3 — Supervisor + per-device reinit orchestration.**
+4. **P3-I.4 — Supervisor + per-device reinit orchestration.**
    `internal/agent/rnic_supervisor.go`: the state machine, quiesce/pause,
-   destroy→reopen(by name)→rebuild→re-register→resume, backoff, DOWN handling.
-   `Prober.Pause/Resume`. Go unit tests with injected fake async events and fake
-   bridge; assert the exact call sequence and fan-in re-wire. Metrics.
-4. **P3-I.4 — soft-RoCE e2e.** New Docker e2e that deletes/re-adds rxe0 mid-run
-   (or netdev down/up fallback) and asserts reinit + resumed probing shape.
-5. **P3-I.5 (optional) — QP_FATAL / GID_CHANGE fine-grained handling.**
+   destroy→**refresh-device-list**→reopen(by name)→rebuild→re-register→resume,
+   backoff, DOWN handling. `Prober.Pause/Resume`. Go unit tests with injected
+   fake async events and fake bridge; assert the exact call sequence (including
+   the `RefreshDevices()` call before re-open) and fan-in re-wire. Metrics.
+5. **P3-I.5 — soft-RoCE e2e.** New Docker e2e that deletes/re-adds rxe0 mid-run
+   (or netdev down/up fallback) and asserts reinit + resumed probing shape,
+   exercising the device-list refresh (the re-added rxe device is found only
+   after refresh).
+6. **P3-I.6 (optional) — QP_FATAL / GID_CHANGE fine-grained handling.**
    Queue-scoped rebuild without device close, and GID re-query + re-register.
-   Smaller, layered on the machinery from I.3.
+   Smaller, layered on the machinery from I.4.
 
 ## Open Questions
 

--- a/rebuild/docs/design/rnic-runtime-reinit.md
+++ b/rebuild/docs/design/rnic-runtime-reinit.md
@@ -1,0 +1,377 @@
+# RNIC Runtime Re-initialization
+
+Status: Design only (P3-I). No implementation is proposed here. This document
+specifies how the agent should detect an RDMA device/port fault at runtime and
+recover the affected Prober/Responder/Queue without a process restart.
+
+## Goals
+
+- Subscribe to RDMA **asynchronous events** (`ibv_get_async_event`) so the agent
+  learns about device-fatal and port up/down transitions instead of silently
+  going deaf after a fault.
+- **Recover per-RNIC**: on a fatal/removal event for device *i*, tear down and
+  rebuild only that device's Prober, Responder, Queues, and event rings, then
+  re-register with the controller so the new QPNs propagate. Other RNICs keep
+  probing untouched.
+- Respect the existing lifecycle contracts: the `destroyOnce`/`sync.Once`
+  idempotent teardown in Prober/Responder, the SPSC event-ring ordering rule
+  (ring created before queue), and the deterministic results fan-in shutdown in
+  `agent.go`.
+- Fail safe: bounded retries with backoff; if a device cannot be recovered,
+  leave it down, surface it as a metric, and keep the rest of the agent healthy.
+
+## Non-Goals
+
+- No recovery from a **host-fatal** condition (RDMA subsystem gone entirely) —
+  that remains a process-restart case handled by systemd `Restart=on-failure`.
+- No attempt to preserve **in-flight probes** across a reinit. Probes pending on
+  a destroyed queue are treated as lost (they already time out via
+  `stalePendingTimeout`); correctness of the *measurement* is not compromised —
+  those windows simply record loss, which is the truthful outcome of a NIC fault.
+- No live QP migration / connection re-establishment tricks. UD QPs are
+  connectionless; recovery is destroy-and-recreate, not repair.
+- No change to the 6-timestamp protocol, the wire format, or the controller
+  registry schema.
+
+## Current State (verified against code)
+
+- **No async-event subscription exists.** The Zig C-ABI
+  (`zig/include/rdma_bridge.h`) exposes context/device/queue lifecycle, the
+  data-path sends, and the **completion** event ring
+  (`rdma_event_ring_create/poll/destroy/drop_count`) — but nothing calls
+  `ibv_get_async_event`. After a device fault the CQ poller thread simply stops
+  producing completions and the affected Prober/Responder goes silent with no
+  signal.
+- **Per-device isolation already exists in the agent.** `agent.go` keeps
+  parallel slices: `devices`, `probers`, `responders`, `monitors`,
+  `proberRings`, `respRings`, one entry per opened RNIC. Everything is already
+  indexed by device *i*, which is exactly the granularity reinit needs.
+- **The device holds its `ibv_context`.** Zig `types.zig RdmaDevice` has
+  `ctx: *c.ibv_context` (line ~111); `ibv_get_async_event(context, &event)`
+  operates on that context. The Go `rdmabridge.Device` wraps `handle`
+  (context) + `devHandle`, with `Info` (GID/IP/name/port). Async subscription
+  therefore lives naturally at the device level, one watcher per open device.
+- **Teardown is already idempotent and per-component.**
+  - `Prober.Destroy()` uses `destroyOnce sync.Once` and `queueMu` to guard the
+    `queue` pointer; it closes the prober's `Results()` channel and tears down
+    the queue exactly once.
+  - `Responder.Destroy()` mirrors this.
+  - `rdmabridge.Queue.Destroy()`, `Device.Close()`, `EventRing.Destroy()` are the
+    lower-level frees; the header documents the ordering constraint (queues
+    destroyed before device; ring outlives... see below).
+- **The results fan-in is the hard integration point.**
+  `Agent.createResultsFanIn` starts **one goroutine per prober**, each capturing
+  a specific `*Prober p` and `range p.Results()`. It shares process-global
+  `resultsWg`, `resultsDone`, `results`, and `analysisResults`.
+  `Agent.stopResultsFanIn` closes `resultsDone`, waits `resultsWg`, then closes
+  `results` (and `analysisResults`) **exactly once**. This whole machine is
+  built for one-shot shutdown, not for replacing a single prober mid-flight —
+  reinit must extend it carefully (see "Fan-in re-wiring").
+- **Re-registration already works.** `buildRegistrationRequest` builds the full
+  RNIC set (GID, current QPN from `responder.GetQueueInfo()`, IP, device name)
+  and `registerWithController` / the heartbeat both send the **complete** set.
+  The registry (`RegisterRNICs`) does set-replacement per agent, so a changed
+  QPN after reinit propagates on the next registration with no special-casing.
+  This means reinit's "re-register" step is just: trigger a registration with
+  the rebuilt state.
+- **Event-ring creation ordering.** Per `agent.go` and CLAUDE.md, the
+  `EventRing` must be created **before** the `Queue` and passed into
+  `rdma_create_queue`. Reinit must recreate the ring first, then the queue.
+
+## Design
+
+### Component 1 — Zig async-event watcher (new C-ABI surface)
+
+`ibv_get_async_event` is **blocking** by default (it reads the device's async
+fd). Mirror the existing completion-ring pattern: a dedicated Zig watcher thread
+per device blocks on the event, classifies it, `ibv_ack_async_event`s it, and
+pushes a typed record into a **new, separate SPSC ring** that Go polls. Keeping
+this ring distinct from the completion ring is deliberate — different struct,
+different semantics, different consumer cadence, and it must not contend with the
+hot completion path.
+
+New C-ABI (added to `rdma_bridge.h`, implemented in a new `zig/src/async.zig`,
+exported from `main.zig`):
+
+```c
+/* Async event kinds delivered to Go (stable ABI values). */
+#define RDMA_ASYNC_DEVICE_FATAL   1   /* IBV_EVENT_DEVICE_FATAL: full reinit */
+#define RDMA_ASYNC_PORT_ERR       2   /* IBV_EVENT_PORT_ERR: link down */
+#define RDMA_ASYNC_PORT_ACTIVE    3   /* IBV_EVENT_PORT_ACTIVE: link back */
+#define RDMA_ASYNC_QP_FATAL       4   /* IBV_EVENT_QP_FATAL: queue-scoped reinit */
+#define RDMA_ASYNC_GID_CHANGE     5   /* IBV_EVENT_GID_CHANGE: re-query GID */
+#define RDMA_ASYNC_OTHER          6   /* logged, no action */
+
+typedef struct {
+    uint32_t event_type;   /* one of RDMA_ASYNC_* */
+    uint8_t  port_num;     /* affected port (0 if N/A) */
+    uint8_t  _pad[3];
+} rdma_async_event_t;
+
+/* One watcher per device. The watcher owns a small SPSC ring Go polls. */
+int32_t  rdma_async_watch_start(rdma_device_t dev, rdma_async_ring_t* out_ring);
+int32_t  rdma_async_ring_poll(rdma_async_ring_t ring, rdma_async_event_t* out, int32_t max);
+void     rdma_async_watch_stop(rdma_async_ring_t ring);   /* unblocks + joins watcher */
+```
+
+**Teardown of a blocking watcher** is the subtle part. `ibv_get_async_event`
+blocks in the watcher thread; `rdma_async_watch_stop` must unblock it
+deterministically. Two workable mechanisms, to be chosen during implementation:
+
+1. **Non-blocking async fd + `poll()`**: dup the device's `async_fd`
+   (`ibv_context.async_fd`), set `O_NONBLOCK`, and have the watcher `poll()` on
+   `{async_fd, shutdown_eventfd}`. `rdma_async_watch_stop` writes the eventfd →
+   `poll` returns → thread drains any pending event and exits. This is the clean
+   approach and is the recommended one.
+2. **Close-to-unblock**: rely on device close to error the blocking call. This
+   races the very reinit we are performing and is harder to reason about;
+   avoid.
+
+Events map to actions:
+
+| Event | Meaning | Action |
+|-------|---------|--------|
+| `DEVICE_FATAL` | HCA/verbs context dead | **Full device reinit** (below) |
+| `PORT_ERR` | link down (cable/peer) | Mark device degraded; pause its prober; wait for `PORT_ACTIVE` (do **not** destroy — the context is still valid) |
+| `PORT_ACTIVE` | link restored | Resume prober; re-query GID if a `GID_CHANGE` was seen |
+| `QP_FATAL` | one QP errored | Queue-scoped rebuild (recreate that Prober/Responder queue) without closing the device |
+| `GID_CHANGE` | GID table changed | Re-query GID/IP; if changed, re-register (new addressing) |
+
+`PORT_ERR` vs `DEVICE_FATAL` distinction matters: a flapping cable should *pause*,
+not *rebuild* (rebuilding on a transient port bounce would churn QPNs and spam
+re-registration). Only a fatal/removal event triggers the destructive path.
+
+### Component 2 — Go async supervisor
+
+A new `internal/agent/rnic_supervisor.go` runs one goroutine per device that
+polls that device's async ring (same poll-in-a-goroutine model as the completion
+ring — never a Cgo callback) and drives a per-device state machine:
+
+```
+        HEALTHY ──PORT_ERR──► DEGRADED ──PORT_ACTIVE──► HEALTHY
+           │                     │
+      DEVICE_FATAL          DEVICE_FATAL
+           ▼                     ▼
+        REINITIALIZING ──ok──► HEALTHY
+           │  fail (backoff exhausted)
+           ▼
+         DOWN  (metric raised; left for operator / process restart)
+```
+
+The supervisor serializes reinit of a given device (a device is reinitialized by
+at most one goroutine at a time) and never touches other devices' state.
+
+### Component 3 — Per-device reinit sequence
+
+For `DEVICE_FATAL` on device *i*, the supervisor performs, under a per-device
+reinit lock:
+
+1. **Quiesce.** Stop `monitors[i]` from pushing new targets and pause
+   `probers[i]` (a new `Prober.Pause()` / `Resume()` or a cheap "suspend sends"
+   flag — sends short-circuit while paused). This prevents new sends against a
+   dead queue.
+2. **Detach fan-in for prober *i*.** Signal the single fan-in goroutine bound to
+   `probers[i]` to exit and wait for just that one (see "Fan-in re-wiring").
+3. **Destroy the affected components** using the existing idempotent teardown:
+   `probers[i].Destroy()`, `responders[i].Destroy()`, then their queues are
+   freed inside those; then `proberRings[i].Destroy()`, `respRings[i].Destroy()`,
+   `rdma_async_watch_stop(asyncRing[i])`, and finally `devices[i].Close()`.
+   Order matches the header rule (queues before device; rings after queues).
+4. **Re-open the device** with the *same* parameters the agent used originally —
+   by name if `AllowedDeviceNames` is set, else by index — passing the same
+   `gidIndex`, `sl`, `tc` (already threaded through `openDevices` →
+   `OpenDevice(index, gidIndex, sl, tc)`). A removed-then-readded rxe device may
+   reappear at a different index; **prefer re-open by name** during reinit even
+   when the initial open was by index, keyed on `devices[i].Info.DeviceName`, to
+   survive index reshuffling.
+5. **Rebuild in creation order**: new `EventRing`s → new async watcher → new
+   `Prober` (new QPN) → new `Responder` (new QPN) → new `ClusterMonitor` bound to
+   the new prober. Re-apply per-target rate limit and flow-label rotation period
+   from config, exactly as `Initialize` does.
+6. **Re-attach fan-in** for the new prober *i* (start one new fan-in goroutine
+   bound to it).
+7. **Re-register** with the controller by triggering `buildRegistrationRequest`
+   + `RegisterAgent` (reusing `registerWithController`'s retry/backoff). The new
+   QPNs are in `responders[i].GetQueueInfo()`, so the full-set re-registration
+   propagates them; the registry's set-replacement does the rest.
+8. **Resume** prober *i* and its monitor. Transition state → HEALTHY.
+
+**In-flight & pending state.** The destroyed prober's `pending` map is discarded
+with it; any probe awaiting an ACK becomes a timeout on the *old* queue and is
+never matched (the sequence-number epoch — `agentEpoch` high bits — was randomized
+per prober and the QPN changed, so a stray late ACK cannot misroute into the new
+queue). Those probes land as loss in whatever window was open, which is correct.
+No special reconciliation is needed.
+
+### Fan-in re-wiring (the critical integration risk)
+
+Today `createResultsFanIn` and `stopResultsFanIn` are a **one-shot** design:
+N goroutines, a single shared `resultsWg`, a single `resultsDone` closed once,
+and `results`/`analysisResults` closed exactly once at shutdown. Reinit needs to
+replace **one** prober's fan-in goroutine while the others keep running and the
+shared channels stay open. Reconciling this with the existing contract:
+
+- **Per-prober cancellation, not global.** Replace the single `resultsDone` with
+  a mechanism that can stop one goroutine: give each fan-in goroutine its own
+  `stop chan struct{}` (kept in a per-device slice), while `stopResultsFanIn`
+  still closes all of them for shutdown. A goroutine selects on its own `stop`
+  in addition to `resultsDone`.
+- **Never close the shared channels on a single reinit.** `results` and
+  `analysisResults` are closed only at final shutdown, exactly as now. A reinit
+  goroutine exit must NOT close them (other probers still send). It only exits
+  its own `range`/select loop; the new goroutine for the rebuilt prober begins
+  sending on the same shared channels.
+- **WaitGroup discipline.** The reinit waits for *only* the one old goroutine to
+  finish (a per-goroutine `done`/`sync.WaitGroup` of size 1), not the global
+  `resultsWg`. The global `resultsWg` still gates final shutdown; the new
+  goroutine is added to it when started.
+- **Ordering vs prober Destroy.** The old prober's `Results()` closes on
+  `Destroy()`, ending its goroutine's `range`. So the safe sequence is: signal
+  the goroutine's `stop` (so it unblocks even if mid-send on a full channel) →
+  `probers[i].Destroy()` (closes Results, ends range) → wait that one goroutine →
+  proceed. This is the same reasoning `stopResultsFanIn` documents, narrowed to a
+  single prober.
+
+This re-wiring (making the fan-in support single-prober replace) is itself the
+largest and riskiest code change and should be its own PR, landed and tested
+**before** any device is actually reinitialized.
+
+### Failure handling, backoff, partial failure
+
+- **Backoff.** Reinit attempts use exponential backoff reusing the existing
+  constants' spirit (`registerRetryInitialBackoff` 1s → `registerRetryMaxBackoff`
+  30s) with a bounded attempt count (e.g. 5). Between attempts the device stays
+  paused/degraded, not spinning.
+- **Give-up → DOWN.** On exhausting attempts, the device is left in `DOWN`: its
+  slot stays nil-ish (prober/responder absent), a metric is raised, and the agent
+  continues with its remaining RNICs. Recovery from `DOWN` is a process restart
+  (systemd), matching the Non-Goal boundary.
+- **Partial failure (multi-RNIC, one bad card).** This is the common case and is
+  handled by construction: everything is per-device, the supervisor touches only
+  device *i*, and the re-registration sends the full current set (healthy RNICs
+  unchanged, rebuilt RNIC with its new QPN, `DOWN` RNIC omitted so the controller
+  stops distributing it in pinglists via set-replacement).
+- **Event storms / flapping.** Debounce: a `PORT_ERR`/`PORT_ACTIVE` flap only
+  pauses/resumes (cheap). Repeated `DEVICE_FATAL` within a short window escalates
+  straight to `DOWN` rather than churning QPNs.
+
+### Metrics (OTLP, low cardinality)
+
+Registered on the agent's existing meter, aggregated across devices under a small
+label set (matching the `ring="prober"/"responder"` aggregation convention in
+`agent.go`):
+
+| metric | type | attributes | meaning |
+|--------|------|-----------|---------|
+| `rpingmesh.agent.rnic_async_events_total` | Counter | `event` (fatal/port_err/port_active/...) | async events observed |
+| `rpingmesh.agent.rnic_reinit_total` | Counter | `result` (ok/failed) | reinit attempts |
+| `rpingmesh.agent.rnic_state` | Gauge | `state` (healthy/degraded/reinit/down) | count of devices in each state |
+
+No per-device / per-GID attributes on metrics; device identity goes to logs.
+
+## soft-RoCE testability (investigation + strategy)
+
+**Can `rdma link delete` reproduce a device-fatal?** This needs empirical
+confirmation on the CI rxe setup, but the expected behavior: deleting an rxe link
+(`rdma link delete rxe0`) removes the device; libibverbs surfaces this to a
+process holding the context as a fatal/removal condition and the async fd becomes
+readable/hung-up. `rdma link add` recreates it (as the e2e harness already does
+for provisioning — see `docker-compose.e2e.yml` cap list and
+`scripts/setup-colima-rdma.sh`). A `PORT_ERR`/`PORT_ACTIVE` pair is harder to
+force on rxe (no real cable); it may be inducible by bringing the underlying
+netdev down/up (`ip link set <veth> down/up`) given the soft-RoCE policy-routing
+setup already in the repo.
+
+**Strategy** (staged, because full device-fatal e2e is the least certain part):
+
+1. **Zig unit test** (`zig build test`): the async ring push/poll/drop and the
+   watcher-stop unblock path, with a fake/mock event source — no real fault
+   needed. Deterministic.
+2. **Go unit test** (RDMA-free): the supervisor state machine and the reinit
+   *orchestration* driven by an injected fake that emits async events and a fake
+   device/bridge — assert the destroy→reopen→rebuild→re-register call sequence
+   and the fan-in single-prober replace, using the same fake-bridge seam the
+   existing agent tests use. This covers the hard integration logic without a
+   NIC.
+3. **e2e (soft-RoCE, Docker)**: a new test that starts the agent against rxe0,
+   confirms probing, then `rdma link delete rxe0` mid-test and (after a delay)
+   `rdma link add`, and asserts the agent emits a reinit event and resumes
+   probing on the rebuilt device (assert *shape*, not success rate, matching the
+   existing e2e philosophy). If device-fatal proves not to fire on rxe delete,
+   fall back to the netdev down/up path for `PORT_ERR`/`PORT_ACTIVE` and gate the
+   destructive-reinit e2e as a known hardware-only test.
+
+The investigation task (does rxe delete raise `IBV_EVENT_DEVICE_FATAL`, and does
+the async fd behave as assumed) is the first concrete implementation step and its
+outcome may adjust the event→action table above.
+
+## Alternatives Considered
+
+- **Poll device health instead of subscribing to async events.** Rejected:
+  polling `ibv_query_port` on a timer is racy and slow to detect fatal removal,
+  and it cannot distinguish a transient port bounce from a fatal. Async events
+  are the purpose-built mechanism.
+- **Cgo callback from the watcher thread into Go.** Rejected for the same reason
+  the completion path avoids it (CLAUDE.md): callbacks across the Cgo boundary
+  from a foreign thread are fragile; the SPSC-ring + Go-poll model is the
+  established pattern and reused here.
+- **Restart the whole agent on any device fault.** Rejected for multi-RNIC
+  hosts: one bad card would blind every other healthy RNIC for the restart
+  window. Per-device reinit preserves monitoring on the survivors. (Whole-process
+  restart remains the fallback only for host-fatal / give-up.)
+- **Reuse the completion event ring for async events.** Rejected: different
+  struct and semantics, and it would couple a cold control path to the hot
+  data path. A separate ring keeps the fast path untouched.
+- **Rebuild on `PORT_ERR`.** Rejected: a flapping link would churn QPNs and spam
+  re-registration. `PORT_ERR` pauses; only fatal rebuilds.
+- **Generalize the fan-in to a fully dynamic registry up front.** Considered;
+  the narrower "support single-prober replace" change is lower-risk and
+  sufficient. A full dynamic redesign is more than reinit needs.
+
+## Implementation Plan (PR breakdown)
+
+1. **P3-I.1 — Zig async watcher + C-ABI.** `zig/src/async.zig`, the
+   `rdma_async_*` exports, the `rdma_async_event_t` struct, and the
+   non-blocking-fd + eventfd stop mechanism. `internal/rdmabridge` wrappers
+   (`AsyncRing`, `Device.WatchAsync`, `AsyncRing.Poll/Stop`). Zig unit tests for
+   ring + stop-unblock. No agent behavior change yet (watcher can be started and
+   its events logged only). **Includes the investigation** of rxe delete
+   behavior.
+2. **P3-I.2 — Fan-in single-prober replace.** Refactor `createResultsFanIn` /
+   `stopResultsFanIn` to per-goroutine stop channels and a helper to
+   detach/attach one prober's fan-in without closing the shared channels. Pure
+   Go, unit-tested with fake probers. Lands and is proven **before** reinit uses
+   it.
+3. **P3-I.3 — Supervisor + per-device reinit orchestration.**
+   `internal/agent/rnic_supervisor.go`: the state machine, quiesce/pause,
+   destroy→reopen(by name)→rebuild→re-register→resume, backoff, DOWN handling.
+   `Prober.Pause/Resume`. Go unit tests with injected fake async events and fake
+   bridge; assert the exact call sequence and fan-in re-wire. Metrics.
+4. **P3-I.4 — soft-RoCE e2e.** New Docker e2e that deletes/re-adds rxe0 mid-run
+   (or netdev down/up fallback) and asserts reinit + resumed probing shape.
+5. **P3-I.5 (optional) — QP_FATAL / GID_CHANGE fine-grained handling.**
+   Queue-scoped rebuild without device close, and GID re-query + re-register.
+   Smaller, layered on the machinery from I.3.
+
+## Open Questions
+
+- **Does `rdma link delete` raise `IBV_EVENT_DEVICE_FATAL` on rxe, and how does
+  the async fd behave on removal?** This is an empirical unknown that shapes the
+  event→action table and the e2e strategy. It is the first task in P3-I.1.
+  *(Investigation, not user input — but if it turns out device-fatal is not
+  reproducible in CI, the destructive-reinit e2e becomes hardware-only, which is
+  a coverage decision worth surfacing.)*
+- **Re-open by name vs by index after removal.** The design recommends by-name
+  during reinit even when the initial open was by index, to survive rxe index
+  reshuffling. Is by-name always resolvable for the target fleet's NICs
+  (mlx5_N)? *(User input helpful.)*
+- **DOWN policy.** Should a device that exhausts reinit attempts trigger a
+  process exit (let systemd restart the whole agent, re-probing everything) or
+  stay DOWN and keep the survivors probing? The design chooses stay-DOWN; the
+  opposite (fail the process) is defensible if operators prefer "all or
+  nothing". *(User input needed.)*
+- **Pause vs keep-registered during `PORT_ERR`.** While a port is down, should
+  the RNIC remain in the registry (so peers keep trying and record loss, which is
+  itself signal) or be withdrawn (so peers stop wasting probes)? The design keeps
+  it registered and lets loss be recorded; withdrawing is an alternative.
+  *(User input helpful.)*

--- a/rebuild/docs/design/rnic-runtime-reinit.md
+++ b/rebuild/docs/design/rnic-runtime-reinit.md
@@ -124,11 +124,30 @@ void     rdma_async_watch_stop(rdma_async_ring_t ring);   /* unblocks + joins wa
 blocks in the watcher thread; `rdma_async_watch_stop` must unblock it
 deterministically. Two workable mechanisms, to be chosen during implementation:
 
-1. **Non-blocking async fd + `poll()`**: dup the device's `async_fd`
-   (`ibv_context.async_fd`), set `O_NONBLOCK`, and have the watcher `poll()` on
-   `{async_fd, shutdown_eventfd}`. `rdma_async_watch_stop` writes the eventfd →
-   `poll` returns → thread drains any pending event and exits. This is the clean
-   approach and is the recommended one.
+1. **`poll()` on `{async_fd, eventfd}`, without changing any fd flags
+   (recommended)**: this is the idiomatic libibverbs pattern for readiness-driven
+   async events. The watcher blocks in `poll(2)` on two descriptors — the device's
+   `ibv_context.async_fd` and a `shutdown_eventfd` — and calls
+   `ibv_get_async_event` **only after** `poll` reports `async_fd` readable, at
+   which point the call returns immediately without blocking (an event is already
+   queued). `rdma_async_watch_stop` `write(2)`s the eventfd → `poll` returns with
+   the eventfd readable → the thread exits. Crucially, **the fd's file status
+   flags are never modified**: `async_fd` stays in its default (blocking) mode and
+   is only ever read after `poll` says data is ready.
+
+   > POSIX note (why we do NOT set `O_NONBLOCK`, and why not via `dup`): file
+   > status flags such as `O_NONBLOCK` live on the **open file description**, not
+   > the file descriptor. `dup(2)` creates a new descriptor referring to the
+   > **same** open file description, so setting `O_NONBLOCK` on a `dup`-ed
+   > `async_fd` would also make the **original** `ibv_context.async_fd`
+   > non-blocking — corrupting any other consumer of it (e.g. a drain path or a
+   > future async-event user), which could then spin on `EAGAIN`. The
+   > "`dup` isolates the original fd" assumption is therefore wrong. The `poll`
+   > approach sidesteps this entirely by never touching the flags: readiness is
+   > established by `poll`, not by non-blocking reads. (In today's rebuild the
+   > watcher would be the sole `ibv_get_async_event` consumer, but relying on that
+   > to justify flipping a shared flag is fragile; the flag-free `poll` design is
+   > correct regardless.)
 2. **Close-to-unblock**: rely on device close to error the blocking call. This
    races the very reinit we are performing and is harder to reason about;
    avoid.
@@ -403,7 +422,9 @@ outcome may adjust the event→action table above.
 
 1. **P3-I.1 — Zig async watcher + C-ABI.** `zig/src/async.zig`, the
    `rdma_async_*` exports, the `rdma_async_event_t` struct, and the
-   non-blocking-fd + eventfd stop mechanism. `internal/rdmabridge` wrappers
+   flag-free `poll({async_fd, eventfd})` stop mechanism (never mutating the
+   `async_fd` file status flags — see the POSIX note above).
+   `internal/rdmabridge` wrappers
    (`AsyncRing`, `Device.WatchAsync`, `AsyncRing.Poll/Stop`). Zig unit tests for
    ring + stop-unblock. No agent behavior change yet (watcher can be started and
    its events logged only). **Includes the investigation** of rxe delete

--- a/rebuild/docs/design/rnic-runtime-reinit.md
+++ b/rebuild/docs/design/rnic-runtime-reinit.md
@@ -176,13 +176,25 @@ reinit lock:
    `probers[i]` (a new `Prober.Pause()` / `Resume()` or a cheap "suspend sends"
    flag — sends short-circuit while paused). This prevents new sends against a
    dead queue.
-2. **Detach fan-in for prober *i*.** Signal the single fan-in goroutine bound to
-   `probers[i]` to exit and wait for just that one (see "Fan-in re-wiring").
-3. **Destroy the affected components** using the existing idempotent teardown:
-   `probers[i].Destroy()`, `responders[i].Destroy()`, then their queues are
-   freed inside those; then `proberRings[i].Destroy()`, `respRings[i].Destroy()`,
+2. **Signal fan-in stop for prober *i* (do NOT wait yet).** Close the single
+   fan-in goroutine's per-goroutine `stop` channel. This alone is *not* enough to
+   unblock it: a fan-in goroutine parked in `range probers[i].Results()` waiting
+   for the next value (the common case once sends are paused and nothing is
+   flowing) only observes `stop` from inside its `select` on a send, not while
+   blocked in `range`. So do not wait here — waiting now would deadlock, because
+   `Results()` has not been closed yet. The `stop` signal is issued first only so
+   a goroutine that *is* mid-send on a full channel can unblock promptly.
+3. **Destroy the affected components, THEN wait for the fan-in goroutine.** Using
+   the existing idempotent teardown: `probers[i].Destroy()` (this closes
+   `probers[i].Results()`, which ends the fan-in goroutine's `range` and lets it
+   exit) — **now** wait for that one goroutine to finish (its size-1
+   `sync.WaitGroup`); then `responders[i].Destroy()`, whose queues are freed
+   inside those Destroys; then `proberRings[i].Destroy()`, `respRings[i].Destroy()`,
    `rdma_async_watch_stop(asyncRing[i])`, and finally `devices[i].Close()`.
-   Order matches the header rule (queues before device; rings after queues).
+   The **signal → Destroy() → wait** order is mandatory (it matches the canonical
+   ordering in "Fan-in re-wiring" below and the reasoning in the existing
+   `stopResultsFanIn`); the queue/device/ring teardown order matches the header
+   rule (queues before device; rings after queues).
 4. **Refresh the device list, then re-open the device.**
    **Stale-device-list hazard (must fix first).** The shared bridge context
    caches the device list at startup: Zig `RdmaContext` (`types.zig`) stores
@@ -206,10 +218,27 @@ reinit lock:
      `ibv_get_device_list()`, updating `RdmaContext.device_list` /
      `num_devices` in place. `ibv_free_device_list()` frees only the *list
      array*, not the `ibv_context` of already-opened devices, so healthy RNICs
-     are untouched. Exposed to Go as `Context.RefreshDevices()`. Refresh must be
-     serialized with respect to any open/count call (the reinit already holds the
-     per-device reinit lock; document that device open/count/refresh on the
-     shared context are mutually exclusive).
+     are untouched. Exposed to Go as `Context.RefreshDevices()`.
+
+     **Concurrency: this needs a shared-context mutex, not the per-device reinit
+     lock.** `rdma_refresh_devices` *frees and replaces* the shared
+     `RdmaContext.device_list` array that every open-by-index, open-by-name, and
+     `rdma_get_device_count` call reads. The per-device reinit lock does **not**
+     serialize these: when two RNICs fail at once, each reinit holds its *own*
+     device lock and they run concurrently, so one goroutine can be walking the
+     old `device_list` inside an open/count while the other's refresh frees and
+     swaps it — a use-after-free / stale-open race on shared state. The fix is a
+     dedicated **context-level mutex** (a `sync.Mutex` on the Go `Context`, or an
+     equivalent lock inside the Zig `RdmaContext`) that makes
+     `RefreshDevices` / `OpenDevice` / `OpenDeviceByName` / `GetDeviceCount`
+     mutually exclusive across *all* devices. Each of those bridge calls takes
+     the context mutex for its whole duration (enumeration + open). The per-device
+     reinit lock still serializes a single device's own reinit steps; the
+     context mutex additionally serializes the shared-list operations across
+     concurrent multi-RNIC reinits. Hold ordering: acquire the per-device reinit
+     lock first, then the context mutex only around the refresh+reopen span, and
+     release it before the (device-local) rebuild/re-register steps so a slow
+     re-registration never blocks another device's enumeration.
 
    Then **re-open** with the *same* parameters the agent used originally —
    by name if `AllowedDeviceNames` is set, else by index — passing the same
@@ -283,10 +312,16 @@ largest and riskiest code change and should be its own PR, landed and tested
   continues with its remaining RNICs. Recovery from `DOWN` is a process restart
   (systemd), matching the Non-Goal boundary.
 - **Partial failure (multi-RNIC, one bad card).** This is the common case and is
-  handled by construction: everything is per-device, the supervisor touches only
-  device *i*, and the re-registration sends the full current set (healthy RNICs
-  unchanged, rebuilt RNIC with its new QPN, `DOWN` RNIC omitted so the controller
-  stops distributing it in pinglists via set-replacement).
+  mostly handled by construction: state is per-device, the supervisor touches
+  only device *i*, and the re-registration sends the full current set (healthy
+  RNICs unchanged, rebuilt RNIC with its new QPN, `DOWN` RNIC omitted so the
+  controller stops distributing it in pinglists via set-replacement). The one
+  piece that is **not** per-device is the shared bridge context's device list:
+  two RNICs failing at once run their reinits concurrently and both touch that
+  shared list during refresh+reopen, so those operations must be serialized by
+  the **context-level mutex** described in step 4 — the per-device isolation
+  holds for everything except the shared enumeration, which the context mutex
+  covers.
 - **Event storms / flapping.** Debounce: a `PORT_ERR`/`PORT_ACTIVE` flap only
   pauses/resumes (cheap). Repeated `DEVICE_FATAL` within a short window escalates
   straight to `DOWN` rather than churning QPNs.
@@ -373,14 +408,19 @@ outcome may adjust the event→action table above.
    ring + stop-unblock. No agent behavior change yet (watcher can be started and
    its events logged only). **Includes the investigation** of rxe delete
    behavior.
-2. **P3-I.2 — Device-list refresh C-ABI.** Add
+2. **P3-I.2 — Device-list refresh C-ABI + context mutex.** Add
    `int32_t rdma_refresh_devices(rdma_context_t ctx)` in `zig/src/device.zig`
    (`ibv_free_device_list` + re-run `ibv_get_device_list`, updating
    `RdmaContext.device_list`/`num_devices` in place) and its `main.zig` export +
-   header entry; Go wrapper `Context.RefreshDevices()`. Zig unit test that a
-   refresh re-reads the count and does not disturb an already-open device's
-   handle. Independent of the async watcher; lands before reinit uses it, since
-   without it re-open cannot find a re-added device.
+   header entry; Go wrapper `Context.RefreshDevices()`. **Add the context-level
+   mutex** that makes `RefreshDevices`/`OpenDevice`/`OpenDeviceByName`/
+   `GetDeviceCount` mutually exclusive across all devices (see the concurrency
+   note in the reinit sequence), so concurrent multi-RNIC reinits cannot race the
+   shared device list. Zig/Go unit tests: a refresh re-reads the count and does
+   not disturb an already-open device's handle; a concurrency test (race
+   detector) that interleaves refresh with open/count and asserts no
+   use-after-free/stale read. Independent of the async watcher; lands before
+   reinit uses it, since without it re-open cannot find a re-added device.
 3. **P3-I.3 — Fan-in single-prober replace.** Refactor `createResultsFanIn` /
    `stopResultsFanIn` to per-goroutine stop channels and a helper to
    detach/attach one prober's fan-in without closing the shared channels. Pure


### PR DESCRIPTION
## Summary

Design-only specifications (P3-H/I/J) for the three deferred tracks, to be implemented in a later round. **No implementation, no proto changes** — three Markdown docs under `rebuild/docs/design/`, each following Goals / Non-Goals / Current State / Design / Alternatives Considered / Test Plan / Implementation Plan (PR breakdown) / Open Questions, and referencing current code by file/function.

### `analyzer-phase2-localization.md` (P3-H)
Cross-agent switch/link fault localization on top of the Phase 1 window ring (`internal/controller/analyzer/analyzer.go`).
- **Adopted algorithm:** a **common-element heuristic at ToR granularity** that ships on today's data — localization granularity is bounded by topology knowledge, and the registry (`rnics` table) is ToR-flat. Classifies down-side / up-side / spine-path faults by cross-agent breadth + confidence. The paper's **set-cover / hitting-set** pass is specified but **gated** on a fabric-topology model (switches/links + path→link mapping) that does not exist yet.
- **Cross-agent quantiles:** exact loss summation for detection + **shared fixed bucket-count histogram summation** for an exact merged p99 (additive proto field). **t-digest deliberately not adopted** — held behind an explicit criterion, because the shared fixed bucket ladder already permits exact bucket-resolution merging with far less code.
- Additive `path_summaries` rqlite table (opt-in, **off by default**; localization runs on the in-memory ring, so persistence is forensic only). Write-rate estimate ≈1.7k rows/s at 1000 agents drives the batched/opt-in decision.
- Findings lifecycle with open/close hysteresis; ToR-granularity OTLP (`suspect_tor` etc.).

### `rnic-runtime-reinit.md` (P3-I)
- New Zig `ibv_get_async_event` watcher thread + **separate SPSC async ring** (distinct from the completion ring), new C-ABI surface; non-blocking async-fd + eventfd stop for deterministic teardown.
- Per-device destroy → reopen (by name) → rebuild → re-register recovery, reusing the existing idempotent `destroyOnce` teardown and full-set re-registration.
- **Critical integration risk identified:** the results fan-in in `agent.go` is a one-shot design; reinit needs single-prober replace without closing the shared channels. This refactor is scoped as its own PR to land before reinit uses it.
- `PORT_ERR` pauses (not rebuilds) to avoid QPN churn on link flaps; partial multi-RNIC failure handled by construction.
- soft-RoCE test strategy staged, with an explicit investigation of whether `rdma link delete` raises `IBV_EVENT_DEVICE_FATAL`.

### `ebpf-service-tracing.md` (P3-J)
- **Adopted tech:** `cilium/ebpf` (pure Go, CO-RE via `bpf2go`, **no libbpf C link**) over libbpf-go — keeps the eBPF loader free of a second C runtime entangled with the Zig/Cgo build. Attach via fentry/kprobe on `ib_core` QP create/modify/destroy; **Linux 5.8+** (BPF ring buffer, CAP_BPF/CAP_PERFMON, BTF).
- Linux build-tag isolation + `!linux` no-op stub → **zero build/runtime impact off Linux**; graceful degradation when eBPF unavailable.
- **Minimal first slice** kept local (QP→service table + low-cardinality metrics, no proto change); controller reporting via a **new** `ReportServiceTracing` RPC deferred to a second round.
- Security: opt-in systemd **drop-in** granting CAP_BPF/CAP_PERFMON and the `bpf`/`perf_event_open` syscalls, keeping the base unit's minimal `CAP_IPC_LOCK` posture. Notes an RDMA-netlink poll fallback as a simpler v1.

## Testing
Docs only; no code changed. Each doc includes a topology-fixture / RDMA-free unit test plan plus staged e2e strategies.

**Do not merge** — this is design review for the next implementation round.