### PR TITLE
feat(rebuild): agent self-protection watchdog (P2-G)

### DIFF
--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -227,6 +227,12 @@ via Cgo (`CGO_ENABLED=1`).
 | `otel_collector_addr` | `localhost:4317` | OTLP gRPC collector endpoint |
 | `analysis_report_enabled` | `true` | Aggregate probe results per path and report `PathSummary` batches to the controller's analyzer (best-effort; never blocks probing) |
 | `analysis_window_sec` | `30` | Per-path aggregation window length in seconds |
+| `self_protection_enabled` | `false` | Opt-in resource watchdog: throttles the probe send rate (fail-slow) under local CPU/memory pressure (see [Self-protection](#self-protection)) |
+| `watchdog_interval_sec` | `5` | How often the watchdog samples resource usage (seconds) |
+| `max_memory_mb` | `0` | Soft runtime memory limit in MiB (`GOMEMLIMIT` via `debug.SetMemoryLimit`; `0` = disabled). Also the reference budget for memory throttling. Applied whenever `> 0`, independent of `self_protection_enabled` |
+| `max_procs` | `0` | Cap `runtime.GOMAXPROCS` to this many cores (`0` = Go default: all cores). Applied whenever `> 0`, independent of `self_protection_enabled` |
+| `throttle_memory_ratio` | `0.9` | Fraction of `max_memory_mb` at which memory throttling engages (`0`-`1`). Only active when `max_memory_mb > 0` |
+| `throttle_cpu_percent` | `90` | Percentage of available CPU capacity (`GOMAXPROCS` cores) at which CPU throttling engages (`0`-`100`) |
 | `log_level` | `info` | Log level: debug, info, warn, error |
 | `tls_mode` | `disabled` | gRPC transport security for the controller connection: `disabled` \| `tls` \| `mtls` (see [TLS/mTLS for controller-agent gRPC](#tlsmtls-for-controller-agent-grpc)) |
 | `tls_cert_file` | `""` | Client certificate file (required when `tls_mode=mtls`) |
@@ -300,6 +306,38 @@ rather than deferring the failure to the first gRPC handshake. `InsecureSkipVeri
 never used; there is deliberately no way to disable server certificate verification
 other than falling back to `tls_mode: disabled`. Certificate loading is static (no
 hot-reload): rotating certificates requires a restart.
+
+### Self-protection
+
+The agent can guard its own host footprint with an opt-in watchdog
+(`self_protection_enabled: true`). Every `watchdog_interval_sec` it samples this
+process's memory (via `runtime/metrics`, the same accounting as `GOMEMLIMIT`) and
+CPU time (via `getrusage`), and applies a **fail-slow** throttle: when either
+resource crosses its threshold it steps a probe-rate multiplier down the ladder
+`1.0 → 0.5 → 0.25 → 0.1` (one step per interval), and steps it back up as usage
+recovers. The multiplier scales every prober's per-target send rate on top of the
+configured per-type caps. It is deliberately floored at `0.1` and **never reaches
+`0`**: self-protection slows probing but never stops it, since a silent agent is a
+monitoring blind spot (fail-slow, not fail-closed).
+
+- **Memory throttling** engages at `throttle_memory_ratio × max_memory_mb` and is
+  active only when `max_memory_mb > 0`. Setting `max_memory_mb` also installs a
+  soft `GOMEMLIMIT` (via `debug.SetMemoryLimit`) so the Go runtime GCs harder to
+  stay under the budget while the watchdog sheds probe load before it is reached.
+- **CPU throttling** engages at `throttle_cpu_percent` of the process's available
+  CPU capacity (its `GOMAXPROCS` cores), so `90` means the agent is saturating
+  nearly all the cores it is allowed to use.
+- A **hysteresis band** (recovery requires usage to fall to 75% of the engage
+  threshold) plus the one-step-per-interval ramp keeps the multiplier from
+  flapping when usage hovers at a threshold.
+- `max_procs` and `max_memory_mb` are honored as plain runtime caps whenever set,
+  independent of `self_protection_enabled`.
+
+Engaging and fully releasing the throttle are logged at `warn`; the live
+multiplier is exported as the `rpingmesh.agent.self_throttle` OTLP gauge
+(`1.0` = unthrottled). CPU utilization is measured via `getrusage` rather than the
+`runtime/metrics` `/cpu/classes` counters because the latter only advance during a
+GC cycle, which would leave a low-allocation agent's CPU reading stale.
 
 ### Environment Variable Overrides
 
@@ -589,8 +627,10 @@ The agent exports the following OTLP metrics:
 | `rpingmesh.probe_success_total` | Counter | | Successful probe count |
 | `rpingmesh.probe_failed_total` | Counter | | Failed probe count |
 | `rpingmesh.probe_total` | Counter | | Total probe attempts |
+| `rpingmesh.agent.self_throttle` | Gauge | | Self-protection rate multiplier (`1.0` = unthrottled, down to `0.1`); emitted only when `self_protection_enabled` |
 
-All metrics carry two attributes: `source_tor` and `target_tor`.
+The probe metrics carry two attributes: `source_tor` and `target_tor`. The
+`self_throttle` gauge is attribute-free (a single process-wide value).
 
 The controller-side analyzer (Phase 1) exports the following OTLP metrics under
 `service.name=rpingmesh-analyzer`:
@@ -716,9 +756,13 @@ sudo rdma link add rxe0 type rxe netdev eth0
   (Phase 2); eBPF-based service tracing from the original design is also not
   part of this rebuild.
 
-- **No agent self-protection.** There is no hard CPU/memory cap on the
-  agent process and no fail-closed behavior (e.g. backing off or shutting
-  down probing) when local resource usage or error rates spike.
+- **Agent self-protection is fail-slow and CPU/memory only (opt-in).** The
+  watchdog (`self_protection_enabled`, see [Self-protection](#self-protection))
+  throttles the probe send rate under local CPU/memory pressure and can install a
+  soft `GOMEMLIMIT`/`GOMAXPROCS` cap, but it deliberately never stops probing
+  (no fail-closed) and does not react to error rates or downstream backpressure.
+  Throttling is coarse (a four-step multiplier) and thresholds are static; there
+  is no adaptive control loop.
 
 - **Address Handle `sl` / `traffic_class` are a single agent-wide value, not
   per-target.** `service_level` and `traffic_class` (see Configuration

--- a/rebuild/configs/agent.yaml
+++ b/rebuild/configs/agent.yaml
@@ -43,5 +43,20 @@ allowed_device_names: []         # Empty = all devices
 metrics_enabled: true
 otel_collector_addr: "localhost:4317"
 
+# Self-protection (opt-in)
+# When enabled, a watchdog samples this process's CPU/memory every
+# watchdog_interval_sec and, on threshold breach, steps the probe send rate down
+# (fail-slow: 1.0 -> 0.5 -> 0.25 -> 0.1, never 0) to shed load, restoring it as
+# usage recovers. It never stops probing (no monitoring blind spot). The current
+# multiplier is exported as the rpingmesh.agent.self_throttle gauge.
+self_protection_enabled: false   # opt-in; default keeps prior behavior
+watchdog_interval_sec: 5         # resource sampling period
+# Hard runtime caps (applied whenever > 0, independent of self_protection_enabled):
+max_memory_mb: 0                 # GOMEMLIMIT via debug.SetMemoryLimit (0 = disabled)
+max_procs: 0                     # cap GOMAXPROCS (0 = Go default: all cores)
+# Throttle thresholds (used only when self_protection_enabled):
+throttle_memory_ratio: 0.9       # engage at 90% of max_memory_mb (only if max_memory_mb > 0)
+throttle_cpu_percent: 90         # engage at 90% of available CPU capacity (GOMAXPROCS cores)
+
 # Logging
 log_level: "info"                # debug, info, warn, error

--- a/rebuild/internal/agent/agent.go
+++ b/rebuild/internal/agent/agent.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -95,6 +97,11 @@ type Agent struct {
 	// reporting is disabled.
 	analysisReporter *AnalysisReporter
 
+	// watchdog samples this process's CPU/memory and throttles every prober's
+	// send rate (fail-slow) under pressure. nil when self-protection is
+	// disabled (the default).
+	watchdog *Watchdog
+
 	// metricsResultsActive records whether a metrics result consumer will drain
 	// a.results (i.e. a.metrics != nil). It is decided before createResultsFanIn
 	// and read by each fan-in goroutine: when false, the fan-in does NOT send on
@@ -124,10 +131,39 @@ func NewAgent(cfg *config.AgentConfig) (*Agent, error) {
 		return nil, fmt.Errorf("agent config must not be nil")
 	}
 
-	return &Agent{
+	a := &Agent{
 		cfg:    cfg,
 		logger: log.With().Str("component", "agent").Logger(),
-	}, nil
+	}
+
+	// Apply optional hard runtime caps as early as possible (before any heavy
+	// allocation) so a soft memory limit governs the whole process lifetime.
+	applyRuntimeLimits(cfg, a.logger)
+
+	return a, nil
+}
+
+// applyRuntimeLimits applies the optional hard runtime caps from config: a soft
+// memory limit (GOMEMLIMIT, via debug.SetMemoryLimit) and a GOMAXPROCS cap.
+// Both are opt-in (0 leaves the Go default) and applied independently of
+// self_protection_enabled, so they can serve as plain runtime tuning knobs. The
+// memory limit also acts as the reference budget the watchdog throttles against.
+func applyRuntimeLimits(cfg *config.AgentConfig, logger zerolog.Logger) {
+	if cfg.MaxMemoryMB > 0 {
+		limit := int64(cfg.MaxMemoryMB) * bytesPerMiB
+		debug.SetMemoryLimit(limit)
+		logger.Info().
+			Int("max_memory_mb", cfg.MaxMemoryMB).
+			Int64("gomemlimit_bytes", limit).
+			Msg("Applied soft memory limit (GOMEMLIMIT)")
+	}
+	if cfg.MaxProcs > 0 {
+		prev := runtime.GOMAXPROCS(cfg.MaxProcs)
+		logger.Info().
+			Int("max_procs", cfg.MaxProcs).
+			Int("previous_gomaxprocs", prev).
+			Msg("Capped GOMAXPROCS")
+	}
 }
 
 // Initialize performs all setup steps required before the agent can be started.
@@ -236,6 +272,28 @@ func (a *Agent) Initialize(ctx context.Context) error {
 		a.logger.Info().
 			Uint32("window_sec", a.cfg.AnalysisWindowSec).
 			Msg("Analysis reporter created")
+	}
+
+	// Create the resource watchdog (self-protection) if enabled. It throttles
+	// every prober's send rate (fail-slow) when this process's CPU/memory
+	// crosses the configured thresholds. Created after the probers (which it
+	// drives) and the metrics collector (whose self_throttle gauge reads its
+	// live multiplier).
+	if a.cfg.SelfProtectionEnabled {
+		throttlers := make([]rateThrottler, 0, len(a.probers))
+		for _, p := range a.probers {
+			throttlers = append(throttlers, p)
+		}
+		a.watchdog = NewWatchdog(a.cfg, throttlers)
+		if a.metrics != nil {
+			if err := a.metrics.RegisterSelfThrottleCallback(a.watchdog.CurrentMultiplier); err != nil {
+				a.logger.Warn().Err(err).
+					Msg("Failed to register self-throttle metric callback")
+			}
+		}
+		a.logger.Info().
+			Int("prober_count", len(a.probers)).
+			Msg("Self-protection watchdog created")
 	}
 
 	// Step 6: Create one responder per device.
@@ -474,6 +532,12 @@ func (a *Agent) Start(ctx context.Context) error {
 		a.analysisReporter.Start(ctx)
 	}
 
+	// Start the resource watchdog if enabled. It runs independently, sampling
+	// on its own interval and throttling the probers under load.
+	if a.watchdog != nil {
+		a.watchdog.Start(ctx)
+	}
+
 	a.logger.Info().Msg("Agent started")
 	return nil
 }
@@ -495,6 +559,12 @@ func (a *Agent) Stop(ctx context.Context) {
 	// Stop the heartbeat goroutine before closing the gRPC client, since
 	// both it and the cluster monitors depend on grpcClient being open.
 	a.stopHeartbeat()
+
+	// Stop the resource watchdog before tearing down the probers, since it
+	// calls SetRateMultiplier on them.
+	if a.watchdog != nil {
+		a.watchdog.Stop()
+	}
 
 	// Stop all probers to cease outgoing probes. Destroy() closes each
 	// prober's own Results() channel, letting each fan-in goroutine's range

--- a/rebuild/internal/agent/prober.go
+++ b/rebuild/internal/agent/prober.go
@@ -242,6 +242,18 @@ type Prober struct {
 	torMeshRate  perTypeRate
 	interTorRate perTypeRate
 
+	// rateMultiplier is the self-protection throttle factor in (0, 1] applied
+	// on top of both per-type aggregate rates: the effective limiter rate is
+	// pps * (targets of that type) * rateMultiplier. It is guarded by rateMu
+	// and set by the Watchdog via SetRateMultiplier when local CPU/memory
+	// pressure warrants slowing probing (fail-slow), and restored toward 1.0 on
+	// recovery. A non-positive value (the zero value of a struct-literal Prober,
+	// or an unset throttle) is treated as 1.0 by scaledRate, so throttling is
+	// strictly opt-in and can never silently disable a limiter. It never reaches
+	// 0: the Watchdog floors it at minThrottleMultiplier so probing degrades but
+	// never stops (no fail-closed monitoring hole).
+	rateMultiplier float64
+
 	// flowLabelRotationPeriodSec is the period over which the rotating subset
 	// of each target's flow-label set is refreshed. Read only by the probe-loop
 	// goroutine via flowLabelRotationEpoch; set once at construction and
@@ -320,6 +332,7 @@ func NewProber(device *rdmabridge.Device, ring *rdmabridge.EventRing, probeInter
 		agentEpoch:                 rand.Uint32(),
 		resultChan:                 make(chan *probe.ProbeResult, resultChanSize),
 		stopCh:                     make(chan struct{}),
+		rateMultiplier:             1.0, // unthrottled until the Watchdog engages
 		probeInterval:              time.Duration(probeIntervalMS) * time.Millisecond,
 		probeTimeout:               probeSendTimeoutMS,
 		flowLabelRotationPeriodSec: defaultFlowLabelRotationPeriodSec,
@@ -408,9 +421,9 @@ func (p *Prober) SetPerTypeRateLimit(torMeshPPS, interTorPPS float64) {
 
 	p.rateMu.Lock()
 	p.torMeshRate.pps = torMeshPPS
-	p.torMeshRate.limiter.SetRate(torMeshPPS * float64(nTorMesh))
+	p.torMeshRate.limiter.SetRate(scaledRate(torMeshPPS, nTorMesh, p.rateMultiplier))
 	p.interTorRate.pps = interTorPPS
-	p.interTorRate.limiter.SetRate(interTorPPS * float64(nInterTor))
+	p.interTorRate.limiter.SetRate(scaledRate(interTorPPS, nInterTor, p.rateMultiplier))
 	p.rateMu.Unlock()
 
 	p.logger.Info().
@@ -419,6 +432,64 @@ func (p *Prober) SetPerTypeRateLimit(torMeshPPS, interTorPPS float64) {
 		Float64("inter_tor_pps", interTorPPS).
 		Int("inter_tor_targets", nInterTor).
 		Msg("Probe send rate limits updated")
+}
+
+// SetRateMultiplier scales BOTH per-type aggregate send rates by mult, the
+// self-protection throttle factor. It is the single integration point between
+// the Watchdog and the send path: the Watchdog calls it to slow probing when
+// local CPU/memory pressure rises (fail-slow) and to restore it on recovery.
+// mult is clamped to (0, 1] (out-of-range values map to 1.0 = unthrottled), so
+// the multiplier can only reduce, never amplify, the configured per-target
+// cadence, and can never fully stop probing.
+//
+// It intentionally reuses the SetPerTypeRateLimit lock order (targetsMu ->
+// rateMu): the per-type target counts are read under targetsMu and the limiter
+// rates recomputed under rateMu, so a concurrent UpdateTargets or
+// SetPerTypeRateLimit can neither race the read nor leave a limiter scaled from
+// a stale count. Because the stored multiplier is applied by every subsequent
+// UpdateTargets/SetPerTypeRateLimit too, a pinglist change while throttled
+// preserves the throttle. Safe to call while running.
+func (p *Prober) SetRateMultiplier(mult float64) {
+	mult = clampRateMultiplier(mult)
+
+	p.targetsMu.RLock()
+	defer p.targetsMu.RUnlock()
+	nTorMesh, nInterTor := countTargetsByType(p.targets)
+
+	p.rateMu.Lock()
+	p.rateMultiplier = mult
+	p.torMeshRate.limiter.SetRate(scaledRate(p.torMeshRate.pps, nTorMesh, mult))
+	p.interTorRate.limiter.SetRate(scaledRate(p.interTorRate.pps, nInterTor, mult))
+	p.rateMu.Unlock()
+
+	p.logger.Debug().
+		Float64("rate_multiplier", mult).
+		Msg("Probe send rate multiplier updated")
+}
+
+// clampRateMultiplier bounds a throttle multiplier to (0, 1]. Any value <= 0 or
+// > 1 is nonsensical for a factor that may only slow probing, so it maps to 1.0
+// (unthrottled) -- the safe default that keeps monitoring at full rate rather
+// than risking a stall from a bad input.
+func clampRateMultiplier(mult float64) float64 {
+	if mult <= 0 || mult > 1 {
+		return 1.0
+	}
+	return mult
+}
+
+// scaledRate computes a pinglist type's aggregate limiter rate: the per-target
+// pps times the number of targets of that type, scaled by the self-protection
+// throttle multiplier. A non-positive multiplier (the zero value of a
+// struct-literal Prober, or an unset throttle) is treated as 1.0 so throttling
+// is opt-in and never silently disables the limiter; multiplying by an exact
+// 1.0 is bit-identical to the un-throttled pps*n, so unthrottled behavior is
+// unchanged. A pps of 0 yields 0, which RateLimiter.SetRate reads as disabled.
+func scaledRate(pps float64, n int, mult float64) float64 {
+	if mult <= 0 {
+		mult = 1.0
+	}
+	return pps * float64(n) * mult
 }
 
 // countTargetsByType counts how many targets belong to each pinglist type. A
@@ -514,10 +585,10 @@ func (p *Prober) UpdateTargets(targets []*controller_agent.PingTarget) {
 	nTorMesh, nInterTor := countTargetsByType(targets)
 	p.rateMu.Lock()
 	if p.torMeshRate.pps > 0 {
-		p.torMeshRate.limiter.SetRate(p.torMeshRate.pps * float64(nTorMesh))
+		p.torMeshRate.limiter.SetRate(scaledRate(p.torMeshRate.pps, nTorMesh, p.rateMultiplier))
 	}
 	if p.interTorRate.pps > 0 {
-		p.interTorRate.limiter.SetRate(p.interTorRate.pps * float64(nInterTor))
+		p.interTorRate.limiter.SetRate(scaledRate(p.interTorRate.pps, nInterTor, p.rateMultiplier))
 	}
 	p.rateMu.Unlock()
 

--- a/rebuild/internal/agent/prober_throttle_test.go
+++ b/rebuild/internal/agent/prober_throttle_test.go
@@ -1,0 +1,161 @@
+// Tests for the self-protection rate multiplier applied on top of the
+// per-pinglist-type send-rate limiters: the multiplier scales both types'
+// aggregate rates, unity (and out-of-range clamped) multipliers are a no-op,
+// the multiplier survives a pinglist resize, and SetRateMultiplier obeys the
+// targetsMu -> rateMu lock order under concurrency. These reuse the helpers in
+// prober_ratelimit_test.go (same package).
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// wantScaledInterval mirrors SetRate(scaledRate(pps, n, mult)) exactly: the
+// aggregate rate is pps*n*mult and the reported minimum inter-send interval is
+// its reciprocal, using the same operand order so the float result is
+// bit-identical to the limiter's.
+func wantScaledInterval(pps float64, n int, mult float64) time.Duration {
+	return time.Duration(float64(time.Second) / (pps * float64(n) * mult))
+}
+
+func mixedTargets(nTor, nInter int) []*controller_agent.PingTarget {
+	return append(
+		typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", nTor),
+		typedTargets(controller_agent.PinglistType_INTER_TOR, "int", nInter)...,
+	)
+}
+
+// TestSetRateMultiplier_ScalesBothTypes verifies a 0.5 multiplier halves each
+// type's aggregate rate (doubling its inter-send interval), independently.
+func TestSetRateMultiplier_ScalesBothTypes(t *testing.T) {
+	const (
+		torPPS   = 10.0
+		interPPS = 2.0
+		nTor     = 4
+		nInter   = 2
+		mult     = 0.5
+	)
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(mixedTargets(nTor, nInter))
+	p.SetPerTypeRateLimit(torPPS, interPPS)
+	p.SetRateMultiplier(mult)
+
+	if got, want := reserveInterval(&p.torMeshRate.limiter), wantScaledInterval(torPPS, nTor, mult); got != want {
+		t.Errorf("ToR-mesh interval @ mult %.2f = %v, want %v", mult, got, want)
+	}
+	if got, want := reserveInterval(&p.interTorRate.limiter), wantScaledInterval(interPPS, nInter, mult); got != want {
+		t.Errorf("inter-ToR interval @ mult %.2f = %v, want %v", mult, got, want)
+	}
+}
+
+// TestSetRateMultiplier_UnityAndClampAreNoops verifies that a unity multiplier,
+// and any out-of-range value (<=0 or >1, which clamp to 1.0), leave both rates
+// exactly at their unthrottled values.
+func TestSetRateMultiplier_UnityAndClampAreNoops(t *testing.T) {
+	const (
+		torPPS   = 10.0
+		interPPS = 2.0
+		nTor     = 3
+		nInter   = 2
+	)
+
+	for _, mult := range []float64{1.0, 0.0, -0.5, 1.5} {
+		p := &Prober{logger: zerolog.Nop()}
+		p.UpdateTargets(mixedTargets(nTor, nInter))
+		p.SetPerTypeRateLimit(torPPS, interPPS)
+		p.SetRateMultiplier(mult)
+
+		if got, want := reserveInterval(&p.torMeshRate.limiter), wantScaledInterval(torPPS, nTor, 1.0); got != want {
+			t.Errorf("ToR-mesh interval @ mult %.2f = %v, want unthrottled %v", mult, got, want)
+		}
+		if got, want := reserveInterval(&p.interTorRate.limiter), wantScaledInterval(interPPS, nInter, 1.0); got != want {
+			t.Errorf("inter-ToR interval @ mult %.2f = %v, want unthrottled %v", mult, got, want)
+		}
+	}
+}
+
+// TestSetRateMultiplier_SurvivesUpdateTargets verifies that an active multiplier
+// keeps applying after a pinglist resize: UpdateTargets recomputes each rate
+// from the new target count but still folds in the stored multiplier.
+func TestSetRateMultiplier_SurvivesUpdateTargets(t *testing.T) {
+	const (
+		torPPS   = 10.0
+		interPPS = 4.0
+		mult     = 0.25
+	)
+
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(mixedTargets(2, 3))
+	p.SetPerTypeRateLimit(torPPS, interPPS)
+	p.SetRateMultiplier(mult)
+
+	// Resize both types; the multiplier must persist through UpdateTargets.
+	p.UpdateTargets(mixedTargets(4, 1))
+
+	if got, want := reserveInterval(&p.torMeshRate.limiter), wantScaledInterval(torPPS, 4, mult); got != want {
+		t.Errorf("ToR-mesh interval after resize = %v, want %v (multiplier not preserved)", got, want)
+	}
+	if got, want := reserveInterval(&p.interTorRate.limiter), wantScaledInterval(interPPS, 1, mult); got != want {
+		t.Errorf("inter-ToR interval after resize = %v, want %v (multiplier not preserved)", got, want)
+	}
+}
+
+// TestSetRateMultiplier_LockOrderRace hammers UpdateTargets, SetPerTypeRateLimit,
+// SetRateMultiplier, and the rateMu-guarded read path concurrently. Under -race
+// it guards against a data race or a lock-order regression: every writer,
+// including the new SetRateMultiplier, must take targetsMu -> rateMu, while the
+// reader takes only rateMu.
+func TestSetRateMultiplier_LockOrderRace(t *testing.T) {
+	p := &Prober{logger: zerolog.Nop()}
+	p.UpdateTargets(typedTargets(controller_agent.PinglistType_TOR_MESH, "tor", 4))
+	p.SetPerTypeRateLimit(10, 2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled so rateLimitWait returns immediately
+
+	var wg sync.WaitGroup
+	const iters = 500
+	mults := []float64{1.0, 0.5, 0.25, 0.1}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.UpdateTargets(mixedTargets(1+i%6, 1+i%3))
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.SetPerTypeRateLimit(float64(1+i%10), float64(1+i%4))
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.SetRateMultiplier(mults[i%len(mults)])
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			p.rateLimitWait(ctx, controller_agent.PinglistType_TOR_MESH)
+			p.rateLimitWait(ctx, controller_agent.PinglistType_INTER_TOR)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/rebuild/internal/agent/watchdog.go
+++ b/rebuild/internal/agent/watchdog.go
@@ -1,0 +1,384 @@
+package agent
+
+import (
+	"context"
+	"math"
+	"runtime"
+	"runtime/metrics"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/yuuki/rpingmesh/rebuild/internal/config"
+	"golang.org/x/sys/unix"
+)
+
+// Watchdog constants.
+const (
+	// defaultWatchdogIntervalSec is the fallback sampling period used when the
+	// configured watchdog_interval_sec is 0 (which Validate rejects while the
+	// feature is enabled, so this only guards direct/test construction).
+	defaultWatchdogIntervalSec = 5
+
+	// throttleRecoveryRatio is the hysteresis band. Throttling engages when a
+	// resource reaches its threshold, but the watchdog only steps the rate
+	// multiplier back UP once usage falls to this fraction of that threshold.
+	// The gap between the engage point (threshold) and the release point
+	// (threshold * ratio) is what keeps the multiplier from flapping when usage
+	// hovers right at the threshold; 0.75 leaves a 25% margin.
+	throttleRecoveryRatio = 0.75
+
+	// bytesPerMiB converts the config's max_memory_mb into the byte-domain
+	// reading the runtime/metrics sampler returns.
+	bytesPerMiB = 1 << 20
+
+	// runtime/metrics keys for GOMEMLIMIT-style memory accounting: all
+	// runtime-managed memory (total) minus what has been returned to the OS
+	// (released). Their difference is directly comparable to the max_memory_mb
+	// budget, which uses the same accounting as debug.SetMemoryLimit.
+	metricMemTotal    = "/memory/classes/total:bytes"
+	metricMemReleased = "/memory/classes/heap/released:bytes"
+)
+
+// throttleLadder is the discrete set of rate multipliers the watchdog steps
+// through, from unthrottled (index 0) down to the fail-slow floor (last index).
+// The watchdog moves at most one step per sample, so a sustained overload ramps
+// down over several intervals and recovery climbs back just as gradually; that
+// gradualness, together with throttleRecoveryRatio, is what prevents abrupt
+// oscillation. The floor is deliberately greater than 0: self-protection slows
+// probing but must never stop it, since a silent agent is a monitoring blind
+// spot (fail-slow, never fail-closed).
+var throttleLadder = []float64{1.0, 0.5, 0.25, 0.1}
+
+// minThrottleMultiplier is the fail-slow floor (the last ladder entry), named
+// so logs and the prober's contract can refer to the guaranteed lower bound.
+var minThrottleMultiplier = throttleLadder[len(throttleLadder)-1]
+
+// resourceSample is a point-in-time reading of this process's resource usage.
+// Kept small and free of any RDMA/cgo dependency so the watchdog logic can be
+// unit-tested with an injected sampler.
+type resourceSample struct {
+	// memInUseBytes is runtime-managed memory currently in use, using the same
+	// accounting as GOMEMLIMIT (total classes minus released-to-OS), so it is
+	// directly comparable to the max_memory_mb budget.
+	memInUseBytes uint64
+	// cpuNanos is cumulative process CPU time (user+system) in nanoseconds. The
+	// watchdog derives a utilization percentage from its delta between samples.
+	cpuNanos uint64
+	// gomaxprocs is the CPU capacity (number of cores the process may use) at
+	// sample time; utilization is measured relative to this so a max_procs cap
+	// is respected automatically.
+	gomaxprocs int
+}
+
+// resourceSampler produces a resourceSample. Injected into the Watchdog so
+// tests can feed deterministic readings without touching real process state.
+type resourceSampler interface {
+	sample() resourceSample
+}
+
+// rateThrottler is the subset of *Prober the watchdog drives: scaling the
+// prober's aggregate send rate by a multiplier in (0, 1]. Declared here (at the
+// point of use) so the watchdog can be tested against a fake.
+type rateThrottler interface {
+	SetRateMultiplier(mult float64)
+}
+
+// runtimeSampler is the production resourceSampler. Memory comes from
+// runtime/metrics (GOMEMLIMIT accounting); CPU comes from getrusage.
+type runtimeSampler struct{}
+
+// sample reads current memory and CPU usage.
+//
+// Memory uses runtime/metrics so the reading matches the debug.SetMemoryLimit
+// budget. CPU uses getrusage rather than runtime/metrics /cpu/classes because
+// those CPU counters only advance during a GC cycle: a low-allocation agent
+// would report stale (often zero) CPU for long stretches unless the watchdog
+// forced a disruptive GC every tick. getrusage returns real cumulative process
+// CPU time on every call and is available on both linux and darwin via
+// golang.org/x/sys/unix (already a dependency) -- the only platforms this agent
+// builds for -- so it adds no new dependency.
+func (runtimeSampler) sample() resourceSample {
+	samples := []metrics.Sample{
+		{Name: metricMemTotal},
+		{Name: metricMemReleased},
+	}
+	metrics.Read(samples)
+	var total, released uint64
+	if samples[0].Value.Kind() == metrics.KindUint64 {
+		total = samples[0].Value.Uint64()
+	}
+	if samples[1].Value.Kind() == metrics.KindUint64 {
+		released = samples[1].Value.Uint64()
+	}
+	var memInUse uint64
+	if total > released {
+		memInUse = total - released
+	}
+
+	var cpuNanos uint64
+	var ru unix.Rusage
+	if err := unix.Getrusage(unix.RUSAGE_SELF, &ru); err == nil {
+		cpuNanos = uint64(ru.Utime.Nano() + ru.Stime.Nano())
+	}
+
+	return resourceSample{
+		memInUseBytes: memInUse,
+		cpuNanos:      cpuNanos,
+		gomaxprocs:    runtime.GOMAXPROCS(0),
+	}
+}
+
+// Watchdog periodically samples this agent process's CPU and memory usage and,
+// on threshold breach, steps every prober's send-rate multiplier down the
+// throttleLadder (fail-slow), restoring it as usage recovers. It never stops
+// probing outright. All mutable state except the published multiplier is owned
+// by the single run goroutine (tick is not called concurrently); the multiplier
+// is published via an atomic for the OTLP gauge callback.
+type Watchdog struct {
+	interval   time.Duration
+	sampler    resourceSampler
+	throttlers []rateThrottler
+
+	// Thresholds precomputed from config. A zero threshold disables that
+	// resource's contribution (memory throttling is off when no max_memory_mb
+	// budget is set).
+	memHighBytes float64 // 0 => memory throttling disabled
+	cpuHighPct   float64 // 0 => CPU throttling disabled
+
+	// State owned by the run goroutine (and tick, called only from it).
+	levelIdx int
+	prev     resourceSample
+	prevTime time.Time
+	havePrev bool
+
+	// multiplierBits is math.Float64bits of the current multiplier, published
+	// for CurrentMultiplier (read from the metrics callback goroutine).
+	multiplierBits atomic.Uint64
+
+	nowFn  func() time.Time
+	logger zerolog.Logger
+
+	wg     sync.WaitGroup
+	stopCh chan struct{}
+}
+
+// NewWatchdog builds a Watchdog from config that drives the given throttlers
+// (one per prober). It reads the production runtimeSampler; tests construct a
+// Watchdog directly to inject a fake sampler and clock.
+func NewWatchdog(cfg *config.AgentConfig, throttlers []rateThrottler) *Watchdog {
+	interval := time.Duration(cfg.WatchdogIntervalSec) * time.Second
+	if interval <= 0 {
+		interval = defaultWatchdogIntervalSec * time.Second
+	}
+
+	// Memory throttling references the max_memory_mb budget; with no budget it
+	// stays disabled and only CPU is watched.
+	var memHigh float64
+	if cfg.MaxMemoryMB > 0 {
+		memHigh = float64(cfg.MaxMemoryMB) * bytesPerMiB * cfg.ThrottleMemoryRatio
+	}
+
+	w := &Watchdog{
+		interval:     interval,
+		sampler:      runtimeSampler{},
+		throttlers:   throttlers,
+		memHighBytes: memHigh,
+		cpuHighPct:   cfg.ThrottleCPUPercent,
+		nowFn:        time.Now,
+		logger:       log.With().Str("component", "watchdog").Logger(),
+	}
+	w.setMultiplier(throttleLadder[0])
+	return w
+}
+
+// Start launches the watchdog goroutine. It returns immediately; the goroutine
+// runs until Stop is called or ctx is cancelled.
+func (w *Watchdog) Start(ctx context.Context) {
+	w.stopCh = make(chan struct{})
+	w.wg.Add(1)
+	go w.run(ctx)
+	w.logger.Info().
+		Dur("interval", w.interval).
+		Float64("mem_high_bytes", w.memHighBytes).
+		Float64("cpu_high_percent", w.cpuHighPct).
+		Float64("floor_multiplier", minThrottleMultiplier).
+		Msg("Self-protection watchdog started")
+}
+
+// Stop signals the watchdog goroutine to exit and waits for it. It is a no-op
+// if Start was never called, matching the nil-guard pattern used in Agent.Stop.
+func (w *Watchdog) Stop() {
+	if w.stopCh == nil {
+		return
+	}
+	close(w.stopCh)
+	w.wg.Wait()
+	w.logger.Info().Msg("Self-protection watchdog stopped")
+}
+
+// CurrentMultiplier returns the watchdog's current rate multiplier (1.0 =
+// unthrottled, down to minThrottleMultiplier). Safe to call from any goroutine;
+// used by the rpingmesh.agent.self_throttle gauge callback.
+func (w *Watchdog) CurrentMultiplier() float64 {
+	return math.Float64frombits(w.multiplierBits.Load())
+}
+
+func (w *Watchdog) setMultiplier(m float64) {
+	w.multiplierBits.Store(math.Float64bits(m))
+}
+
+// run is the watchdog loop: sample, evaluate, apply, on each interval tick.
+func (w *Watchdog) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.tick(w.sampler.sample(), w.nowFn())
+		}
+	}
+}
+
+// tick evaluates one sample and, if the throttle level changes, applies the new
+// multiplier to every prober and logs the transition. It is called only from
+// the run goroutine, so its state mutations need no lock. Extracted from run so
+// tests can drive it directly with injected samples and timestamps for
+// deterministic threshold/hysteresis verification.
+func (w *Watchdog) tick(cur resourceSample, now time.Time) {
+	cpuUtil := -1.0 // negative => no CPU reading yet (need a prior sample)
+	if w.havePrev {
+		cpuUtil = cpuUtilization(w.prev, cur, w.prevTime, now)
+	}
+	w.prev = cur
+	w.prevTime = now
+	w.havePrev = true
+
+	over, clear := w.assess(cur.memInUseBytes, cpuUtil)
+	newIdx := nextLevel(w.levelIdx, over, clear)
+	if newIdx == w.levelIdx {
+		return
+	}
+
+	oldMult := throttleLadder[w.levelIdx]
+	newMult := throttleLadder[newIdx]
+	w.levelIdx = newIdx
+	w.setMultiplier(newMult)
+	for _, t := range w.throttlers {
+		t.SetRateMultiplier(newMult)
+	}
+	w.logThrottleChange(oldMult, newMult, cur.memInUseBytes, cpuUtil)
+}
+
+// assess reports whether the current reading is OVER any enabled threshold
+// (=> throttle down) and whether it is CLEAR of ALL enabled thresholds by the
+// hysteresis margin (=> recover up). A disabled resource (or a CPU reading not
+// yet available, cpuUtil < 0) counts as clear and never over, so it neither
+// triggers nor blocks throttling. over and clear are mutually exclusive
+// (threshold > threshold*ratio), so a reading in the deadband between the
+// release and engage points yields neither, holding the current level.
+func (w *Watchdog) assess(memBytes uint64, cpuUtil float64) (over, clear bool) {
+	over = false
+	clear = true
+
+	if w.memHighBytes > 0 {
+		high := w.memHighBytes
+		low := high * throttleRecoveryRatio
+		m := float64(memBytes)
+		if m >= high {
+			over = true
+		}
+		if m > low {
+			clear = false
+		}
+	}
+
+	if w.cpuHighPct > 0 && cpuUtil >= 0 {
+		high := w.cpuHighPct
+		low := high * throttleRecoveryRatio
+		if cpuUtil >= high {
+			over = true
+		}
+		if cpuUtil > low {
+			clear = false
+		}
+	}
+
+	return over, clear
+}
+
+// nextLevel returns the throttle-ladder index for the next tick: one step down
+// (more throttle) when over, one step up (less throttle) when clear, otherwise
+// unchanged. Clamped to the ladder bounds. Pure, so the ladder walk is
+// trivially unit-testable.
+func nextLevel(cur int, over, clear bool) int {
+	switch {
+	case over:
+		if cur < len(throttleLadder)-1 {
+			return cur + 1
+		}
+		return cur
+	case clear:
+		if cur > 0 {
+			return cur - 1
+		}
+		return cur
+	default:
+		return cur
+	}
+}
+
+// cpuUtilization returns process CPU utilization between two samples as a
+// percentage of the available CPU capacity (GOMAXPROCS cores) over the wall
+// interval, using the current sample's core count as capacity. It returns 0 for
+// a non-positive interval or a counter that went backwards, guarding against a
+// clock that did not advance or a rusage anomaly.
+func cpuUtilization(prev, cur resourceSample, prevTime, curTime time.Time) float64 {
+	wall := curTime.Sub(prevTime).Nanoseconds()
+	if wall <= 0 {
+		return 0
+	}
+	if cur.cpuNanos < prev.cpuNanos {
+		return 0
+	}
+	cores := cur.gomaxprocs
+	if cores <= 0 {
+		cores = 1
+	}
+	busy := float64(cur.cpuNanos - prev.cpuNanos)
+	capacity := float64(wall) * float64(cores)
+	return busy / capacity * 100
+}
+
+// logThrottleChange records a throttle-level transition. Engaging throttle
+// (leaving the unthrottled top of the ladder) and fully recovering (returning
+// to it) are logged at Warn since they mark a change in monitoring fidelity;
+// intermediate steps are Info to avoid noise.
+func (w *Watchdog) logThrottleChange(oldMult, newMult float64, memBytes uint64, cpuUtil float64) {
+	unthrottled := throttleLadder[0]
+	var event *zerolog.Event
+	switch {
+	case oldMult == unthrottled && newMult < unthrottled:
+		event = w.logger.Warn()
+	case newMult == unthrottled:
+		event = w.logger.Warn()
+	default:
+		event = w.logger.Info()
+	}
+	event.
+		Float64("old_multiplier", oldMult).
+		Float64("new_multiplier", newMult).
+		Float64("floor_multiplier", minThrottleMultiplier).
+		Uint64("mem_in_use_bytes", memBytes).
+		Float64("cpu_util_percent", cpuUtil).
+		Msg("Self-protection throttle level changed")
+}

--- a/rebuild/internal/agent/watchdog_test.go
+++ b/rebuild/internal/agent/watchdog_test.go
@@ -1,0 +1,231 @@
+// Tests for the self-protection watchdog's throttle state machine: threshold
+// breach steps the rate multiplier down the ladder, recovery steps it back up,
+// a hysteresis deadband holds it steady near the threshold, and the floor is
+// never breached (fail-slow, never fail-closed). Samples and timestamps are
+// injected so every case is deterministic without real resource pressure.
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// fakeThrottler records every multiplier the watchdog applies, standing in for
+// a *Prober so the watchdog can be tested without RDMA.
+type fakeThrottler struct{ mults []float64 }
+
+func (f *fakeThrottler) SetRateMultiplier(m float64) { f.mults = append(f.mults, m) }
+
+// newTestWatchdog builds a Watchdog with the given thresholds and a fake
+// throttler, bypassing NewWatchdog so tests drive tick() directly with injected
+// samples instead of the sampler/goroutine.
+func newTestWatchdog(memHigh, cpuHigh float64) (*Watchdog, *fakeThrottler) {
+	ft := &fakeThrottler{}
+	w := &Watchdog{
+		memHighBytes: memHigh,
+		cpuHighPct:   cpuHigh,
+		throttlers:   []rateThrottler{ft},
+		logger:       zerolog.Nop(),
+	}
+	w.setMultiplier(throttleLadder[0])
+	return w, ft
+}
+
+// memSample builds a sample carrying only a memory reading.
+func memSample(bytes uint64) resourceSample {
+	return resourceSample{memInUseBytes: bytes, gomaxprocs: 1}
+}
+
+func TestNextLevel(t *testing.T) {
+	last := len(throttleLadder) - 1
+	cases := []struct {
+		name       string
+		cur        int
+		over, clr  bool
+		wantResult int
+	}{
+		{"over steps down from top", 0, true, false, 1},
+		{"over steps down mid", 1, true, false, 2},
+		{"over clamps at floor", last, true, false, last},
+		{"clear steps up", 2, false, true, 1},
+		{"clear clamps at top", 0, false, true, 0},
+		{"deadband holds mid", 2, false, false, 2},
+		{"over wins over clear (mutually exclusive guard)", 1, true, true, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := nextLevel(c.cur, c.over, c.clr); got != c.wantResult {
+				t.Errorf("nextLevel(%d, over=%v, clear=%v) = %d, want %d", c.cur, c.over, c.clr, got, c.wantResult)
+			}
+		})
+	}
+}
+
+func TestAssess_MemoryThresholdsAndHysteresis(t *testing.T) {
+	// high=100 => low = 100 * 0.75 = 75. CPU disabled.
+	w, _ := newTestWatchdog(100, 0)
+	cases := []struct {
+		mem              uint64
+		wantOver, wantCl bool
+	}{
+		{100, true, false}, // exactly at high engages
+		{101, true, false}, // above high
+		{99, false, false}, // deadband (below high, above low)
+		{76, false, false}, // deadband just above low
+		{75, false, true},  // exactly at low recovers (not > low)
+		{74, false, true},  // below low
+		{0, false, true},   // idle
+	}
+	for _, c := range cases {
+		over, clr := w.assess(c.mem, -1)
+		if over != c.wantOver || clr != c.wantCl {
+			t.Errorf("assess(mem=%d) = (over=%v, clear=%v), want (over=%v, clear=%v)", c.mem, over, clr, c.wantOver, c.wantCl)
+		}
+	}
+}
+
+func TestAssess_CPUThresholdsAndUnavailable(t *testing.T) {
+	// high=90 => low = 67.5. Memory disabled.
+	w, _ := newTestWatchdog(0, 90)
+	cases := []struct {
+		util             float64
+		wantOver, wantCl bool
+	}{
+		{-1, false, true},   // no reading yet: clear, never over
+		{90, true, false},   // at threshold engages
+		{95, true, false},   // above
+		{80, false, false},  // deadband
+		{68, false, false},  // deadband just above low
+		{67.5, false, true}, // at low recovers
+		{10, false, true},   // idle
+	}
+	for _, c := range cases {
+		over, clr := w.assess(0, c.util)
+		if over != c.wantOver || clr != c.wantCl {
+			t.Errorf("assess(cpu=%g) = (over=%v, clear=%v), want (over=%v, clear=%v)", c.util, over, clr, c.wantOver, c.wantCl)
+		}
+	}
+}
+
+func TestAssess_EitherResourceTriggers_BothRequiredToClear(t *testing.T) {
+	// Both enabled: mem high=100 (low 75), cpu high=90 (low 67.5).
+	w, _ := newTestWatchdog(100, 90)
+
+	// Memory over, CPU idle => over (any resource triggers).
+	if over, clr := w.assess(120, 10); !over || clr {
+		t.Errorf("mem-over: got (over=%v, clear=%v), want (true, false)", over, clr)
+	}
+	// CPU over, memory idle => over.
+	if over, clr := w.assess(10, 95); !over || clr {
+		t.Errorf("cpu-over: got (over=%v, clear=%v), want (true, false)", over, clr)
+	}
+	// Memory clear but CPU still in deadband => not clear (both must clear).
+	if over, clr := w.assess(10, 80); over || clr {
+		t.Errorf("cpu-deadband: got (over=%v, clear=%v), want (false, false)", over, clr)
+	}
+	// Both clear => clear.
+	if over, clr := w.assess(10, 10); over || !clr {
+		t.Errorf("both-clear: got (over=%v, clear=%v), want (false, true)", over, clr)
+	}
+}
+
+// TestTick_MemoryRampDownAndRecover drives the full ladder: sustained overload
+// steps down one level per tick to the floor (and no further), then sustained
+// idle steps back up to unthrottled, each step applied to the throttler exactly
+// once.
+func TestTick_MemoryRampDownAndRecover(t *testing.T) {
+	w, ft := newTestWatchdog(100, 0)
+	base := time.Unix(0, 0)
+	step := time.Second
+
+	over := memSample(150) // above high=100
+	idle := memSample(50)  // below low=75
+
+	// Ramp down: 0->0.5->0.25->0.1, then hold at floor.
+	seq := []resourceSample{over, over, over, over}
+	for i, s := range seq {
+		w.tick(s, base.Add(time.Duration(i)*step))
+	}
+	// Then recover: 0.1->0.25->0.5->1.0, then hold at top.
+	for i, s := range []resourceSample{idle, idle, idle, idle} {
+		w.tick(s, base.Add(time.Duration(len(seq)+i)*step))
+	}
+
+	want := []float64{0.5, 0.25, 0.1, 0.25, 0.5, 1.0}
+	assertMults(t, ft.mults, want)
+	if got := w.CurrentMultiplier(); got != 1.0 {
+		t.Errorf("CurrentMultiplier() = %g, want 1.0 after recovery", got)
+	}
+}
+
+// TestTick_HysteresisHoldsInDeadband verifies that once throttled, a reading in
+// the deadband (below the engage threshold but above the recovery threshold)
+// neither throttles further nor recovers -- the multiplier holds until usage
+// clears the recovery threshold.
+func TestTick_HysteresisHoldsInDeadband(t *testing.T) {
+	w, ft := newTestWatchdog(100, 0) // low=75
+	base := time.Unix(0, 0)
+
+	w.tick(memSample(150), base)                   // over -> 0.5
+	w.tick(memSample(80), base.Add(1*time.Second)) // deadband -> hold
+	w.tick(memSample(80), base.Add(2*time.Second)) // deadband -> hold
+	w.tick(memSample(70), base.Add(3*time.Second)) // clear -> 1.0
+
+	assertMults(t, ft.mults, []float64{0.5, 1.0})
+}
+
+// TestTick_CPURampNeedsPriorSample verifies the first tick cannot throttle on
+// CPU (no delta yet), and that a subsequent high-CPU delta throttles while a
+// low delta recovers.
+func TestTick_CPURampNeedsPriorSample(t *testing.T) {
+	w, ft := newTestWatchdog(0, 90) // cpu low = 67.5, 1 core
+	base := time.Unix(0, 0)
+	sec := int64(time.Second)
+
+	// First sample: no prior => cpuUtil unavailable => no throttle.
+	w.tick(resourceSample{cpuNanos: 0, gomaxprocs: 1}, base)
+	// +1s, +0.95s CPU on 1 core => 95% => over.
+	w.tick(resourceSample{cpuNanos: uint64(0.95 * float64(sec)), gomaxprocs: 1}, base.Add(time.Second))
+	// +1s, +0.95s CPU => 95% => over again.
+	w.tick(resourceSample{cpuNanos: uint64(1.90 * float64(sec)), gomaxprocs: 1}, base.Add(2*time.Second))
+	// +1s, +0.10s CPU => 10% < low => clear.
+	w.tick(resourceSample{cpuNanos: uint64(2.00 * float64(sec)), gomaxprocs: 1}, base.Add(3*time.Second))
+
+	assertMults(t, ft.mults, []float64{0.5, 0.25, 0.5})
+}
+
+func TestCPUUtilization_Guards(t *testing.T) {
+	base := time.Unix(0, 0)
+	prev := resourceSample{cpuNanos: 1_000, gomaxprocs: 4}
+	// Non-positive interval => 0.
+	if got := cpuUtilization(prev, resourceSample{cpuNanos: 2_000, gomaxprocs: 4}, base, base); got != 0 {
+		t.Errorf("zero interval util = %g, want 0", got)
+	}
+	// Counter went backwards => 0.
+	if got := cpuUtilization(prev, resourceSample{cpuNanos: 500, gomaxprocs: 4}, base, base.Add(time.Second)); got != 0 {
+		t.Errorf("backwards counter util = %g, want 0", got)
+	}
+	// 2 cores, 1s wall, 1s CPU => 50% of capacity.
+	got := cpuUtilization(
+		resourceSample{cpuNanos: 0, gomaxprocs: 2},
+		resourceSample{cpuNanos: uint64(time.Second), gomaxprocs: 2},
+		base, base.Add(time.Second),
+	)
+	if got < 49.9 || got > 50.1 {
+		t.Errorf("util = %g, want ~50", got)
+	}
+}
+
+func assertMults(t *testing.T, got, want []float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("multiplier sequence = %v, want %v (length %d != %d)", got, want, len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("multiplier sequence = %v, want %v (index %d)", got, want, i)
+		}
+	}
+}

--- a/rebuild/internal/config/agent_config.go
+++ b/rebuild/internal/config/agent_config.go
@@ -39,6 +39,23 @@ const DefaultFlowLabelRotationPeriodSec = 3600
 // volume against detection latency.
 const DefaultAnalysisWindowSec = 30
 
+// Defaults for agent self-protection (P2-G). The feature is opt-in
+// (SelfProtectionEnabled defaults to false), so an untouched config behaves
+// exactly as before. When enabled, the watchdog samples this process's
+// CPU/memory usage every WatchdogIntervalSec seconds and, on threshold breach,
+// steps the probe-rate multiplier down (fail-slow) rather than stopping.
+const (
+	DefaultSelfProtectionEnabled = false
+	DefaultWatchdogIntervalSec   = 5
+	// DefaultThrottleMemoryRatio triggers throttling once runtime-managed
+	// memory reaches this fraction of max_memory_mb (the GOMEMLIMIT budget).
+	// Memory throttling is inactive unless max_memory_mb > 0.
+	DefaultThrottleMemoryRatio = 0.9
+	// DefaultThrottleCPUPercent triggers throttling once the process's CPU use
+	// reaches this percentage of its available capacity (GOMAXPROCS cores).
+	DefaultThrottleCPUPercent = 90
+)
+
 // MaxGIDIndex is a coarse sanity upper bound for gid_index. Real ibv GID
 // tables are small (rdma_rxe typically exposes a handful of entries; mlx5
 // rarely exceeds a few dozen), so a huge value can never be valid on any
@@ -104,6 +121,31 @@ type AgentConfig struct {
 	// the controller; useful when controller_addr is an IP literal that
 	// doesn't match the server certificate's subject.
 	TLSServerName string `mapstructure:"tls_server_name"`
+
+	// SelfProtectionEnabled turns on the resource watchdog (P2-G): a background
+	// goroutine that samples this process's CPU/memory every
+	// WatchdogIntervalSec and, on threshold breach, steps the probe-rate
+	// multiplier down (fail-slow) to shed load, restoring it on recovery. It
+	// defaults to false, so the agent's behavior is unchanged unless opted in.
+	SelfProtectionEnabled bool `mapstructure:"self_protection_enabled"`
+	// WatchdogIntervalSec is how often the watchdog samples resource usage.
+	WatchdogIntervalSec uint32 `mapstructure:"watchdog_interval_sec"`
+	// MaxMemoryMB sets a soft runtime memory limit via debug.SetMemoryLimit
+	// (GOMEMLIMIT equivalent) at startup; 0 disables it. It is also the
+	// reference budget for memory-based throttling (see ThrottleMemoryRatio):
+	// memory throttling is inactive when this is 0. Applied whenever > 0,
+	// independent of SelfProtectionEnabled, so it can be used as a plain
+	// runtime knob.
+	MaxMemoryMB int `mapstructure:"max_memory_mb"`
+	// MaxProcs caps runtime.GOMAXPROCS at startup; 0 leaves the Go default
+	// (all cores). Applied whenever > 0, independent of SelfProtectionEnabled.
+	MaxProcs int `mapstructure:"max_procs"`
+	// ThrottleMemoryRatio is the fraction of MaxMemoryMB at which memory-based
+	// throttling engages (e.g. 0.9 = 90%). Only meaningful when MaxMemoryMB > 0.
+	ThrottleMemoryRatio float64 `mapstructure:"throttle_memory_ratio"`
+	// ThrottleCPUPercent is the percentage of available CPU capacity (GOMAXPROCS
+	// cores) at which CPU-based throttling engages (e.g. 90 = 90%).
+	ThrottleCPUPercent float64 `mapstructure:"throttle_cpu_percent"`
 }
 
 // LoadAgentConfig loads agent configuration from a YAML file, environment
@@ -141,6 +183,12 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 	v.SetDefault("tls_key_file", "")
 	v.SetDefault("tls_ca_file", "")
 	v.SetDefault("tls_server_name", "")
+	v.SetDefault("self_protection_enabled", DefaultSelfProtectionEnabled)
+	v.SetDefault("watchdog_interval_sec", DefaultWatchdogIntervalSec)
+	v.SetDefault("max_memory_mb", 0)
+	v.SetDefault("max_procs", 0)
+	v.SetDefault("throttle_memory_ratio", DefaultThrottleMemoryRatio)
+	v.SetDefault("throttle_cpu_percent", DefaultThrottleCPUPercent)
 
 	// Enable environment variable override with RPINGMESH_ prefix.
 	// Underscores in env var names map to underscores in config keys.
@@ -218,6 +266,12 @@ func LoadAgentConfig(configPath string, flags *pflag.FlagSet) (*AgentConfig, err
 		TLSKeyFile:                 v.GetString("tls_key_file"),
 		TLSCAFile:                  v.GetString("tls_ca_file"),
 		TLSServerName:              v.GetString("tls_server_name"),
+		SelfProtectionEnabled:      v.GetBool("self_protection_enabled"),
+		WatchdogIntervalSec:        v.GetUint32("watchdog_interval_sec"),
+		MaxMemoryMB:                v.GetInt("max_memory_mb"),
+		MaxProcs:                   v.GetInt("max_procs"),
+		ThrottleMemoryRatio:        v.GetFloat64("throttle_memory_ratio"),
+		ThrottleCPUPercent:         v.GetFloat64("throttle_cpu_percent"),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -279,6 +333,37 @@ func (c *AgentConfig) Validate() error {
 		return fmt.Errorf("analysis_window_sec must be > 0 when analysis_report_enabled, got: %d", c.AnalysisWindowSec)
 	}
 
+	// Hard runtime limits are honored regardless of self-protection, so range
+	// checks always apply. Negative values are meaningless (the runtime APIs
+	// take non-negative sizes/counts), so reject them up front.
+	if c.MaxMemoryMB < 0 {
+		return fmt.Errorf("max_memory_mb must be >= 0, got: %d", c.MaxMemoryMB)
+	}
+	if c.MaxProcs < 0 {
+		return fmt.Errorf("max_procs must be >= 0, got: %d", c.MaxProcs)
+	}
+
+	// The throttle thresholds only drive behavior when self-protection is
+	// enabled; validate them only then so a disabled feature never blocks
+	// startup over a knob it does not use.
+	if c.SelfProtectionEnabled {
+		// The interval drives a time.Ticker, which panics on a non-positive
+		// period.
+		if c.WatchdogIntervalSec == 0 {
+			return fmt.Errorf("watchdog_interval_sec must be > 0 when self_protection_enabled, got: %d", c.WatchdogIntervalSec)
+		}
+		// The memory ratio is a fraction of the limit; a value outside (0, 1]
+		// would trigger either never or only after exceeding the limit.
+		if c.ThrottleMemoryRatio <= 0 || c.ThrottleMemoryRatio > 1 {
+			return fmt.Errorf("throttle_memory_ratio must be in (0, 1] when self_protection_enabled, got: %g", c.ThrottleMemoryRatio)
+		}
+		// CPU is measured as a percentage of GOMAXPROCS-core capacity, so the
+		// threshold lives in (0, 100].
+		if c.ThrottleCPUPercent <= 0 || c.ThrottleCPUPercent > 100 {
+			return fmt.Errorf("throttle_cpu_percent must be in (0, 100] when self_protection_enabled, got: %g", c.ThrottleCPUPercent)
+		}
+	}
+
 	// The agent is the gRPC client of the controller connection: fail fast
 	// if the certificate files required by tls_mode are missing, rather
 	// than at the first dial attempt.
@@ -336,4 +421,10 @@ func BindAgentFlags(flags *pflag.FlagSet) {
 	flags.String("tls-key-file", "", "Client private key file (required when tls-mode=mtls)")
 	flags.String("tls-ca-file", "", "CA file used to verify the controller's certificate (required when tls-mode is tls or mtls)")
 	flags.String("tls-server-name", "", "Server name for TLS SNI/verification (optional; defaults to the name derived from controller-addr)")
+	flags.Bool("self-protection-enabled", DefaultSelfProtectionEnabled, "Enable the resource watchdog that throttles probing (fail-slow) under local CPU/memory pressure")
+	flags.Uint32("watchdog-interval-sec", DefaultWatchdogIntervalSec, "How often the self-protection watchdog samples resource usage (seconds)")
+	flags.Int("max-memory-mb", 0, "Soft runtime memory limit in MiB (GOMEMLIMIT via debug.SetMemoryLimit; 0 = disabled). Also the reference budget for memory throttling")
+	flags.Int("max-procs", 0, "Cap runtime.GOMAXPROCS to this many cores (0 = Go default: all cores)")
+	flags.Float64("throttle-memory-ratio", DefaultThrottleMemoryRatio, "Fraction of max-memory-mb at which memory throttling engages (0-1; only when max-memory-mb > 0)")
+	flags.Float64("throttle-cpu-percent", DefaultThrottleCPUPercent, "Percentage of available CPU capacity (GOMAXPROCS cores) at which CPU throttling engages (0-100)")
 }

--- a/rebuild/internal/config/config_test.go
+++ b/rebuild/internal/config/config_test.go
@@ -322,6 +322,26 @@ func TestLoadAgentConfig_Defaults(t *testing.T) {
 	if cfg.TLSMode != TLSModeDisabled {
 		t.Errorf("TLSMode = %q, want %q (backward-compatible default)", cfg.TLSMode, TLSModeDisabled)
 	}
+	// Self-protection is opt-in: disabled by default, with sane threshold
+	// defaults so that merely enabling it needs no other settings.
+	if cfg.SelfProtectionEnabled != DefaultSelfProtectionEnabled {
+		t.Errorf("SelfProtectionEnabled = %v, want %v", cfg.SelfProtectionEnabled, DefaultSelfProtectionEnabled)
+	}
+	if cfg.WatchdogIntervalSec != DefaultWatchdogIntervalSec {
+		t.Errorf("WatchdogIntervalSec = %d, want %d", cfg.WatchdogIntervalSec, DefaultWatchdogIntervalSec)
+	}
+	if cfg.MaxMemoryMB != 0 {
+		t.Errorf("MaxMemoryMB = %d, want 0 (disabled)", cfg.MaxMemoryMB)
+	}
+	if cfg.MaxProcs != 0 {
+		t.Errorf("MaxProcs = %d, want 0 (Go default)", cfg.MaxProcs)
+	}
+	if cfg.ThrottleMemoryRatio != DefaultThrottleMemoryRatio {
+		t.Errorf("ThrottleMemoryRatio = %g, want %g", cfg.ThrottleMemoryRatio, DefaultThrottleMemoryRatio)
+	}
+	if cfg.ThrottleCPUPercent != DefaultThrottleCPUPercent {
+		t.Errorf("ThrottleCPUPercent = %g, want %g", cfg.ThrottleCPUPercent, float64(DefaultThrottleCPUPercent))
+	}
 }
 
 // TestEffectiveProbeRates verifies the per-pinglist-type rate resolution,
@@ -649,6 +669,85 @@ func TestAgentConfig_Validate(t *testing.T) {
 			cfg: AgentConfig{
 				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
 				TLSMode: TLSModeMTLS,
+			},
+			wantErr: true,
+		},
+		{
+			name: "self-protection enabled with valid thresholds",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: true, WatchdogIntervalSec: 5,
+				ThrottleMemoryRatio: 0.9, ThrottleCPUPercent: 90,
+			},
+			wantErr: false,
+		},
+		{
+			name: "self-protection enabled rejects zero watchdog interval",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: true, WatchdogIntervalSec: 0,
+				ThrottleMemoryRatio: 0.9, ThrottleCPUPercent: 90,
+			},
+			wantErr: true,
+		},
+		{
+			name: "self-protection enabled rejects memory ratio of zero",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: true, WatchdogIntervalSec: 5,
+				ThrottleMemoryRatio: 0, ThrottleCPUPercent: 90,
+			},
+			wantErr: true,
+		},
+		{
+			name: "self-protection enabled rejects memory ratio above one",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: true, WatchdogIntervalSec: 5,
+				ThrottleMemoryRatio: 1.5, ThrottleCPUPercent: 90,
+			},
+			wantErr: true,
+		},
+		{
+			name: "self-protection enabled rejects cpu percent of zero",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: true, WatchdogIntervalSec: 5,
+				ThrottleMemoryRatio: 0.9, ThrottleCPUPercent: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "self-protection enabled rejects cpu percent above 100",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: true, WatchdogIntervalSec: 5,
+				ThrottleMemoryRatio: 0.9, ThrottleCPUPercent: 101,
+			},
+			wantErr: true,
+		},
+		{
+			name: "self-protection disabled ignores throttle knobs",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				SelfProtectionEnabled: false, WatchdogIntervalSec: 0,
+				ThrottleMemoryRatio: 0, ThrottleCPUPercent: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative max_memory_mb rejected regardless of self-protection",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				MaxMemoryMB: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative max_procs rejected regardless of self-protection",
+			cfg: AgentConfig{
+				GIDIndex: 0, ProbeIntervalMS: 500, FlowLabelRotationPeriodSec: 3600,
+				MaxProcs: -1,
 			},
 			wantErr: true,
 		},

--- a/rebuild/internal/telemetry/otel_metrics.go
+++ b/rebuild/internal/telemetry/otel_metrics.go
@@ -122,6 +122,7 @@ type MetricsCollector struct {
 	probeFailed      metric.Int64Counter
 	probeTotal       metric.Int64Counter
 	eventRingDropped metric.Int64ObservableCounter
+	selfThrottle     metric.Float64ObservableGauge
 	logger           zerolog.Logger
 }
 
@@ -297,6 +298,21 @@ func registerInstruments(provider *sdkmetric.MeterProvider) (*MetricsCollector, 
 		return nil, err
 	}
 
+	// Registered without a callback here for the same reason as
+	// eventRingDropped: the value it reports (the current self-protection rate
+	// multiplier) is owned by the agent package's Watchdog, not telemetry.
+	// RegisterSelfThrottleCallback wires the reader in once the agent has
+	// created its watchdog. The gauge carries no attributes: it is a single
+	// process-wide value (1.0 = unthrottled, down to 0.1 = maximally throttled).
+	selfThrottle, err := meter.Float64ObservableGauge(
+		"rpingmesh.agent.self_throttle",
+		metric.WithDescription("Current self-protection probe-rate multiplier (1.0 = unthrottled, lower = throttled to protect local CPU/memory)"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetricsCollector{
 		meterProvider:    provider,
 		meter:            meter,
@@ -307,6 +323,7 @@ func registerInstruments(provider *sdkmetric.MeterProvider) (*MetricsCollector, 
 		probeFailed:      probeFailed,
 		probeTotal:       probeTotal,
 		eventRingDropped: eventRingDropped,
+		selfThrottle:     selfThrottle,
 		logger:           log.With().Str("component", "telemetry").Logger(),
 	}, nil
 }
@@ -398,6 +415,29 @@ func (mc *MetricsCollector) RegisterEventRingDropCallback(readers map[string]fun
 	)
 	if err != nil {
 		return fmt.Errorf("register event ring drop callback: %w", err)
+	}
+	return nil
+}
+
+// RegisterSelfThrottleCallback registers an OTel callback that reports the
+// agent's current self-protection rate multiplier on the
+// rpingmesh.agent.self_throttle gauge. read returns the live multiplier
+// (1.0 = unthrottled, down to 0.1 = maximally throttled) and must be cheap
+// (an atomic load, per Watchdog.CurrentMultiplier): it is invoked once per
+// collection cycle by the reader. Like RegisterEventRingDropCallback, the
+// value is owned by the agent package (the Watchdog), so telemetry takes a
+// plain closure rather than importing it. The gauge is intentionally
+// attribute-free to keep it a single, low-cardinality process-wide series.
+func (mc *MetricsCollector) RegisterSelfThrottleCallback(read func() float64) error {
+	_, err := mc.meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			o.ObserveFloat64(mc.selfThrottle, read())
+			return nil
+		},
+		mc.selfThrottle,
+	)
+	if err != nil {
+		return fmt.Errorf("register self throttle callback: %w", err)
 	}
 	return nil
 }

--- a/rebuild/internal/telemetry/otel_metrics_test.go
+++ b/rebuild/internal/telemetry/otel_metrics_test.go
@@ -316,6 +316,45 @@ func TestRegisterEventRingDropCallback(t *testing.T) {
 	}
 }
 
+// TestRegisterSelfThrottleCallback verifies that the self_throttle gauge reports
+// the current rate multiplier returned by the registered reader, as a single
+// attribute-free data point.
+func TestRegisterSelfThrottleCallback(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer provider.Shutdown(context.Background())
+
+	mc, err := NewMetricsCollectorWithProvider(provider)
+	if err != nil {
+		t.Fatalf("NewMetricsCollectorWithProvider: %v", err)
+	}
+
+	multiplier := 0.25
+	if err := mc.RegisterSelfThrottleCallback(func() float64 { return multiplier }); err != nil {
+		t.Fatalf("RegisterSelfThrottleCallback: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("ManualReader.Collect: %v", err)
+	}
+
+	m := findMetric(&rm, "rpingmesh.agent.self_throttle")
+	if m == nil {
+		t.Fatal("rpingmesh.agent.self_throttle metric not found")
+	}
+	gauge, ok := m.Data.(metricdata.Gauge[float64])
+	if !ok || len(gauge.DataPoints) != 1 {
+		t.Fatalf("rpingmesh.agent.self_throttle = %+v, want 1 gauge data point", m.Data)
+	}
+	if got := gauge.DataPoints[0].Value; got != multiplier {
+		t.Errorf("self_throttle = %g, want %g", got, multiplier)
+	}
+	if n := gauge.DataPoints[0].Attributes.Len(); n != 0 {
+		t.Errorf("self_throttle carries %d attributes, want 0 (low cardinality)", n)
+	}
+}
+
 // TestStartResultConsumer verifies that StartResultConsumer reads
 // ProbeResults from the channel, computes RTT via probe.CalculateRTT, and
 // records them, and that it exits cleanly when the channel is closed.


### PR DESCRIPTION
## Summary

Implements **P2-G: agent self-protection** — an opt-in resource watchdog that protects the agent's own host footprint by throttling its probe send rate (fail-slow) under local CPU/memory pressure. Disabled by default (`self_protection_enabled: false`), so existing deployments are unaffected.

## What it does

- **Watchdog** (`internal/agent/watchdog.go`): every `watchdog_interval_sec`, samples this process's memory (`runtime/metrics`, same accounting as `GOMEMLIMIT`) and CPU (`getrusage`). On threshold breach it steps a probe-rate multiplier **down the ladder `1.0 → 0.5 → 0.25 → 0.1`** (one step per interval), and steps it **back up** as usage recovers.
  - **Fail-slow, never fail-closed**: the floor is `0.1`, never `0` — probing slows but never stops, so self-protection never opens a monitoring blind spot.
  - **Hysteresis**: recovery requires usage to fall to 75% of the engage threshold; combined with the one-step-per-interval ramp, this prevents flapping.
  - Memory throttling is active only when `max_memory_mb > 0` (engages at `throttle_memory_ratio × max_memory_mb`); CPU throttling engages at `throttle_cpu_percent` of the process's `GOMAXPROCS`-core capacity.
- **Prober integration** (builds on PR #40's per-type limiters): new `Prober.SetRateMultiplier` scales *both* per-type aggregate rates on top of `pps × targets`, reusing the existing `targetsMu → rateMu` lock order. `UpdateTargets`/`SetPerTypeRateLimit` fold the stored multiplier in, so a pinglist change while throttled preserves the throttle. An exact `1.0` multiplier is bit-identical to the un-throttled rate — unthrottled behavior and the existing `prober_ratelimit_test.go` are unchanged.
- **Startup runtime caps**: `max_memory_mb` installs a soft `GOMEMLIMIT` (`debug.SetMemoryLimit`), `max_procs` caps `GOMAXPROCS`. Both apply whenever set, independent of the watchdog.
- **Telemetry**: live multiplier exported as the `rpingmesh.agent.self_throttle` OTLP gauge (attribute-free, low cardinality), via a callback mirroring `RegisterEventRingDropCallback`. Engage/release logged at `warn`.
- **Config**: `self_protection_enabled` (default `false`), `watchdog_interval_sec` (5), `max_memory_mb` (0), `max_procs` (0), `throttle_memory_ratio` (0.9), `throttle_cpu_percent` (90), with range validation gated on the enabled flag. README Configuration + Metrics + Limitations and `configs/agent.yaml` updated.

## Design notes

- **CPU via `getrusage`, not `runtime/metrics` `/cpu/classes`**: those CPU counters only advance during a GC cycle, so a low-allocation agent would report stale/zero CPU unless the watchdog forced a disruptive GC each tick. `x/sys/unix.Getrusage` returns real cumulative CPU time on every call and works on linux + darwin (the only build targets) — no new dependency.
- **Thresholds/ladder/hysteresis**: two thresholds (memory tied to `GOMEMLIMIT` budget; CPU relative to `GOMAXPROCS` so a `max_procs` cap is respected automatically); a 4-step multiplier ladder; a 25% recovery margin. `over = any resource over threshold`, `clear = all resources below the recovery threshold`; the deadband holds the level.

## Tests

Run under `-race` in the Linux e2e image (`Dockerfile.e2e`); config/telemetry also pass locally on macOS.

- Watchdog state machine with injected samples + clock: ladder walk, ramp-down to floor and gradual recovery, hysteresis deadband hold, exact thresholds, CPU-needs-prior-sample, `cpuUtilization` guards.
- Prober multiplier: scales both per-type limiters, survives `UpdateTargets`, unity/out-of-range clamp are no-ops, and a lock-order race test adding `SetRateMultiplier`.
- Config validation + defaults for the new keys; `self_throttle` gauge value/cardinality.
- `go build ./...`, `go vet ./...`, and `go test -race ./internal/agent/... ./internal/config/... ./internal/telemetry/...` all green in Linux.

## Out of scope (per design)

Real resource-spike e2e is a non-goal; error-rate/backpressure-driven throttling and adaptive control are noted as future work in Limitations.