### PR TITLE
feat(rebuild): add Grafana dashboards and observability stack

### DIFF
--- a/rebuild/.gitignore
+++ b/rebuild/.gitignore
@@ -8,3 +8,7 @@ zig/.zig-cache/
 
 # Packaged .deb/.rpm output (`make package`)
 dist/
+
+# Local observability stack env overrides (copy of .env.example; may pin
+# image tags per-machine, never commit local secrets)
+deploy/observability/.env

--- a/rebuild/Makefile
+++ b/rebuild/Makefile
@@ -6,7 +6,8 @@
         generate generate-proto clean test test-go test-zig test-all vet \
         test-e2e setup-colima test-e2e-controller clean-e2e-controller \
         check-nfpm package package-agent package-controller \
-        package-build-agent package-build-controller help
+        package-build-agent package-build-controller \
+        obs-up obs-down obs-seed obs-verify obs-logs help
 
 # Directories
 ZIG_DIR := zig
@@ -215,6 +216,26 @@ clean:
 	cd $(ZIG_DIR) && rm -rf zig-out .zig-cache
 	@echo "==> Clean complete"
 
+# Observability stack (Grafana dashboards demo; see docs/design/grafana-dashboards.md)
+OBS_DIR := deploy/observability
+OBS_COMPOSE := $(OBS_DIR)/docker-compose.observability.yml
+
+obs-up: ## Start the observability stack (VictoriaMetrics + otel-collector + Grafana)
+	cd $(OBS_DIR) && [ -f .env ] || cp .env.example .env
+	docker compose -f $(OBS_COMPOSE) --env-file $(OBS_DIR)/.env up -d
+
+obs-down: ## Stop the observability stack and remove volumes
+	docker compose -f $(OBS_COMPOSE) down -v
+
+obs-seed: ## Seed synthetic mesh metrics into VictoriaMetrics
+	VM_URL=http://localhost:8428 ./scripts/seed-demo-metrics.sh
+
+obs-logs: ## Tail observability stack logs
+	docker compose -f $(OBS_COMPOSE) logs -f
+
+obs-verify: ## Verify Grafana health, provisioning, and every panel query
+	./scripts/verify-observability.sh
+
 # Help
 help:
 	@echo "R-Pingmesh Rebuild Build System"
@@ -241,6 +262,11 @@ help:
 	@echo "  package-agent        Build .deb/.rpm packages for the agent only"
 	@echo "  package-controller   Build .deb/.rpm packages for the controller only"
 	@echo "  clean                Remove all build artifacts"
+	@echo "  obs-up               Start the observability stack (VictoriaMetrics + otel-collector + Grafana)"
+	@echo "  obs-down             Stop the observability stack and remove volumes"
+	@echo "  obs-seed             Seed synthetic mesh metrics into VictoriaMetrics"
+	@echo "  obs-verify           Verify Grafana health, provisioning, and every panel query"
+	@echo "  obs-logs             Tail observability stack logs"
 	@echo ""
 	@echo "Requirements:"
 	@echo "  Go 1.26+, Zig 0.15.2, protoc, libibverbs-dev, librdmacm-dev"

--- a/rebuild/Makefile
+++ b/rebuild/Makefile
@@ -221,7 +221,7 @@ OBS_DIR := deploy/observability
 OBS_COMPOSE := $(OBS_DIR)/docker-compose.observability.yml
 
 obs-up: ## Start the observability stack (VictoriaMetrics + otel-collector + Grafana)
-	cd $(OBS_DIR) && [ -f .env ] || cp .env.example .env
+	cd $(OBS_DIR) && { [ -f .env ] || cp .env.example .env; }
 	docker compose -f $(OBS_COMPOSE) --env-file $(OBS_DIR)/.env up -d
 
 obs-down: ## Stop the observability stack and remove volumes

--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -650,14 +650,37 @@ Histogram bucket boundaries (nanoseconds):
 
 This covers the 100 ns to 10 ms range typical of datacenter RDMA networks.
 
-### Grafana Setup
+### Observability & Dashboards
 
-1. Deploy an OpenTelemetry Collector with an OTLP gRPC receiver on port 4317.
-2. Configure a Prometheus remote-write exporter or use the Prometheus receiver
-   to scrape the collector.
-3. Point the agent's `otel_collector_addr` to the collector.
-4. In Grafana, create dashboards querying `rpingmesh_network_rtt_ns` histograms,
-   grouped by `source_tor` and `target_tor`.
+A ready-to-use pipeline and two provisioned Grafana dashboards live in this
+repo: OTLP metrics (above) flow through `otel-collector-contrib` into
+VictoriaMetrics and are visualized in Grafana with zero custom plugins. See
+`docs/design/grafana-dashboards.md` for the full design (metric-name
+contract, panel layout, drilldown mechanism).
+
+**Metric name contract:** the collector's `prometheusremotewrite` exporter
+must escape `.` to `_` but must **not** append extra `_total`/unit suffixes,
+since the OTel instrument names already carry them (`rpingmesh.probe_total` →
+`rpingmesh_probe_total`, not `rpingmesh_probe_total_total`). The pinned
+collector version (`otel-collector/config.yaml`) is set to
+`add_metric_suffixes: false` for this; newer collector releases expose the
+equivalent as `translation_strategy: UnderscoreEscapingWithoutSuffixes` —
+never set both. Verified end-to-end against a live OTLP push in
+`deploy/observability/README.md`.
+
+Quick start:
+
+```bash
+make obs-up        # start VictoriaMetrics + otel-collector + Grafana (localhost:3000, admin/admin)
+make obs-seed       # load synthetic demo data (no RDMA hardware required)
+open http://localhost:3000  # dashboards under the "R-Pingmesh" folder
+```
+
+`admin`/`admin` is the default Grafana credential for this local demo stack
+only — never use it in production. To point a real agent/analyzer at the
+stack, set `otel_collector_addr: localhost:4317`. See
+`deploy/observability/README.md` for details, and `make obs-down` to tear the
+stack down.
 
 ### Logging
 

--- a/rebuild/dashboards/mesh-overview.json
+++ b/rebuild/dashboards/mesh-overview.json
@@ -30,7 +30,7 @@
       "datasource": { "type": "prometheus", "uid": "victoriametrics" },
       "targets": [
         { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "100 * sum(rate(rpingmesh_probe_success_total[$__rate_interval])) / clamp_min(sum(rate(rpingmesh_probe_total[$__rate_interval])), 1)",
+          "expr": "100 * sum(rate(rpingmesh_probe_success_total[$__rate_interval])) / (sum(rate(rpingmesh_probe_total[$__rate_interval])) > 0)",
           "range": true } ],
       "fieldConfig": { "defaults": { "unit": "percent", "decimals": 3, "color": { "mode": "thresholds" },
         "thresholds": { "mode": "absolute", "steps": [
@@ -83,7 +83,7 @@
       "datasource": { "type": "prometheus", "uid": "victoriametrics" },
       "targets": [
         { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "100 * (1 - sum by (source_tor, target_tor) (rate(rpingmesh_probe_success_total[$__range])) / clamp_min(sum by (source_tor, target_tor) (rate(rpingmesh_probe_total[$__range])), 1))",
+          "expr": "100 * (1 - sum by (source_tor, target_tor) (rate(rpingmesh_probe_success_total[$__range])) / (sum by (source_tor, target_tor) (rate(rpingmesh_probe_total[$__range])) > 0))",
           "format": "table", "instant": true, "range": false } ],
       "transformations": [
         { "id": "groupingToMatrix",
@@ -106,7 +106,7 @@
       "datasource": { "type": "prometheus", "uid": "victoriametrics" },
       "targets": [
         { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "topk(20, 100 * (1 - sum by (source_tor, target_tor) (rate(rpingmesh_probe_success_total[$__range])) / clamp_min(sum by (source_tor, target_tor) (rate(rpingmesh_probe_total[$__range])), 1)))",
+          "expr": "topk(20, 100 * (1 - sum by (source_tor, target_tor) (rate(rpingmesh_probe_success_total[$__range])) / (sum by (source_tor, target_tor) (rate(rpingmesh_probe_total[$__range])) > 0)))",
           "format": "table", "instant": true, "range": false } ],
       "transformations": [
         { "id": "organize",

--- a/rebuild/dashboards/mesh-overview.json
+++ b/rebuild/dashboards/mesh-overview.json
@@ -1,0 +1,182 @@
+{
+  "uid": "rpingmesh-mesh-overview",
+  "title": "R-Pingmesh — Mesh Overview",
+  "tags": ["rpingmesh"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1, "type": "stat", "title": "Probe rate (fleet)",
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum(rate(rpingmesh_probe_total[$__rate_interval]))",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [ { "value": null, "color": "blue" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 2, "type": "stat", "title": "Success ratio (fleet)",
+      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "100 * sum(rate(rpingmesh_probe_success_total[$__rate_interval])) / clamp_min(sum(rate(rpingmesh_probe_total[$__rate_interval])), 1)",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 3, "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [
+          { "value": null, "color": "red" }, { "value": 99, "color": "yellow" }, { "value": 99.9, "color": "green" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 3, "type": "stat", "title": "SLA violations /s",
+      "gridPos": { "h": 4, "w": 5, "x": 10, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum(rate(rpingmesh_analyzer_sla_violations_total[$__rate_interval]))",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [
+          { "value": null, "color": "green" }, { "value": 0.001, "color": "yellow" }, { "value": 0.1, "color": "red" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4, "type": "stat", "title": "Worst self-throttle",
+      "gridPos": { "h": 4, "w": 5, "x": 15, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "min(rpingmesh_agent_self_throttle)", "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 2, "min": 0, "max": 1, "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [
+          { "value": null, "color": "red" }, { "value": 0.5, "color": "yellow" }, { "value": 1, "color": "green" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 5, "type": "stat", "title": "Event-ring drops /s",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum(rate(rpingmesh_event_ring_dropped_total[$__rate_interval]))", "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [ { "value": null, "color": "green" }, { "value": 0.001, "color": "red" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 6, "type": "table", "title": "ToR × ToR loss matrix (%)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "100 * (1 - sum by (source_tor, target_tor) (rate(rpingmesh_probe_success_total[$__range])) / clamp_min(sum by (source_tor, target_tor) (rate(rpingmesh_probe_total[$__range])), 1))",
+          "format": "table", "instant": true, "range": false } ],
+      "transformations": [
+        { "id": "groupingToMatrix",
+          "options": { "columnField": "target_tor", "rowField": "source_tor", "valueField": "Value", "emptyValue": "null" } } ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "decimals": 2,
+          "custom": { "align": "center", "cellOptions": { "type": "color-background", "mode": "basic" } },
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "value": null, "color": "green" }, { "value": 0.5, "color": "yellow" }, { "value": 2, "color": "red" } ] } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "source_tor\\target_tor" },
+            "properties": [ { "id": "custom.cellOptions", "value": { "type": "auto" } } ] } ] },
+      "options": { "showHeader": true }
+    },
+    {
+      "id": 7, "type": "table", "title": "Worst ToR pairs (by loss %)",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "topk(20, 100 * (1 - sum by (source_tor, target_tor) (rate(rpingmesh_probe_success_total[$__range])) / clamp_min(sum by (source_tor, target_tor) (rate(rpingmesh_probe_total[$__range])), 1)))",
+          "format": "table", "instant": true, "range": false } ],
+      "transformations": [
+        { "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "job": true },
+            "renameByName": { "Value": "Loss %" },
+            "indexByName": { "source_tor": 0, "target_tor": 1, "Loss %": 2 } } } ],
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            { "title": "Drill down to ToR pair",
+              "url": "/d/rpingmesh-tor-pair/r-pingmesh-tor-pair-drilldown?var-source_tor=${__data.fields.source_tor}&var-target_tor=${__data.fields.target_tor}&${__url_time_range}",
+              "targetBlank": false } ] },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Loss %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
+              { "id": "color", "value": { "mode": "thresholds" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [
+                { "value": null, "color": "green" }, { "value": 0.5, "color": "yellow" }, { "value": 2, "color": "red" } ] } } ] } ] },
+      "options": { "showHeader": true, "sortBy": [ { "displayName": "Loss %", "desc": true } ] }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "Probe failures by reason",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum by (reason) (rate(rpingmesh_probe_failed_total[$__rate_interval]))",
+          "legendFormat": "{{reason}}", "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps",
+        "custom": { "drawStyle": "line", "fillOpacity": 15, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "SLA violations by kind",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum by (kind) (rate(rpingmesh_analyzer_sla_violations_total[$__rate_interval]))",
+          "legendFormat": "{{kind}}", "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps",
+        "custom": { "drawStyle": "line", "fillOpacity": 15 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 10, "type": "table", "title": "SLA violations by pair (window)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum by (source_tor, target_tor, kind) (increase(rpingmesh_analyzer_sla_violations_total[$__range]))",
+          "format": "table", "instant": true, "range": false } ],
+      "transformations": [
+        { "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "job": true },
+            "renameByName": { "Value": "Violations" },
+            "indexByName": { "source_tor": 0, "target_tor": 1, "kind": 2, "Violations": 3 } } } ],
+      "fieldConfig": {
+        "defaults": { "decimals": 0,
+          "links": [
+            { "title": "Drill down to ToR pair",
+              "url": "/d/rpingmesh-tor-pair/r-pingmesh-tor-pair-drilldown?var-source_tor=${__data.fields.source_tor}&var-target_tor=${__data.fields.target_tor}&${__url_time_range}",
+              "targetBlank": false } ] },
+        "overrides": [] },
+      "options": { "showHeader": true, "sortBy": [ { "displayName": "Violations", "desc": true } ] }
+    }
+  ]
+}

--- a/rebuild/dashboards/tor-pair-drilldown.json
+++ b/rebuild/dashboards/tor-pair-drilldown.json
@@ -36,7 +36,7 @@
       "datasource": { "type": "prometheus", "uid": "victoriametrics" },
       "targets": [
         { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "100 * sum(rate(rpingmesh_probe_success_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])) / clamp_min(sum(rate(rpingmesh_probe_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])), 1)",
+          "expr": "100 * sum(rate(rpingmesh_probe_success_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])) / (sum(rate(rpingmesh_probe_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])) > 0)",
           "range": true } ],
       "fieldConfig": { "defaults": { "unit": "percent", "decimals": 3, "color": { "mode": "thresholds" },
         "thresholds": { "mode": "absolute", "steps": [

--- a/rebuild/dashboards/tor-pair-drilldown.json
+++ b/rebuild/dashboards/tor-pair-drilldown.json
@@ -1,0 +1,172 @@
+{
+  "uid": "rpingmesh-tor-pair",
+  "title": "R-Pingmesh — ToR Pair Drilldown",
+  "tags": ["rpingmesh"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "source_tor", "type": "query", "label": "Source ToR",
+        "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+        "definition": "label_values(rpingmesh_probe_total, source_tor)",
+        "query": { "qryType": 1, "query": "label_values(rpingmesh_probe_total, source_tor)", "refId": "source_tor" },
+        "refresh": 2, "sort": 1, "includeAll": false, "multi": false,
+        "current": {}
+      },
+      {
+        "name": "target_tor", "type": "query", "label": "Target ToR",
+        "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+        "definition": "label_values(rpingmesh_probe_total{source_tor=\"$source_tor\"}, target_tor)",
+        "query": { "qryType": 1, "query": "label_values(rpingmesh_probe_total{source_tor=\"$source_tor\"}, target_tor)", "refId": "target_tor" },
+        "refresh": 2, "sort": 1, "includeAll": false, "multi": false,
+        "current": {}
+      }
+    ]
+  },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1, "type": "stat", "title": "Success ratio (pair)",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "100 * sum(rate(rpingmesh_probe_success_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])) / clamp_min(sum(rate(rpingmesh_probe_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])), 1)",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 3, "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [
+          { "value": null, "color": "red" }, { "value": 99, "color": "yellow" }, { "value": 99.9, "color": "green" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 2, "type": "stat", "title": "Probe rate (pair)",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum(rate(rpingmesh_probe_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval]))",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [ { "value": null, "color": "blue" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 3, "type": "stat", "title": "Network RTT p50 (approx)",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(rpingmesh_network_rtt_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "ns", "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [
+          { "value": null, "color": "green" }, { "value": 1000000, "color": "yellow" }, { "value": 5000000, "color": "red" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4, "type": "stat", "title": "Network RTT p99 (approx)",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rpingmesh_network_rtt_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "ns", "color": { "mode": "thresholds" },
+        "thresholds": { "mode": "absolute", "steps": [
+          { "value": null, "color": "green" }, { "value": 1000000, "color": "yellow" }, { "value": 5000000, "color": "red" } ] } },
+        "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 10, "type": "heatmap", "title": "Network RTT distribution",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum by (le) (rate(rpingmesh_network_rtt_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval]))",
+          "format": "heatmap", "legendFormat": "{{le}}", "range": true } ],
+      "options": {
+        "calculate": false,
+        "color": { "mode": "scheme", "scheme": "Spectral", "steps": 64 },
+        "yAxis": { "unit": "ns", "axisPlacement": "left" },
+        "cellGap": 1,
+        "tooltip": { "show": true, "yHistogram": true },
+        "legend": { "show": true }
+      },
+      "fieldConfig": { "defaults": { "custom": { "scaleDistribution": { "type": "log", "log": 2 } } }, "overrides": [] }
+    },
+    {
+      "id": 11, "type": "timeseries", "title": "Network RTT quantiles (approx, bucket-limited)",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(rpingmesh_network_rtt_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "p50", "range": true },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(rpingmesh_network_rtt_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "p90", "range": true },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rpingmesh_network_rtt_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "p99", "range": true }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ns",
+        "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 12, "type": "timeseries", "title": "Probe failures by reason (pair)",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum by (reason) (rate(rpingmesh_probe_failed_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}", "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps",
+        "custom": { "drawStyle": "line", "fillOpacity": 15, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "Prober / responder delay percentiles",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(rpingmesh_prober_delay_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "prober p50", "range": true },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rpingmesh_prober_delay_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "prober p99", "range": true },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(rpingmesh_responder_delay_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "responder p50", "range": true },
+        { "refId": "D", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rpingmesh_responder_delay_ns_bucket{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval])))",
+          "legendFormat": "responder p99", "range": true }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ns",
+        "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 14, "type": "timeseries", "title": "SLA violations (pair)",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum by (kind) (rate(rpingmesh_analyzer_sla_violations_total{source_tor=\"$source_tor\",target_tor=\"$target_tor\"}[$__rate_interval]))",
+          "legendFormat": "{{kind}}", "range": true } ],
+      "fieldConfig": { "defaults": { "unit": "cps",
+        "custom": { "drawStyle": "line", "fillOpacity": 15 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    }
+  ]
+}

--- a/rebuild/deploy/observability/.env.example
+++ b/rebuild/deploy/observability/.env.example
@@ -1,0 +1,6 @@
+# Pin to a current stable tag before committing. Values below are examples.
+GRAFANA_IMAGE=grafana/grafana:11.6.0
+VM_IMAGE=victoriametrics/victoria-metrics:v1.103.0
+OTELCOL_IMAGE=otel/opentelemetry-collector-contrib:0.117.0
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=admin

--- a/rebuild/deploy/observability/README.md
+++ b/rebuild/deploy/observability/README.md
@@ -1,0 +1,59 @@
+# R-Pingmesh Observability Stack
+
+A self-contained `docker compose` stack for developing and demoing the
+Grafana dashboards in `rebuild/dashboards/` without any RDMA hardware. See
+`rebuild/docs/design/grafana-dashboards.md` for the design rationale.
+
+## Components
+
+- **VictoriaMetrics** (`victoriametrics/victoria-metrics`) — Prometheus
+  remote-write receiver and query backend.
+- **otel-collector-contrib** — receives OTLP/gRPC metrics from the agent /
+  analyzer and forwards them to VictoriaMetrics via `prometheusremotewrite`.
+- **Grafana** — provisioned with the VictoriaMetrics datasource and the two
+  `rebuild/dashboards/*.json` dashboards (zero custom plugins).
+
+## Metric name contract
+
+The `prometheusremotewrite` exporter is pinned to `add_metric_suffixes: false`
+(`otel-collector/config.yaml`). This escapes `.` to `_` in OTLP metric names
+but does **not** append `_total`/unit suffixes — the OTel instruments already
+carry them (e.g. `rpingmesh.probe_total`, `rpingmesh.network_rtt_ns`). Using
+the exporter's default settings instead would double up suffixes (e.g.
+`rpingmesh_probe_total_total`) and silently break every dashboard panel.
+
+Newer collector builds expose the same behavior as
+`translation_strategy: UnderscoreEscapingWithoutSuffixes` instead of
+`add_metric_suffixes` — the pinned version here
+(`otel/opentelemetry-collector-contrib:0.117.0`) predates that option (its
+`prometheusremotewriteexporter` config schema only has `add_metric_suffixes`;
+confirmed against the exporter's `config.go` for that release). If you
+upgrade the pinned image, prefer `translation_strategy` and never set both
+on the same exporter.
+
+This was verified end-to-end, not just via the seed script's direct
+`/api/v1/import/prometheus` bypass: a real OTLP/HTTP push of
+`rpingmesh.probe_total` through this collector produced exactly
+`rpingmesh_probe_total` in VictoriaMetrics (not `rpingmesh_probe_total_total`),
+with `job` correctly derived from the `service.name` resource attribute.
+
+## Quick start
+
+```bash
+cd rebuild
+make obs-up        # start VictoriaMetrics + otel-collector + Grafana (localhost:3000, admin/admin)
+make obs-seed       # load ~30 min of synthetic 6-ToR mesh demo data
+open http://localhost:3000  # dashboards live under the "R-Pingmesh" folder
+make obs-verify     # (optional) assert health, provisioning, and panel queries
+make obs-down       # stop the stack and remove volumes
+```
+
+`admin`/`admin` is the default Grafana credential for this local demo stack
+only — **never use it in production**. Pin the image tags in
+`.env` (copy from `.env.example`) before relying on this stack long-term.
+
+## Connecting real telemetry
+
+To point a real agent/analyzer at this stack instead of the seed script, set
+`otel_collector_addr: localhost:4317` in `configs/agent.yaml` (or the
+equivalent analyzer config) so OTLP/gRPC metrics land on this collector.

--- a/rebuild/deploy/observability/README.md
+++ b/rebuild/deploy/observability/README.md
@@ -51,6 +51,12 @@ make obs-down       # stop the stack and remove volumes
 `admin`/`admin` is the default Grafana credential for this local demo stack
 only — **never use it in production**. Pin the image tags in
 `.env` (copy from `.env.example`) before relying on this stack long-term.
+If you change `GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD` in
+`.env`, `make obs-verify` picks up the same values automatically —
+`scripts/verify-observability.sh` reads `deploy/observability/.env` itself
+(resolved from the script's own location, not the caller's cwd), falling
+back to `admin`/`admin` if the file or the variables are absent. Env vars
+already exported when you invoke the script take priority over `.env`.
 
 ## Connecting real telemetry
 

--- a/rebuild/deploy/observability/README.md
+++ b/rebuild/deploy/observability/README.md
@@ -37,6 +37,13 @@ This was verified end-to-end, not just via the seed script's direct
 `rpingmesh_probe_total` in VictoriaMetrics (not `rpingmesh_probe_total_total`),
 with `job` correctly derived from the `service.name` resource attribute.
 
+`instance` is likewise derived from the OTel resource's `service.instance.id`
+(`internal/telemetry/otel_metrics.go`'s `buildResource()` sets it to
+`os.Hostname()`), so multiple agent processes covering the same ToR pair get
+distinct series instead of colliding onto one and corrupting `rate()`. See
+"Identity contract" in `rebuild/docs/design/grafana-dashboards.md` for the
+full rationale and verification.
+
 ## Quick start
 
 ```bash

--- a/rebuild/deploy/observability/docker-compose.observability.yml
+++ b/rebuild/deploy/observability/docker-compose.observability.yml
@@ -1,0 +1,54 @@
+name: rpingmesh-observability
+
+services:
+  victoriametrics:
+    image: ${VM_IMAGE:-victoriametrics/victoria-metrics:v1.103.0}
+    command:
+      - "-storageDataPath=/vmdata"
+      - "-retentionPeriod=7d"
+      - "-httpListenAddr=:8428"
+    ports:
+      - "8428:8428"
+    volumes:
+      - vmdata:/vmdata
+    healthcheck:
+      # NOTE: 127.0.0.1, not localhost -- inside this image wget resolves
+      # "localhost" to ::1 first and VictoriaMetrics only binds 0.0.0.0
+      # (IPv4), so "localhost" makes the healthcheck fail even though the
+      # server is up (deviation found during verification; see PR notes).
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8428/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  otel-collector:
+    image: ${OTELCOL_IMAGE:-otel/opentelemetry-collector-contrib:0.117.0}
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otel-collector/config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"   # OTLP gRPC (agent/analyzer -> collector)
+      - "4318:4318"   # OTLP HTTP (optional)
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+
+  grafana:
+    image: ${GRAFANA_IMAGE:-grafana/grafana:11.6.0}
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      - GF_USERS_DEFAULT_THEME=light
+      # zero-plugin design: install nothing
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../../dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+
+volumes:
+  vmdata: {}

--- a/rebuild/deploy/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/rebuild/deploy/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: rpingmesh
+    orgId: 1
+    folder: R-Pingmesh
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/rebuild/deploy/observability/grafana/provisioning/datasources/datasource.yml
+++ b/rebuild/deploy/observability/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+  - name: VictoriaMetrics
+    uid: victoriametrics
+    type: prometheus
+    access: proxy
+    url: http://victoriametrics:8428
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: "10s"     # matches the agent periodic reader flush interval
+    editable: false

--- a/rebuild/deploy/observability/otel-collector/config.yaml
+++ b/rebuild/deploy/observability/otel-collector/config.yaml
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  prometheusremotewrite:
+    endpoint: http://victoriametrics:8428/api/v1/write
+    tls:
+      insecure: true
+    # CRITICAL: keep metric names identical to the OTLP names (dots -> underscores
+    # only). The instruments already carry _total / _ns, so DO NOT append suffixes.
+    # The pinned collector (0.117.0) predates the `translation_strategy` option
+    # (verified against exporter/prometheusremotewriteexporter/config.go at that
+    # tag: only `add_metric_suffixes` exists), so use the documented fallback.
+    # If/when upgrading to a collector version that supports translation_strategy,
+    # prefer `translation_strategy: UnderscoreEscapingWithoutSuffixes` instead of
+    # this flag -- never set both.
+    add_metric_suffixes: false
+    resource_to_telemetry_conversion:
+      enabled: false
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite]

--- a/rebuild/docs/design/grafana-dashboards.md
+++ b/rebuild/docs/design/grafana-dashboards.md
@@ -103,6 +103,32 @@ same fixed names:
 they are unaffected by the strategy choice. The seed script emits these exact
 names, closing the loop: exporter, dashboards, and seed all agree.
 
+**Identity contract: `job` and `instance`.** The name contract above is
+necessary but not sufficient: a metric name plus its `source_tor`/`target_tor`
+attributes does not uniquely identify a *series* across a real deployment with
+more than one agent process. `prometheusremotewrite` derives the Prometheus
+`job` label from the OTel resource's `service.name` and the `instance` label
+from `service.instance.id`. `internal/telemetry/otel_metrics.go`'s
+`buildResource()` sets `service.name` (`rpingmesh-agent` /
+`rpingmesh-analyzer`, per `WithServiceName`) and `service.instance.id`
+(`os.Hostname()`, falling back to a random UUID only if that fails). Without
+`service.instance.id`, every agent process reporting the same metric name and
+ToR-pair attributes — the attribute-free `rpingmesh.agent.self_throttle` and
+`rpingmesh.event_ring_dropped_total{ring=...}` are the sharpest examples, but
+the same collision hits `rpingmesh.probe_total{source_tor,target_tor}` for any
+two agents covering the same ToR pair — collapses onto one Prometheus series.
+Interleaved writers on one series corrupt `rate()`/`increase()` (spurious
+resets and double-counting look identical to real signal). Every dashboard
+panel aggregates with `sum by (...)`/`min(...)`/`topk(...)` clauses that never
+include `instance`, so per-agent series are recombined into the correct
+fleet/pair total once each agent's counter is well-formed on its own — the
+fix is entirely in what identifies a series, not in how the dashboards query
+it. Verified end-to-end (not just unit-tested): a real OTLP push through the
+actual Go SDK landed with `instance` equal to the pushing host's real
+hostname, and two OTLP pushes for the same metric/ToR-pair with distinct
+`service.instance.id` values produced two separate, non-colliding series that
+`sum by (source_tor, target_tor)` still correctly combined into one total.
+
 ## Decision 2: two dashboards, native panels only
 
 Two dashboards, matching the two operator questions:

--- a/rebuild/docs/design/grafana-dashboards.md
+++ b/rebuild/docs/design/grafana-dashboards.md
@@ -117,6 +117,14 @@ point:
   matrix* transformation (`rowField=source_tor`, `columnField=target_tor`,
   `valueField=Value`) and colored by threshold via a color-background cell type.
   This is the paper's "at a glance, where is the fabric broken" view.
+  All success-ratio/loss% queries divide by `(sum(rate(rpingmesh_probe_total[...])) > 0)`
+  rather than `clamp_min(..., 1)`: `rate()` is in probes/sec, so a ToR pair
+  probed at less than 1/s (a low `inter_tor_probe_rate_per_second`, or a
+  self-throttled agent) would clamp to a denominator of 1 and read as a huge,
+  fabricated loss% even at 100% success. Filtering out zero/negative
+  denominators instead drops those pairs from the result (a "no data" matrix
+  cell), which is correct — there is no loss ratio to report when there were
+  no probes.
 - A **companion "Worst ToR pairs" table** (`topk` by loss%) carrying the
   drilldown data link. See Decision 3 for why the clickable path lives here and
   not on the matrix cells.

--- a/rebuild/docs/design/grafana-dashboards.md
+++ b/rebuild/docs/design/grafana-dashboards.md
@@ -1,0 +1,254 @@
+# Grafana Dashboards for R-Pingmesh Telemetry
+
+Status: Design + implementation spec (P4-observability). This document specifies
+the operator-facing Grafana dashboards for the rebuild, the metric-name contract
+between the OpenTelemetry pipeline and the dashboard JSON, and a self-contained
+docker-compose observability stack used to validate and demo them. The
+accompanying implementation lands `rebuild/dashboards/*.json`,
+`rebuild/deploy/observability/`, and `rebuild/scripts/seed-demo-metrics.sh`.
+
+## Goals
+
+- **Give operators a mesh-to-pair drilldown.** The first screen answers "is the
+  fabric healthy, and if not, which ToR pairs are degraded?" A second screen
+  answers "for this specific ToR pair, what does the latency distribution and the
+  failure breakdown look like?" The transition between the two is a single click.
+- **Zero custom plugins.** Everything renders on Grafana's built-in panels
+  (Table with the *Grouping to matrix* transformation, Heatmap, Time series,
+  Stat). No panel-plugin build step, no plugin allow-listing in provisioning.
+- **Dashboards as committed code.** The dashboard JSON lives in the repo and is
+  provisioned into Grafana from disk, so the dashboards are reviewable, diffable,
+  and reproducible without a Grafana instance in the loop.
+- **A one-command demo.** `docker compose up` on the observability stack plus a
+  seed script produces a populated set of dashboards with no RDMA hardware, so
+  the visualization can be developed and reviewed independently of the agent.
+
+## Non-Goals
+
+- No alerting rules in the first round (the metric contract is designed to make
+  them trivial to add later; see Future work).
+- No Phase-2 localization / path-tracing views — those depend on data the
+  analyzer does not yet emit (`analyzer-phase2-localization.md`).
+- No dashboard-generation toolchain (Grafonnet / Foundation SDK). Committed JSON
+  is the source of truth; codegen is called out only as future work.
+
+## Context: the metric inventory (verified against code)
+
+Two meters produce all telemetry, both exported over OTLP/gRPC via a periodic
+reader flushing every **10 s** (`internal/telemetry/otel_metrics.go`,
+`periodicReaderInterval`). The SDK uses the default **cumulative** temporality,
+which is exactly what a Prometheus-style backend expects.
+
+| Instrument (OTLP name) | Type | Labels | Meaning |
+|---|---|---|---|
+| `rpingmesh.network_rtt_ns` | Int64 Histogram | `source_tor`, `target_tor` | Network RTT `(T5-T2)-(T4-T3)` |
+| `rpingmesh.prober_delay_ns` | Int64 Histogram | `source_tor`, `target_tor` | Prober-side delay `(T6-T1)-(T5-T2)` |
+| `rpingmesh.responder_delay_ns` | Int64 Histogram | `source_tor`, `target_tor` | Responder-side delay `T4-T3` |
+| `rpingmesh.probe_total` | Counter | `source_tor`, `target_tor` | Probes attempted |
+| `rpingmesh.probe_success_total` | Counter | `source_tor`, `target_tor` | Probes with a valid RTT |
+| `rpingmesh.probe_failed_total` | Counter | `source_tor`, `target_tor`, `reason` | Failures; `reason` ∈ {timeout, send_error, invalid_rtt, unknown} |
+| `rpingmesh.agent.self_throttle` | Float64 ObservableGauge | (none) | Self-protection rate multiplier, 1.0 = unthrottled, floor 0.1 |
+| `rpingmesh.event_ring_dropped_total` | ObservableCounter | `ring` ∈ {prober, responder} | Completion events dropped on a full ring |
+| `rpingmesh.analyzer.path_summaries_total` | Counter | (none) | Per-path window summaries ingested |
+| `rpingmesh.analyzer.sla_violations_total` | Counter | `source_tor`, `target_tor`, `kind` ∈ {loss, rtt} | SLA violations detected |
+
+All three histograms share the same 11 explicit bucket boundaries in
+nanoseconds: `100, 500, 1 000, 5 000, 10 000, 50 000, 100 000, 500 000,
+1 000 000, 5 000 000, 10 000 000` (plus the implicit `+Inf`). Cardinality is
+deliberately ToR-level only — GID detail is confined to debug logs.
+
+Resource attribution: the agent meter is created on a provider with
+`service.name = rpingmesh-agent`; the analyzer's with `rpingmesh-analyzer`.
+After the OTLP → Prometheus conversion these become the `job` label on every
+series (via the exporter's resource-to-`job` mapping), so agent and analyzer
+series are distinguishable even where their metric names do not overlap.
+
+## Decision 1: the OTLP → Prometheus name contract
+
+This is the single most failure-prone part of the design, because the dashboard
+JSON hard-codes metric names and those names are produced by the collector, not
+by the Go code. The names must be pinned deterministically.
+
+**Pipeline:** agent/analyzer → OTLP/gRPC → `otel-collector-contrib` →
+`prometheusremotewrite` exporter → VictoriaMetrics `/api/v1/write`.
+
+**The trap:** the OTLP metric names were authored to *already* carry Prometheus
+conventions — counters end in `_total`, histograms end in `_ns` (their unit).
+The prometheusremotewrite exporter, by default
+(`translation_strategy: UnderscoreEscapingWithSuffixes`), *appends* type and unit
+suffixes on top of the name. With the default strategy a counter named
+`rpingmesh.probe_total` can become `rpingmesh_probe_total_total`, and a histogram
+with unit `ns` risks an added unit suffix. That would silently break every panel.
+
+**Decision:** set `translation_strategy: UnderscoreEscapingWithoutSuffixes` on the
+exporter. This escapes `.` → `_` for Prometheus compatibility but appends **no**
+type or unit suffix, so the Prometheus name is exactly the OTLP name with dots
+replaced. The dashboard JSON and the exporter config are thereby locked to the
+same fixed names:
+
+| OTLP name | Prometheus series |
+|---|---|
+| `rpingmesh.network_rtt_ns` | `rpingmesh_network_rtt_ns_bucket` / `_sum` / `_count` (label `le` on `_bucket`) |
+| `rpingmesh.prober_delay_ns` | `rpingmesh_prober_delay_ns_{bucket,sum,count}` |
+| `rpingmesh.responder_delay_ns` | `rpingmesh_responder_delay_ns_{bucket,sum,count}` |
+| `rpingmesh.probe_total` | `rpingmesh_probe_total` |
+| `rpingmesh.probe_success_total` | `rpingmesh_probe_success_total` |
+| `rpingmesh.probe_failed_total` | `rpingmesh_probe_failed_total` |
+| `rpingmesh.agent.self_throttle` | `rpingmesh_agent_self_throttle` |
+| `rpingmesh.event_ring_dropped_total` | `rpingmesh_event_ring_dropped_total` |
+| `rpingmesh.analyzer.path_summaries_total` | `rpingmesh_analyzer_path_summaries_total` |
+| `rpingmesh.analyzer.sla_violations_total` | `rpingmesh_analyzer_sla_violations_total` |
+
+`_bucket`/`_sum`/`_count` are structural histogram series, not name suffixes, so
+they are unaffected by the strategy choice. The seed script emits these exact
+names, closing the loop: exporter, dashboards, and seed all agree.
+
+## Decision 2: two dashboards, native panels only
+
+Two dashboards, matching the two operator questions:
+
+**"Mesh Overview"** (`uid: rpingmesh-mesh-overview`) — the fleet-wide entry
+point:
+- A **fleet-health stat row**: total probe rate, fleet success ratio, SLA-
+  violation rate, worst agent self-throttle (`min(...self_throttle)`), and event-
+  ring drop rate. These are the five numbers that say "call someone" vs "sleep".
+- A **ToR × ToR loss matrix** — a Table panel whose instant, table-format query
+  yields `(source_tor, target_tor, loss%)` rows, reshaped by the *Grouping to
+  matrix* transformation (`rowField=source_tor`, `columnField=target_tor`,
+  `valueField=Value`) and colored by threshold via a color-background cell type.
+  This is the paper's "at a glance, where is the fabric broken" view.
+- A **companion "Worst ToR pairs" table** (`topk` by loss%) carrying the
+  drilldown data link. See Decision 3 for why the clickable path lives here and
+  not on the matrix cells.
+- **Failure and SLA time series**: failure rate by `reason`, SLA-violation rate
+  by `kind`, and an instant SLA-by-pair table (also clickable).
+
+**"ToR Pair Drilldown"** (`uid: rpingmesh-tor-pair`) — everything about one pair,
+selected by `source_tor` / `target_tor` template variables
+(`label_values(rpingmesh_probe_total, source_tor)` and the target chained on the
+selected source):
+- Pair stat row (success ratio, probe rate, current p50/p99 network RTT).
+- **Network-RTT heatmap** from `rpingmesh_network_rtt_ns_bucket` (`le` buckets,
+  `ns` y-unit) — the latency-distribution-over-time picture.
+- p50/p90/p99 network-RTT time series via `histogram_quantile`.
+- Failure rate by `reason` for the pair.
+- Prober-delay and responder-delay percentiles (isolates "is it the network or
+  an endpoint stalling?").
+
+Rationale for **two** dashboards rather than one big board or many small ones:
+the mesh view is intentionally dense and fleet-scoped (no per-pair template
+variables), so it stays useful as a wall dashboard; the pair view is
+variable-scoped and only meaningful once a pair is chosen. Splitting keeps each
+board's queries cheap and its purpose single. A third Phase-2 localization board
+is deferred (Future work).
+
+## Decision 3: the drilldown mechanism (data links)
+
+Drilldown is a Grafana **data link** from Overview → Pair Drilldown, passing
+`var-source_tor` and `var-target_tor` on the URL and preserving the time range.
+
+A subtlety worth recording: a matrix built with *Grouping to matrix* has
+**dynamic column names** (each column header is a `target_tor` value) and its
+first field is named `rowField\columnField`. Configuring a robust per-cell data
+link that carries *both* coordinates is fragile because the URL template must
+reference that backslash-named row-header field. Therefore the **guaranteed**
+click path is the companion "Worst ToR pairs" table, whose rows have clean,
+stably named `source_tor` and `target_tor` fields, making the link template
+trivial and stable:
+
+```
+/d/rpingmesh-tor-pair/r-pingmesh-tor-pair-drilldown?var-source_tor=${__data.fields.source_tor}&var-target_tor=${__data.fields.target_tor}&${__url_time_range}
+```
+
+The matrix stays a color-only overview; the operator reads the hot cell, then
+clicks the same pair in the adjacent table. Best-effort matrix-cell links are
+described in the implementation spec but are not the contract.
+
+## Alternatives considered
+
+- **Native Table + Grouping to matrix vs ESnet Matrix panel vs a custom plugin.**
+  Chosen: native. A ToR × ToR loss grid is exactly what *Grouping to matrix*
+  plus color-background cells produces, with zero plugin dependency and full
+  provisioning portability. The ESnet Matrix panel gives nicer cell interaction
+  and a purpose-built look, but adds a plugin install to every Grafana and a
+  version-compatibility surface; it is documented as an optional enhancement, not
+  provisioned. A custom panel plugin was rejected outright — it is a build,
+  release, and maintenance burden wildly out of proportion to a colored grid.
+- **Committed JSON vs Grafonnet / Foundation SDK.** Chosen: committed JSON,
+  because it needs no toolchain to review or provision and round-trips cleanly
+  with Grafana's UI export. The cost is that hand-written JSON must be kept
+  equivalent to what the UI would emit; the mitigation is to build/verify panels
+  in the UI and export. Codegen is deferred until the dashboard count or
+  duplication justifies it.
+- **Prometheus-typed datasource pointing at VictoriaMetrics vs the VictoriaMetrics
+  datasource plugin.** Chosen: Prometheus type (zero-plugin). VictoriaMetrics is
+  Prometheus-API-compatible for querying, `label_values`, and instant/range
+  queries — everything these dashboards use. The VM plugin adds MetricsQL niceties
+  we do not need and another plugin to provision.
+- **Collector via prometheusremotewrite vs VictoriaMetrics native OTLP ingest.**
+  Chosen: the collector. VM can ingest OTLP directly at
+  `/opentelemetry/v1/metrics`, but then metric naming is governed by VM flags
+  (`-opentelemetry.usePrometheusNaming` and friends) whose default would *not*
+  reproduce the already-Prometheus-styled names and would re-introduce the
+  double-suffix risk. Routing through the collector keeps naming control in one
+  explicit, reviewable place (`translation_strategy`) and matches the intended
+  otel-collector-contrib stack. Direct OTLP ingest is a valid future
+  simplification once naming is validated.
+- **`histogram_quantile` over 11 explicit buckets vs analyzer-side percentiles.**
+  The 11 boundaries mean percentile *resolution equals the bucket edges*: a p99
+  that falls between 1 ms and 5 ms is linearly interpolated across a 4 ms-wide
+  bucket and cannot be more precise than that. This is acceptable for a *shape*
+  and *regression* view (the dashboards' job) but is **not** an accurate
+  percentile. The design's stance: dashboards show distribution shape and coarse
+  quantiles; authoritative percentiles are the analyzer's job (its per-path
+  summaries and SLA evaluation), surfaced as counts, not recomputed on the
+  dashboard. Panels label these as approximate.
+- **Cardinality and query cost.** Series scale as O(ToR²): with `N` ToRs the
+  probe counters are `~N²` series each and each histogram is `~N² × 12` bucket
+  series. A cluster with 50 ToRs is ~2 500 pairs → ~30 000 bucket series per
+  histogram — well within VictoriaMetrics, but the *matrix panel query* fans out
+  over all pairs on every refresh. Mitigations baked into the design: the matrix
+  uses an instant query over `$__range` (one evaluation, not a range fan-out); the
+  companion table uses `topk` to bound rows; the heavy per-pair histogram queries
+  live only on the drilldown board where they are constrained to a single pair by
+  template variables. This keeps the always-on Overview cheap and pushes the
+  expensive queries behind an explicit pair selection.
+
+## Verification strategy
+
+The stack is validated end to end without any RDMA hardware:
+
+1. **Bring up the stack** — `docker compose` (on colima) starts VictoriaMetrics,
+   otel-collector-contrib, and Grafana with provisioned datasource + dashboards.
+2. **Seed synthetic mesh data** — `seed-demo-metrics.sh` backfills ~30 min of a
+   4–6 ToR mesh into VictoriaMetrics via `/api/v1/import/prometheus` (per-line
+   timestamps), including realistic histogram buckets, success/failure counters
+   with a couple of deliberately degraded pairs, SLA-violation counters, and the
+   self-throttle gauge. Timestamped backfill is required so `rate()` and
+   `histogram_quantile()` have ≥2 points to work with.
+3. **Assert Grafana health and provisioning** — `GET /api/health` is `ok`;
+   `GET /api/search` lists both dashboards (provisioning succeeded).
+4. **Assert every panel query returns data** — replay each panel's PromQL through
+   `POST /api/ds/query` (or the datasource proxy) and assert HTTP 200 with a
+   non-empty frame. This catches name-contract drift directly: if the exporter
+   ever re-introduces a suffix, these queries return empty and the check fails.
+
+Exact commands are in the implementation spec.
+
+## Future work
+
+- **ESnet Matrix panel** as an opt-in enhancement once its Grafana-version
+  compatibility is pinned and plugin provisioning is acceptable — it would host
+  richer cell interactions (including reliable per-cell drilldown, removing the
+  companion-table workaround).
+- **Phase-2 localization view**: a third dashboard over the analyzer's
+  path/segment attribution once those metrics exist
+  (`analyzer-phase2-localization.md`).
+- **Alerting rules**: the metric contract already supports the obvious alerts —
+  per-pair loss ratio, per-pair p99 breach, sustained self-throttle < 1, and any
+  event-ring drops — as Grafana or vmalert rules.
+- **Dashboards-as-code**: migrate the committed JSON to Grafonnet/Foundation SDK
+  if the board count grows or duplication between Overview and Drilldown becomes
+  a maintenance cost.
+- **Direct OTLP ingest**: drop the collector once VM-side naming is validated to
+  reproduce the pinned names.

--- a/rebuild/go.mod
+++ b/rebuild/go.mod
@@ -3,6 +3,7 @@ module github.com/yuuki/rpingmesh/rebuild
 go 1.26.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/rqlite/gorqlite v0.0.0-20260504155303-50d445fd0ab9
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
@@ -15,7 +16,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	golang.org/x/sys v0.46.0
 	google.golang.org/grpc v1.82.0
-	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -25,7 +25,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -44,4 +43,5 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/rebuild/internal/telemetry/otel_metrics.go
+++ b/rebuild/internal/telemetry/otel_metrics.go
@@ -10,9 +10,11 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
@@ -126,10 +128,38 @@ type MetricsCollector struct {
 	logger           zerolog.Logger
 }
 
+// instanceID returns a value suitable for the OTel resource's
+// service.instance.id attribute: the machine's hostname, which is stable
+// across an agent's lifetime and distinct per host in the common case of
+// one agent per machine. os.Hostname() essentially never fails on Linux,
+// but if it does (e.g. a container with an unusual /proc setup), fall back
+// to a random UUID rather than leaving service.instance.id unset -- an
+// unset instance ID is exactly the bug this exists to prevent (see
+// buildResource): multiple agents would collide onto the same Prometheus
+// series after prometheusremotewrite derives `instance` from this
+// attribute.
+func instanceID() string {
+	host, err := os.Hostname()
+	if err != nil {
+		log.Warn().Err(err).Msg("os.Hostname failed; falling back to a random service.instance.id")
+		return uuid.NewString()
+	}
+	return host
+}
+
 // buildResource builds the OTel resource identifying this service, merging
-// process/host defaults with the given service name and a fixed service
-// version. Extracted as its own function so tests can verify service-name
+// process/host defaults with the given service name, a fixed service
+// version, and a per-process service.instance.id (see instanceID).
+// Extracted as its own function so tests can verify service-name
 // parameterization without dialing a real OTLP collector.
+//
+// service.instance.id matters beyond identification: the collector's
+// prometheusremotewrite exporter derives the Prometheus `instance` label
+// from it (as it derives `job` from service.name). Without it, every agent
+// process reporting the same metric name+ToR-pair attributes collides onto
+// one Prometheus series -- rate() then mixes counters from unrelated
+// processes, corrupting every rate/quantile derived from it. See
+// docs/design/grafana-dashboards.md's "identity contract" note.
 func buildResource(serviceName string) (*resource.Resource, error) {
 	return resource.Merge(
 		resource.Default(),
@@ -137,6 +167,7 @@ func buildResource(serviceName string) (*resource.Resource, error) {
 			semconv.SchemaURL,
 			semconv.ServiceName(serviceName),
 			semconv.ServiceVersion("0.1.0"),
+			semconv.ServiceInstanceID(instanceID()),
 		),
 	)
 }

--- a/rebuild/internal/telemetry/otel_metrics_test.go
+++ b/rebuild/internal/telemetry/otel_metrics_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -38,6 +39,49 @@ func TestBuildResource_DefaultServiceName(t *testing.T) {
 	}
 	if got != "rpingmesh-agent" {
 		t.Errorf("service.name = %q, want rpingmesh-agent", got)
+	}
+}
+
+// TestBuildResource_InstanceID verifies that buildResource sets a non-empty
+// service.instance.id attribute, and that it matches os.Hostname() in the
+// common case (no fallback triggered). This is the attribute
+// prometheusremotewrite derives the Prometheus `instance` label from; a
+// missing or empty value here means every agent process reporting the same
+// metric name+ToR-pair attributes collides onto one series (see
+// buildResource's doc comment).
+func TestBuildResource_InstanceID(t *testing.T) {
+	res, err := buildResource(defaultServiceName)
+	if err != nil {
+		t.Fatalf("buildResource(%q) returned error: %v", defaultServiceName, err)
+	}
+
+	var got string
+	var ok bool
+	for _, kv := range res.Attributes() {
+		if kv.Key == semconv.ServiceInstanceIDKey {
+			got, ok = kv.Value.AsString(), true
+			break
+		}
+	}
+	if !ok {
+		t.Fatal("service.instance.id attribute not found in resource")
+	}
+	if got == "" {
+		t.Error("service.instance.id is empty, want a non-empty host identifier")
+	}
+
+	wantHost, hostErr := os.Hostname()
+	if hostErr == nil && got != wantHost {
+		t.Errorf("service.instance.id = %q, want os.Hostname() = %q", got, wantHost)
+	}
+}
+
+// TestInstanceID_NonEmpty verifies instanceID() never returns an empty
+// string: an empty service.instance.id would be exactly the bug this
+// attribute exists to prevent (per-agent series collision).
+func TestInstanceID_NonEmpty(t *testing.T) {
+	if got := instanceID(); got == "" {
+		t.Error("instanceID() returned an empty string, want a non-empty host identifier")
 	}
 }
 

--- a/rebuild/scripts/seed-demo-metrics.sh
+++ b/rebuild/scripts/seed-demo-metrics.sh
@@ -29,55 +29,73 @@ gen() {
           if (i == 1 && j == 4) { loss = 0.06;  modal = 9 }   # a->d lossy
           if (i == 3 && j == 5) { loss = 0.04;  modal = 8 }   # c->e lossy
           if (i == 2 && j == 6) { loss = 0.002; modal = 10 }  # b->f high RTT (1-5ms)
-          per = 30                        # probes attempted per step
-          fail = int(per * loss + 0.5)
-          succ = per - fail
-          # accumulate counters
-          tot[key]  += per
-          ok[key]   += succ
-          # failures: most timeouts, a steady trickle of invalid_rtt
-          ftimeout[key] += fail
-          finvalid[key] += (( (i+j+t) % 7 == 0) ? 1 : 0)
-          # histogram cumulative buckets: put succ obs into modal bucket
-          for (b = 1; b <= nle; b++) if (b >= modal) hb[key,b] += succ
-          hcount[key] += succ
-          hsum[key]   += succ * LE[modal]   # rough sum using modal bucket bound (ns)
-          # SLA violations for the bad pairs.
-          # NOTE: gated on (t - start), not raw t: STEP (15s) shares a common
-          # factor with 60/90/120, so a raw "t % 60 == 0" check only ever
-          # fires if the absolute epoch `start` happens to be a multiple of
-          # 15 -- true for only 1 in 15 runs depending on wall-clock time at
-          # invocation. Anchoring to the loop-relative offset (always a
-          # multiple of STEP, starting at 0) makes it fire deterministically
-          # regardless of when the script is run.
-          if (i == 1 && j == 4) slaloss[key] += (((t - start) % 60 == 0) ? 1 : 0)
-          if (i == 3 && j == 5) slaloss[key] += (((t - start) % 90 == 0) ? 1 : 0)
-          if (i == 2 && j == 6) slartt[key]  += (((t - start) % 120 == 0) ? 1 : 0)
+          per_total = 30                  # probes attempted per step, across all agents
 
-          lbl = "source_tor=\"" T[i] "\",target_tor=\"" T[j] "\",job=\"rpingmesh-agent\""
-          printf "rpingmesh_probe_total{%s} %d %d\n", lbl, tot[key], ts
-          printf "rpingmesh_probe_success_total{%s} %d %d\n", lbl, ok[key], ts
-          if (ftimeout[key] > 0)
-            printf "rpingmesh_probe_failed_total{%s,reason=\"timeout\"} %d %d\n", lbl, ftimeout[key], ts
-          if (finvalid[key] > 0)
-            printf "rpingmesh_probe_failed_total{%s,reason=\"invalid_rtt\"} %d %d\n", lbl, finvalid[key], ts
-          for (b = 1; b <= nle; b++)
-            printf "rpingmesh_network_rtt_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[key,b], ts
-          printf "rpingmesh_network_rtt_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[key], ts
-          printf "rpingmesh_network_rtt_ns_sum{%s} %d %d\n", lbl, hsum[key], ts
-          printf "rpingmesh_network_rtt_ns_count{%s} %d %d\n", lbl, hcount[key], ts
-          # reuse the same distribution for prober/responder delay (demo only)
-          for (b = 1; b <= nle; b++) {
-            printf "rpingmesh_prober_delay_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[key,b], ts
-            printf "rpingmesh_responder_delay_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[key,b], ts
+          # Split this pairs probes across two synthetic agent instances
+          # (instance="agent-1"/"agent-2") instead of one combined series.
+          # This exercises the identity contract (job <- service.name,
+          # instance <- service.instance.id, see
+          # docs/design/grafana-dashboards.md): without an instance label,
+          # multiple agents covering the same ToR pair would collide onto
+          # one Prometheus series and corrupt rate(); with it, each agent
+          # gets its own well-formed monotonic counter and dashboard panels
+          # (all of which aggregate with sum by (source_tor, target_tor) /
+          # sum by (le) / etc., never by instance) recombine them correctly.
+          for (inst = 1; inst <= 2; inst++) {
+            per = int(per_total / 2) + ((inst == 1 && per_total % 2 == 1) ? 1 : 0)
+            fail = int(per * loss + 0.5)
+            succ = per - fail
+            ik = key SUBSEP inst
+            # accumulate counters
+            tot[ik]  += per
+            ok[ik]   += succ
+            # failures: most timeouts, a steady trickle of invalid_rtt
+            ftimeout[ik] += fail
+            finvalid[ik] += (( (i+j+t+inst) % 7 == 0) ? 1 : 0)
+            # histogram cumulative buckets: put succ obs into modal bucket
+            for (b = 1; b <= nle; b++) if (b >= modal) hb[ik,b] += succ
+            hcount[ik] += succ
+            hsum[ik]   += succ * LE[modal]   # rough sum using modal bucket bound (ns)
+            # SLA violations for the bad pairs, attributed to instance 1
+            # only (the analyzer emits one violation per detection window,
+            # not per contributing agent).
+            # NOTE: gated on (t - start), not raw t: STEP (15s) shares a
+            # common factor with 60/90/120, so a raw "t % 60 == 0" check
+            # only ever fires if the absolute epoch `start` happens to be a
+            # multiple of 15 -- true for only 1 in 15 runs depending on
+            # wall-clock time at invocation. Anchoring to the loop-relative
+            # offset (always a multiple of STEP, starting at 0) makes it
+            # fire deterministically regardless of when the script is run.
+            if (inst == 1 && i == 1 && j == 4) slaloss[key] += (((t - start) % 60 == 0) ? 1 : 0)
+            if (inst == 1 && i == 3 && j == 5) slaloss[key] += (((t - start) % 90 == 0) ? 1 : 0)
+            if (inst == 1 && i == 2 && j == 6) slartt[key]  += (((t - start) % 120 == 0) ? 1 : 0)
+
+            lbl = "source_tor=\"" T[i] "\",target_tor=\"" T[j] "\",job=\"rpingmesh-agent\",instance=\"agent-" inst "\""
+            printf "rpingmesh_probe_total{%s} %d %d\n", lbl, tot[ik], ts
+            printf "rpingmesh_probe_success_total{%s} %d %d\n", lbl, ok[ik], ts
+            if (ftimeout[ik] > 0)
+              printf "rpingmesh_probe_failed_total{%s,reason=\"timeout\"} %d %d\n", lbl, ftimeout[ik], ts
+            if (finvalid[ik] > 0)
+              printf "rpingmesh_probe_failed_total{%s,reason=\"invalid_rtt\"} %d %d\n", lbl, finvalid[ik], ts
+            for (b = 1; b <= nle; b++)
+              printf "rpingmesh_network_rtt_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[ik,b], ts
+            printf "rpingmesh_network_rtt_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[ik], ts
+            printf "rpingmesh_network_rtt_ns_sum{%s} %d %d\n", lbl, hsum[ik], ts
+            printf "rpingmesh_network_rtt_ns_count{%s} %d %d\n", lbl, hcount[ik], ts
+            # reuse the same distribution for prober/responder delay (demo only)
+            for (b = 1; b <= nle; b++) {
+              printf "rpingmesh_prober_delay_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[ik,b], ts
+              printf "rpingmesh_responder_delay_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[ik,b], ts
+            }
+            printf "rpingmesh_prober_delay_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[ik], ts
+            printf "rpingmesh_prober_delay_ns_sum{%s} %d %d\n", lbl, hsum[ik], ts
+            printf "rpingmesh_prober_delay_ns_count{%s} %d %d\n", lbl, hcount[ik], ts
+            printf "rpingmesh_responder_delay_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[ik], ts
+            printf "rpingmesh_responder_delay_ns_sum{%s} %d %d\n", lbl, hsum[ik], ts
+            printf "rpingmesh_responder_delay_ns_count{%s} %d %d\n", lbl, hcount[ik], ts
           }
-          printf "rpingmesh_prober_delay_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[key], ts
-          printf "rpingmesh_prober_delay_ns_sum{%s} %d %d\n", lbl, hsum[key], ts
-          printf "rpingmesh_prober_delay_ns_count{%s} %d %d\n", lbl, hcount[key], ts
-          printf "rpingmesh_responder_delay_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[key], ts
-          printf "rpingmesh_responder_delay_ns_sum{%s} %d %d\n", lbl, hsum[key], ts
-          printf "rpingmesh_responder_delay_ns_count{%s} %d %d\n", lbl, hcount[key], ts
-          # analyzer SLA violations (job=rpingmesh-analyzer)
+          # analyzer SLA violations (job=rpingmesh-analyzer; the analyzer is
+          # a separate, single process in this demo, so no instance split).
           albl = "source_tor=\"" T[i] "\",target_tor=\"" T[j] "\",job=\"rpingmesh-analyzer\""
           if (slaloss[key] > 0)
             printf "rpingmesh_analyzer_sla_violations_total{%s,kind=\"loss\"} %d %d\n", albl, slaloss[key], ts

--- a/rebuild/scripts/seed-demo-metrics.sh
+++ b/rebuild/scripts/seed-demo-metrics.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Seed synthetic R-Pingmesh mesh metrics into VictoriaMetrics for dashboard demos.
+# Backfills ~30 min of a 6-ToR mesh so that rate()/histogram_quantile() have data.
+# Names MUST match the exporter output (translation_strategy=WithoutSuffixes).
+set -euo pipefail
+
+VM_URL="${VM_URL:-http://localhost:8428}"
+WINDOW="${WINDOW:-1800}"   # seconds of backfill
+STEP="${STEP:-15}"         # sample interval seconds
+NOW="$(date +%s)"
+START="$(( NOW - WINDOW ))"
+
+gen() {
+  awk -v start="$START" -v now="$NOW" -v step="$STEP" '
+  BEGIN {
+    ntor = split("tor-a tor-b tor-c tor-d tor-e tor-f", T, " ")
+    nle  = split("100 500 1000 5000 10000 50000 100000 500000 1000000 5000000 10000000", LE, " ")
+    # cumulative accumulators, keyed by pair index "i,j"
+    # bad pairs: high loss on (a->d) and (c->e); high RTT on (b->f)
+    for (t = start; t <= now; t += step) {
+      ts = t * 1000
+      for (i = 1; i <= ntor; i++) {
+        for (j = 1; j <= ntor; j++) {
+          if (i == j) continue
+          key = i "," j
+          # per-pair profile
+          loss = 0.001
+          modal = 3                      # default modal bucket index (~1us..5us region)
+          if (i == 1 && j == 4) { loss = 0.06;  modal = 9 }   # a->d lossy
+          if (i == 3 && j == 5) { loss = 0.04;  modal = 8 }   # c->e lossy
+          if (i == 2 && j == 6) { loss = 0.002; modal = 10 }  # b->f high RTT (1-5ms)
+          per = 30                        # probes attempted per step
+          fail = int(per * loss + 0.5)
+          succ = per - fail
+          # accumulate counters
+          tot[key]  += per
+          ok[key]   += succ
+          # failures: most timeouts, a steady trickle of invalid_rtt
+          ftimeout[key] += fail
+          finvalid[key] += (( (i+j+t) % 7 == 0) ? 1 : 0)
+          # histogram cumulative buckets: put succ obs into modal bucket
+          for (b = 1; b <= nle; b++) if (b >= modal) hb[key,b] += succ
+          hcount[key] += succ
+          hsum[key]   += succ * LE[modal]   # rough sum using modal bucket bound (ns)
+          # SLA violations for the bad pairs.
+          # NOTE: gated on (t - start), not raw t: STEP (15s) shares a common
+          # factor with 60/90/120, so a raw "t % 60 == 0" check only ever
+          # fires if the absolute epoch `start` happens to be a multiple of
+          # 15 -- true for only 1 in 15 runs depending on wall-clock time at
+          # invocation. Anchoring to the loop-relative offset (always a
+          # multiple of STEP, starting at 0) makes it fire deterministically
+          # regardless of when the script is run.
+          if (i == 1 && j == 4) slaloss[key] += (((t - start) % 60 == 0) ? 1 : 0)
+          if (i == 3 && j == 5) slaloss[key] += (((t - start) % 90 == 0) ? 1 : 0)
+          if (i == 2 && j == 6) slartt[key]  += (((t - start) % 120 == 0) ? 1 : 0)
+
+          lbl = "source_tor=\"" T[i] "\",target_tor=\"" T[j] "\",job=\"rpingmesh-agent\""
+          printf "rpingmesh_probe_total{%s} %d %d\n", lbl, tot[key], ts
+          printf "rpingmesh_probe_success_total{%s} %d %d\n", lbl, ok[key], ts
+          if (ftimeout[key] > 0)
+            printf "rpingmesh_probe_failed_total{%s,reason=\"timeout\"} %d %d\n", lbl, ftimeout[key], ts
+          if (finvalid[key] > 0)
+            printf "rpingmesh_probe_failed_total{%s,reason=\"invalid_rtt\"} %d %d\n", lbl, finvalid[key], ts
+          for (b = 1; b <= nle; b++)
+            printf "rpingmesh_network_rtt_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[key,b], ts
+          printf "rpingmesh_network_rtt_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[key], ts
+          printf "rpingmesh_network_rtt_ns_sum{%s} %d %d\n", lbl, hsum[key], ts
+          printf "rpingmesh_network_rtt_ns_count{%s} %d %d\n", lbl, hcount[key], ts
+          # reuse the same distribution for prober/responder delay (demo only)
+          for (b = 1; b <= nle; b++) {
+            printf "rpingmesh_prober_delay_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[key,b], ts
+            printf "rpingmesh_responder_delay_ns_bucket{%s,le=\"%s\"} %d %d\n", lbl, LE[b], hb[key,b], ts
+          }
+          printf "rpingmesh_prober_delay_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[key], ts
+          printf "rpingmesh_prober_delay_ns_sum{%s} %d %d\n", lbl, hsum[key], ts
+          printf "rpingmesh_prober_delay_ns_count{%s} %d %d\n", lbl, hcount[key], ts
+          printf "rpingmesh_responder_delay_ns_bucket{%s,le=\"+Inf\"} %d %d\n", lbl, hcount[key], ts
+          printf "rpingmesh_responder_delay_ns_sum{%s} %d %d\n", lbl, hsum[key], ts
+          printf "rpingmesh_responder_delay_ns_count{%s} %d %d\n", lbl, hcount[key], ts
+          # analyzer SLA violations (job=rpingmesh-analyzer)
+          albl = "source_tor=\"" T[i] "\",target_tor=\"" T[j] "\",job=\"rpingmesh-analyzer\""
+          if (slaloss[key] > 0)
+            printf "rpingmesh_analyzer_sla_violations_total{%s,kind=\"loss\"} %d %d\n", albl, slaloss[key], ts
+          if (slartt[key] > 0)
+            printf "rpingmesh_analyzer_sla_violations_total{%s,kind=\"rtt\"} %d %d\n", albl, slartt[key], ts
+        }
+      }
+      # fleet-level analyzer + agent gauges
+      psum += ntor * (ntor - 1)
+      printf "rpingmesh_analyzer_path_summaries_total{job=\"rpingmesh-analyzer\"} %d %d\n", psum, ts
+      # self_throttle: agent-1 dips mid-window, agent-2 stays healthy
+      thr = (t > start + 600 && t < start + 900) ? 0.6 : 1.0
+      printf "rpingmesh_agent_self_throttle{job=\"rpingmesh-agent\",instance=\"agent-1\"} %.2f %d\n", thr, ts
+      printf "rpingmesh_agent_self_throttle{job=\"rpingmesh-agent\",instance=\"agent-2\"} 1.00 %d\n", ts
+      # event ring drops on agent-1 during the throttled window
+      if (t > start + 600 && t < start + 900) drops += 3
+      printf "rpingmesh_event_ring_dropped_total{job=\"rpingmesh-agent\",instance=\"agent-1\",ring=\"prober\"} %d %d\n", drops, ts
+    }
+  }'
+}
+
+echo "Seeding ${WINDOW}s of mesh data (step ${STEP}s) into ${VM_URL} ..." >&2
+gen | curl -s --fail --data-binary @- "${VM_URL}/api/v1/import/prometheus"
+# flush VM in-memory buffers so queries see the data immediately
+curl -s "${VM_URL}/internal/force_flush" >/dev/null || true
+echo "Seed complete. Try: curl -s '${VM_URL}/api/v1/label/__name__/values' | tr ',' '\n' | grep rpingmesh" >&2

--- a/rebuild/scripts/verify-observability.sh
+++ b/rebuild/scripts/verify-observability.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Verify the observability stack: Grafana health/provisioning and every
+# dashboard panel's PromQL against VictoriaMetrics. Run after `make obs-up`
+# and `make obs-seed`.
+set -euo pipefail
+
+VM_URL="${VM_URL:-http://localhost:8428}"
+GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
+GRAFANA_USER="${GF_SECURITY_ADMIN_USER:-admin}"
+GRAFANA_PASS="${GF_SECURITY_ADMIN_PASSWORD:-admin}"
+
+fail=0
+
+echo "== Grafana health ==" >&2
+curl -sf "${GRAFANA_URL}/api/health" | tee /dev/stderr | grep -q '"database": *"ok"' \
+  || { echo "!! Grafana health check failed" >&2; fail=1; }
+echo >&2
+
+echo "== Provisioned dashboards ==" >&2
+search="$(curl -s -u "${GRAFANA_USER}:${GRAFANA_PASS}" "${GRAFANA_URL}/api/search?type=dash-db")"
+echo "$search" | grep -o '"uid":"[^"]*"' >&2
+echo "$search" | grep -q '"uid":"rpingmesh-mesh-overview"' || { echo "!! missing rpingmesh-mesh-overview" >&2; fail=1; }
+echo "$search" | grep -q '"uid":"rpingmesh-tor-pair"' || { echo "!! missing rpingmesh-tor-pair" >&2; fail=1; }
+echo >&2
+
+echo "== Provisioned datasource ==" >&2
+curl -s -u "${GRAFANA_USER}:${GRAFANA_PASS}" "${GRAFANA_URL}/api/datasources" \
+  | grep -q '"uid":"victoriametrics"' || { echo "!! missing victoriametrics datasource" >&2; fail=1; }
+
+echo "== Panel queries against VictoriaMetrics ==" >&2
+queries=(
+  'sum(rate(rpingmesh_probe_total[5m]))'
+  '100 * (1 - sum by (source_tor,target_tor)(rate(rpingmesh_probe_success_total[30m])) / clamp_min(sum by (source_tor,target_tor)(rate(rpingmesh_probe_total[30m])),1))'
+  'sum by (reason)(rate(rpingmesh_probe_failed_total[5m]))'
+  'sum by (kind)(rate(rpingmesh_analyzer_sla_violations_total[5m]))'
+  'histogram_quantile(0.99, sum by (le)(rate(rpingmesh_network_rtt_ns_bucket{source_tor="tor-a",target_tor="tor-d"}[5m])))'
+  'sum by (le)(rate(rpingmesh_network_rtt_ns_bucket{source_tor="tor-a",target_tor="tor-d"}[5m]))'
+  'min(rpingmesh_agent_self_throttle)'
+)
+for q in "${queries[@]}"; do
+  r=$(curl -s -G "${VM_URL}/api/v1/query" --data-urlencode "query=$q")
+  echo "$q -> $(echo "$r" | head -c 120)" >&2
+  echo "$r" | grep -q '"result":\[{' || { echo "  !! EMPTY/ERROR for: $q" >&2; fail=1; }
+done
+
+echo >&2
+echo "== label_values(rpingmesh_probe_total) sanity ==" >&2
+curl -s "${VM_URL}/api/v1/series?match[]=rpingmesh_probe_total" | head -c 200 >&2
+echo >&2
+
+if [ "$fail" -ne 0 ]; then
+  echo "!! Verification FAILED" >&2
+  exit 1
+fi
+echo "All checks passed." >&2

--- a/rebuild/scripts/verify-observability.sh
+++ b/rebuild/scripts/verify-observability.sh
@@ -4,6 +4,27 @@
 # and `make obs-seed`.
 set -euo pipefail
 
+# Resolve deploy/observability/.env from this script's own location, not the
+# caller's cwd, so `make obs-verify` (cwd=rebuild/) and a direct
+# `./scripts/verify-observability.sh` invocation both find it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../deploy/observability/.env"
+
+# If `make obs-up` started Grafana with a non-default admin user/password
+# from deploy/observability/.env, verify against those same credentials
+# instead of silently falling back to admin/admin. Env vars already
+# exported by the caller take priority over the .env file.
+if [ -f "$ENV_FILE" ]; then
+  _preset_user="${GF_SECURITY_ADMIN_USER-}"
+  _preset_pass="${GF_SECURITY_ADMIN_PASSWORD-}"
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+  [ -n "$_preset_user" ] && GF_SECURITY_ADMIN_USER="$_preset_user"
+  [ -n "$_preset_pass" ] && GF_SECURITY_ADMIN_PASSWORD="$_preset_pass"
+fi
+
 VM_URL="${VM_URL:-http://localhost:8428}"
 GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
 GRAFANA_USER="${GF_SECURITY_ADMIN_USER:-admin}"

--- a/rebuild/scripts/verify-observability.sh
+++ b/rebuild/scripts/verify-observability.sh
@@ -30,7 +30,7 @@ curl -s -u "${GRAFANA_USER}:${GRAFANA_PASS}" "${GRAFANA_URL}/api/datasources" \
 echo "== Panel queries against VictoriaMetrics ==" >&2
 queries=(
   'sum(rate(rpingmesh_probe_total[5m]))'
-  '100 * (1 - sum by (source_tor,target_tor)(rate(rpingmesh_probe_success_total[30m])) / clamp_min(sum by (source_tor,target_tor)(rate(rpingmesh_probe_total[30m])),1))'
+  '100 * (1 - sum by (source_tor,target_tor)(rate(rpingmesh_probe_success_total[30m])) / (sum by (source_tor,target_tor)(rate(rpingmesh_probe_total[30m])) > 0))'
   'sum by (reason)(rate(rpingmesh_probe_failed_total[5m]))'
   'sum by (kind)(rate(rpingmesh_analyzer_sla_violations_total[5m]))'
   'histogram_quantile(0.99, sum by (le)(rate(rpingmesh_network_rtt_ns_bucket{source_tor="tor-a",target_tor="tor-d"}[5m])))'


### PR DESCRIPTION
## Summary

Implements the design in `rebuild/docs/design/grafana-dashboards.md` (commit `23da6fe`, merged separately):

- Two Grafana dashboards, committed as JSON and provisioned from disk:
  - **Mesh Overview** (`rpingmesh-mesh-overview`): fleet-health stat row (probe rate, success ratio, SLA-violation rate, worst self-throttle, event-ring drops), a ToR×ToR loss-percentage matrix (Table + *Grouping to matrix* transformation, color-background cells), a "Worst ToR pairs" companion table carrying the drilldown data link, failure-by-reason and SLA-by-kind time series, and an SLA-by-pair table.
  - **ToR Pair Drilldown** (`rpingmesh-tor-pair`): `source_tor`/`target_tor` template variables, pair stat row, a network-RTT heatmap, p50/p90/p99 RTT quantiles (labelled "approx" — 11 explicit histogram buckets), failure-by-reason, prober/responder delay percentiles, and pair-scoped SLA violations.
  - Zero custom Grafana plugins; native Table/Heatmap/Time series/Stat only.
- A self-contained `docker-compose` observability stack under `rebuild/deploy/observability/`: VictoriaMetrics ← otel-collector-contrib ← OTLP, with Grafana provisioned against it (datasource + both dashboards, folder `R-Pingmesh`).
- `rebuild/scripts/seed-demo-metrics.sh`: backfills ~30 min of a synthetic 6-ToR mesh (two lossy pairs, one high-RTT pair, a self-throttle dip) directly into VictoriaMetrics via `/api/v1/import/prometheus`, so the dashboards can be exercised without RDMA hardware.
- `rebuild/scripts/verify-observability.sh` + `make obs-up/obs-down/obs-seed/obs-verify/obs-logs` targets.
- README updates (`rebuild/README.md`, `rebuild/deploy/observability/README.md`) documenting the quick start and the metric-name contract.

## Metric name contract

The `prometheusremotewrite` exporter must escape OTLP's `.` → `_` **without** appending extra `_total`/unit suffixes, since the instrument names already carry them (`rpingmesh.probe_total` → `rpingmesh_probe_total`, not `rpingmesh_probe_total_total`). The design doc specifies `translation_strategy: UnderscoreEscapingWithoutSuffixes`; the pinned collector image here (`otel/opentelemetry-collector-contrib:0.117.0`) predates that option (confirmed against `exporter/prometheusremotewriteexporter/config.go` at that tag — only `add_metric_suffixes` exists), so `add_metric_suffixes: false` is used instead, exactly per the design doc's documented fallback. This was verified against the **real** OTLP pipeline (not just the seed script's direct-import bypass): a live OTLP/HTTP push of `rpingmesh.probe_total` through the collector landed as exactly `rpingmesh_probe_total` in VictoriaMetrics, with `job` correctly derived from the `service.name` resource attribute.

## Verification

Ran on colima (arm64) per the spec's §9 checklist:

- `make obs-up` → VictoriaMetrics, otel-collector, Grafana all healthy.
- `GET /api/health` → `{"database": "ok", ...}`.
- `GET /api/search?type=dash-db` → both `rpingmesh-mesh-overview` and `rpingmesh-tor-pair` provisioned, in the `R-Pingmesh` folder.
- `GET /api/datasources` → `victoriametrics` datasource provisioned (Prometheus type, proxy access).
- `make obs-seed` → all `rpingmesh_*` series present in VictoriaMetrics.
- All representative panel PromQL queries return HTTP 200 with non-empty results, both directly against VictoriaMetrics and through the Grafana datasource proxy (`/api/datasources/proxy/uid/victoriametrics/...`):
  - fleet probe rate, ToR×ToR loss-matrix expression, failure-by-reason, SLA-by-kind, `histogram_quantile` p99 RTT for a specific pair, per-`le` bucket rates, `min(self_throttle)`, and `topk` worst-pairs.
- Fetched both dashboards' JSON models back via `/api/dashboards/uid/...` to confirm they load without corruption (10 and 9 panels respectively, `schemaVersion: 39`, `groupingToMatrix`/`organize` transformations intact, template variables present).
- Confirmed the matrix panel's underlying query returns proper per-`(source_tor,target_tor)` frames through Grafana's own `/api/ds/query` endpoint.
- `make obs-down` torn down (volumes removed) after each round.
- No browser was available in this environment, so the spec's final "目視" (visual) check of rendered panels/click-through was not performed; all structural and data-level checks above were performed via the API instead.

`bash -n` and `shellcheck` clean on both scripts (one info-level `SC2028` on an `echo` diagnostic message, not fixed since it's cosmetic and doesn't affect behavior).

## Deviations from the implementation spec (with reasons)

1. **`otel-collector-contrib` image bumped `0.116.0` → `0.117.0`.** The arm64 build of `0.116.0` ships a dynamically-linked binary with no libc/dynamic-linker in the image (`exec /otelcol-contrib: no such file or directory` even with the correct platform selected) — a broken release artifact for that tag/arch, not a config issue. `0.117.0` is otherwise the nearest compatible version.
2. **`add_metric_suffixes: false` instead of `translation_strategy`.** `0.117.0`'s `prometheusremotewriteexporter` doesn't have the `translation_strategy` key yet. Used the spec's own documented fallback; see "Metric name contract" above.
3. **VictoriaMetrics healthcheck: `127.0.0.1` instead of `localhost`.** Inside the VM container, `wget http://localhost:8428/health` resolves to `::1` first and fails to connect (VM only binds `0.0.0.0`/IPv4), making the healthcheck report unhealthy even though the server was up. Switched to `127.0.0.1`.
4. **Seed script SLA-violation gating fixed to be time-anchor-independent.** The spec's `((t) % 60 == 0)`-style conditions (and `% 90`, `% 120`) depend on the absolute Unix epoch aligning with the 15s step grid — since `gcd(15, 60) = 15`, whether the condition ever fires depends entirely on `start % 15`, which is arbitrary based on wall-clock time at invocation. Discovered this because `rpingmesh_analyzer_sla_violations_total` was silently never emitted on first verification run. Fixed by anchoring to `(t - start) % N` instead of `t % N`, which is always a multiple of the step size and fires deterministically every run.

## Test plan

- [x] `make obs-up` brings up all three services healthy
- [x] `make obs-seed` populates all contracted `rpingmesh_*` series, including SLA violations
- [x] Both dashboards + datasource provisioned and visible via Grafana API
- [x] All panel PromQL queries return non-empty data via VictoriaMetrics and the Grafana datasource proxy
- [x] Real OTLP push through the collector confirms the metric-name contract independent of the seed script
- [x] `bash -n` / `shellcheck` clean on both scripts
- [x] `make obs-down` cleans up volumes