### PR TITLE
fix(rebuild): exclude same-host and cross-family targets from pinglists

### DIFF
--- a/rebuild/cmd/controller/main.go
+++ b/rebuild/cmd/controller/main.go
@@ -86,7 +86,6 @@ func run(cmd *cobra.Command, args []string) error {
 		cfg.DatabaseURI,
 		cfg.ActiveThresholdSec,
 		cfg.StaleThresholdSec,
-		cfg.InterTorSampleSize,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize registry: %w", err)
@@ -103,7 +102,7 @@ func run(cmd *cobra.Command, args []string) error {
 		PathsAssumed:        cfg.EcmpPathsAssumed,
 		CoverageProbability: cfg.EcmpCoverageProbability,
 		MaxFlowLabels:       cfg.EcmpMaxFlowLabels,
-	})
+	}, cfg.InterTorSampleSize)
 
 	// Set up the Phase 1 analyzer if enabled: it ingests agent-reported
 	// per-path summaries and flags SLA violations. Its OTLP metrics are

--- a/rebuild/internal/controller/pinglist/ecmp_test.go
+++ b/rebuild/internal/controller/pinglist/ecmp_test.go
@@ -67,19 +67,33 @@ func TestComputeFlowLabelCount_MonotonicInProbability(t *testing.T) {
 }
 
 // fakeRnicSource is a minimal RnicSource returning a fixed set of RNICs so the
-// generator's PingTarget construction (seed/count stamping) can be tested
-// without a real registry.
+// generator's PingTarget construction (seed/count stamping) and its same-host /
+// same-family filtering can be tested without a real registry.
 type fakeRnicSource struct {
 	torMesh  []*controller_agent.RnicInfo
 	interTor []*controller_agent.RnicInfo
+	// hostnameByGID maps a requester GID to the hostname it is registered
+	// under. A GID absent from the map resolves to "" (unregistered), which
+	// exercises the GID self-exclusion fallback.
+	hostnameByGID map[string]string
+	// resolveErr, if set, is returned by ResolveHostnameByGID to exercise the
+	// graceful-degradation path.
+	resolveErr error
 }
 
 func (f *fakeRnicSource) GetRNICsByToR(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
 	return f.torMesh, nil
 }
 
-func (f *fakeRnicSource) GetSampleRNICsFromOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+func (f *fakeRnicSource) GetActiveRNICsInOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
 	return f.interTor, nil
+}
+
+func (f *fakeRnicSource) ResolveHostnameByGID(_ context.Context, gid string) (string, error) {
+	if f.resolveErr != nil {
+		return "", f.resolveErr
+	}
+	return f.hostnameByGID[gid], nil
 }
 
 // TestPinglistCarriesSeedAndCount verifies that generated PingTargets carry the
@@ -98,7 +112,7 @@ func TestPinglistCarriesSeedAndCount(t *testing.T) {
 		PathsAssumed:        16,
 		CoverageProbability: 0.9,
 		MaxFlowLabels:       64,
-	})
+	}, DefaultInterTorSampleSize)
 
 	targets, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
 	if err != nil {

--- a/rebuild/internal/controller/pinglist/filtering_test.go
+++ b/rebuild/internal/controller/pinglist/filtering_test.go
@@ -1,0 +1,297 @@
+package pinglist
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
+)
+
+// targetGIDs returns the sorted TargetGid values of the given targets so tests
+// can assert on the exact set of RNICs a pinglist paired the requester with,
+// independent of ordering.
+func targetGIDs(targets []*controller_agent.PingTarget) []string {
+	gids := make([]string, 0, len(targets))
+	for _, t := range targets {
+		gids = append(gids, t.GetTargetGid())
+	}
+	sort.Strings(gids)
+	return gids
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestTorMesh_SameHostExclusion verifies issue #39: when the requester is
+// registered, every RNIC on its own host (not just its own GID) is excluded
+// from the ToR-mesh pinglist, while RNICs on other hosts in the same ToR are
+// kept. Same-host probes can hairpin without reaching the fabric, so their RTTs
+// would skew ToR-level aggregates.
+func TestTorMesh_SameHostExclusion(t *testing.T) {
+	src := &fakeRnicSource{
+		torMesh: []*controller_agent.RnicInfo{
+			{Gid: "fe80::1", HostName: "host-a", TorId: "tor-1"}, // requester (self)
+			{Gid: "fe80::2", HostName: "host-a", TorId: "tor-1"}, // same host, other rail
+			{Gid: "fe80::3", HostName: "host-b", TorId: "tor-1"}, // different host
+			{Gid: "fe80::4", HostName: "host-b", TorId: "tor-1"}, // different host
+		},
+		hostnameByGID: map[string]string{"fe80::1": "host-a"},
+	}
+	gen := newTestGenerator(src)
+
+	targets, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateTorMeshPinglist: %v", err)
+	}
+	got := targetGIDs(targets)
+	want := []string{"fe80::3", "fe80::4"}
+	if !equalStrings(got, want) {
+		t.Errorf("targets = %v, want %v (self and same-host RNIC excluded)", got, want)
+	}
+}
+
+// TestTorMesh_UnregisteredRequesterFallsBackToGID verifies that when the
+// requester is not registered (hostname unknown), the generator falls back to
+// GID self-exclusion only: it can no longer identify same-host RNICs, so a
+// sibling NIC on the same host is (unavoidably) kept, but the request still
+// succeeds rather than failing.
+func TestTorMesh_UnregisteredRequesterFallsBackToGID(t *testing.T) {
+	src := &fakeRnicSource{
+		torMesh: []*controller_agent.RnicInfo{
+			{Gid: "fe80::1", HostName: "host-a", TorId: "tor-1"}, // requester (self)
+			{Gid: "fe80::2", HostName: "host-a", TorId: "tor-1"}, // same host, but unknowable
+			{Gid: "fe80::3", HostName: "host-b", TorId: "tor-1"},
+		},
+		// hostnameByGID is empty: the requester is not registered.
+	}
+	gen := newTestGenerator(src)
+
+	targets, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateTorMeshPinglist: %v", err)
+	}
+	got := targetGIDs(targets)
+	want := []string{"fe80::2", "fe80::3"} // only the requester's own GID is excluded
+	if !equalStrings(got, want) {
+		t.Errorf("targets = %v, want %v (only self excluded on fallback)", got, want)
+	}
+}
+
+// TestTorMesh_ResolveErrorDegradesGracefully verifies that a hostname-lookup
+// failure does not fail the pinglist request: it degrades to GID self-exclusion
+// (same as the unregistered case) so the requester still receives a pinglist.
+func TestTorMesh_ResolveErrorDegradesGracefully(t *testing.T) {
+	src := &fakeRnicSource{
+		torMesh: []*controller_agent.RnicInfo{
+			{Gid: "fe80::1", HostName: "host-a", TorId: "tor-1"}, // requester (self)
+			{Gid: "fe80::2", HostName: "host-a", TorId: "tor-1"},
+			{Gid: "fe80::3", HostName: "host-b", TorId: "tor-1"},
+		},
+		resolveErr: errors.New("rqlite unreachable"),
+	}
+	gen := newTestGenerator(src)
+
+	targets, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateTorMeshPinglist must not fail on a hostname-lookup error: %v", err)
+	}
+	got := targetGIDs(targets)
+	want := []string{"fe80::2", "fe80::3"} // self excluded via GID fallback
+	if !equalStrings(got, want) {
+		t.Errorf("targets = %v, want %v", got, want)
+	}
+}
+
+// TestTorMesh_CrossFamilyExclusion verifies issue #41 in both directions: a
+// native-IPv6 requester never probes an IPv4-mapped target and vice versa,
+// while same-family targets are preserved. A cross-family probe fails at
+// ibv_create_ah() before reaching the wire.
+func TestTorMesh_CrossFamilyExclusion(t *testing.T) {
+	cases := []struct {
+		name         string
+		requesterGID string
+		torMesh      []*controller_agent.RnicInfo
+		want         []string
+	}{
+		{
+			name:         "ipv6_requester_skips_ipv4_mapped",
+			requesterGID: "fe80::1",
+			torMesh: []*controller_agent.RnicInfo{
+				{Gid: "fe80::2", HostName: "host-b", TorId: "tor-1"},         // same family (ipv6) -> kept
+				{Gid: "::ffff:10.0.0.2", HostName: "host-c", TorId: "tor-1"}, // cross family -> skipped
+				{Gid: "fe80::3", HostName: "host-d", TorId: "tor-1"},         // same family -> kept
+			},
+			want: []string{"fe80::2", "fe80::3"},
+		},
+		{
+			name:         "ipv4_mapped_requester_skips_ipv6",
+			requesterGID: "::ffff:10.0.0.1",
+			torMesh: []*controller_agent.RnicInfo{
+				{Gid: "fe80::2", HostName: "host-b", TorId: "tor-1"},         // cross family -> skipped
+				{Gid: "::ffff:10.0.0.3", HostName: "host-c", TorId: "tor-1"}, // same family -> kept
+				{Gid: "::ffff:10.0.0.4", HostName: "host-d", TorId: "tor-1"}, // same family -> kept
+			},
+			want: []string{"::ffff:10.0.0.3", "::ffff:10.0.0.4"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &fakeRnicSource{torMesh: tc.torMesh}
+			gen := newTestGenerator(src)
+
+			targets, err := gen.GenerateTorMeshPinglist(context.Background(), tc.requesterGID, "tor-1")
+			if err != nil {
+				t.Fatalf("GenerateTorMeshPinglist: %v", err)
+			}
+			got := targetGIDs(targets)
+			if !equalStrings(got, tc.want) {
+				t.Errorf("targets = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTorMesh_UnparseableGIDHandling verifies the deliberate "unknown is its
+// own family" rule: an unparseable requester GID pairs only with equally
+// unparseable targets (preserving prior behavior for such GIDs), and never with
+// a parseable one; conversely a parseable requester never pairs with an
+// unparseable target. Production GIDs always parse, so this is defensive.
+func TestTorMesh_UnparseableGIDHandling(t *testing.T) {
+	t.Run("unparseable_requester_pairs_only_with_unparseable", func(t *testing.T) {
+		src := &fakeRnicSource{
+			torMesh: []*controller_agent.RnicInfo{
+				{Gid: "fe80::2", HostName: "host-b", TorId: "tor-1"},   // parseable -> skipped
+				{Gid: "also-junk", HostName: "host-c", TorId: "tor-1"}, // unparseable -> kept
+			},
+		}
+		gen := newTestGenerator(src)
+
+		targets, err := gen.GenerateTorMeshPinglist(context.Background(), "junk-gid", "tor-1")
+		if err != nil {
+			t.Fatalf("GenerateTorMeshPinglist: %v", err)
+		}
+		got := targetGIDs(targets)
+		want := []string{"also-junk"}
+		if !equalStrings(got, want) {
+			t.Errorf("targets = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("parseable_requester_skips_unparseable_target", func(t *testing.T) {
+		src := &fakeRnicSource{
+			torMesh: []*controller_agent.RnicInfo{
+				{Gid: "fe80::2", HostName: "host-b", TorId: "tor-1"}, // same family -> kept
+				{Gid: "junk", HostName: "host-c", TorId: "tor-1"},    // unparseable -> skipped
+			},
+		}
+		gen := newTestGenerator(src)
+
+		targets, err := gen.GenerateTorMeshPinglist(context.Background(), "fe80::1", "tor-1")
+		if err != nil {
+			t.Fatalf("GenerateTorMeshPinglist: %v", err)
+		}
+		got := targetGIDs(targets)
+		want := []string{"fe80::2"}
+		if !equalStrings(got, want) {
+			t.Errorf("targets = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestInterTor_SameHostExcludedBeforeSampling verifies issue #39 for
+// rail-optimized fabrics (a host's NICs register under different ToR IDs) AND
+// that coverage is preserved: even though the same-host RNIC in tor-2 is
+// listed first, filtering happens before per-ToR sampling, so tor-2 is still
+// represented by its valid different-host RNIC instead of being dropped.
+func TestInterTor_SameHostExcludedBeforeSampling(t *testing.T) {
+	src := &fakeRnicSource{
+		interTor: []*controller_agent.RnicInfo{
+			// tor-2: the requester's own host appears first; it must be
+			// filtered out, but tor-2 must still be covered by fe80::b2.
+			{Gid: "fe80::a2", HostName: "host-a", TorId: "tor-2"},
+			{Gid: "fe80::b2", HostName: "host-b", TorId: "tor-2"},
+			// tor-3: only a valid different-host RNIC.
+			{Gid: "fe80::c3", HostName: "host-c", TorId: "tor-3"},
+		},
+		hostnameByGID: map[string]string{"fe80::1": "host-a"},
+	}
+	gen := newTestGenerator(src)
+
+	targets, err := gen.GenerateInterTorPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateInterTorPinglist: %v", err)
+	}
+	got := targetGIDs(targets)
+	want := []string{"fe80::b2", "fe80::c3"} // tor-2 covered by fe80::b2, not the same-host fe80::a2
+	if !equalStrings(got, want) {
+		t.Errorf("targets = %v, want %v (same-host excluded, ToR coverage preserved)", got, want)
+	}
+}
+
+// TestInterTor_CrossFamilyExcludedBeforeSampling verifies issue #41 for the
+// inter-ToR list: a foreign ToR whose first candidate is cross-family is still
+// covered by a same-family RNIC rather than being dropped from coverage.
+func TestInterTor_CrossFamilyExcludedBeforeSampling(t *testing.T) {
+	src := &fakeRnicSource{
+		interTor: []*controller_agent.RnicInfo{
+			{Gid: "::ffff:10.0.2.1", HostName: "host-x", TorId: "tor-2"}, // cross family -> skipped
+			{Gid: "fe80::b2", HostName: "host-y", TorId: "tor-2"},        // same family -> represents tor-2
+			{Gid: "fe80::c3", HostName: "host-z", TorId: "tor-3"},
+		},
+	}
+	gen := newTestGenerator(src)
+
+	targets, err := gen.GenerateInterTorPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateInterTorPinglist: %v", err)
+	}
+	got := targetGIDs(targets)
+	want := []string{"fe80::b2", "fe80::c3"}
+	if !equalStrings(got, want) {
+		t.Errorf("targets = %v, want %v", got, want)
+	}
+}
+
+// TestInterTor_SamplesOnePerToRUpToSize verifies that the generator still caps
+// the inter-ToR pinglist at interTorSampleSize distinct ToRs, one representative
+// each, after filtering.
+func TestInterTor_SamplesOnePerToRUpToSize(t *testing.T) {
+	src := &fakeRnicSource{
+		interTor: []*controller_agent.RnicInfo{
+			{Gid: "fe80::a", HostName: "host-a", TorId: "tor-2"},
+			{Gid: "fe80::b", HostName: "host-b", TorId: "tor-2"}, // second RNIC in tor-2 -> not sampled
+			{Gid: "fe80::c", HostName: "host-c", TorId: "tor-3"},
+			{Gid: "fe80::d", HostName: "host-d", TorId: "tor-4"},
+		},
+	}
+	// Cap at 2 distinct ToRs.
+	gen := NewPinglistGenerator(src, ECMPConfig{PathsAssumed: 16, CoverageProbability: 0.9, MaxFlowLabels: 64}, 2)
+
+	targets, err := gen.GenerateInterTorPinglist(context.Background(), "fe80::1", "tor-1")
+	if err != nil {
+		t.Fatalf("GenerateInterTorPinglist: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets, want 2 (capped at interTorSampleSize)", len(targets))
+	}
+	// Exactly one representative per distinct ToR.
+	seen := map[string]bool{}
+	for _, tgt := range targets {
+		if seen[tgt.GetTargetTorId()] {
+			t.Errorf("ToR %s represented more than once", tgt.GetTargetTorId())
+		}
+		seen[tgt.GetTargetTorId()] = true
+	}
+}

--- a/rebuild/internal/controller/pinglist/generate_test.go
+++ b/rebuild/internal/controller/pinglist/generate_test.go
@@ -19,8 +19,12 @@ func (erroringRnicSource) GetRNICsByToR(_ context.Context, _ string) ([]*control
 	return nil, errFakeRegistry
 }
 
-func (erroringRnicSource) GetSampleRNICsFromOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+func (erroringRnicSource) GetActiveRNICsInOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
 	return nil, errFakeRegistry
+}
+
+func (erroringRnicSource) ResolveHostnameByGID(_ context.Context, _ string) (string, error) {
+	return "", nil
 }
 
 func newTestGenerator(src RnicSource) *PinglistGenerator {
@@ -28,7 +32,7 @@ func newTestGenerator(src RnicSource) *PinglistGenerator {
 		PathsAssumed:        16,
 		CoverageProbability: 0.9,
 		MaxFlowLabels:       64,
-	})
+	}, DefaultInterTorSampleSize)
 }
 
 // TestGenerateTorMeshPinglist_Error verifies that a registry error is
@@ -76,8 +80,8 @@ func TestGenerateTorMeshPinglist_EmptyToR(t *testing.T) {
 
 // TestGenerateInterTorPinglist_Success verifies that sampled RNICs from other
 // ToRs are converted into PingTargets carrying the ECMP seed/count, mirroring
-// GenerateTorMeshPinglist's contract but without excluding the requester
-// (GetSampleRNICsFromOtherToRs already excludes the requester's own ToR).
+// GenerateTorMeshPinglist's contract. The requester's own ToR is already
+// excluded by GetActiveRNICsInOtherToRs's query.
 func TestGenerateInterTorPinglist_Success(t *testing.T) {
 	src := &fakeRnicSource{
 		interTor: []*controller_agent.RnicInfo{

--- a/rebuild/internal/controller/pinglist/pinglist.go
+++ b/rebuild/internal/controller/pinglist/pinglist.go
@@ -5,8 +5,14 @@ import (
 	"hash/fnv"
 
 	"github.com/rs/zerolog/log"
+	"github.com/yuuki/rpingmesh/rebuild/internal/probe"
 	"github.com/yuuki/rpingmesh/rebuild/proto/controller_agent"
 )
+
+// DefaultInterTorSampleSize is the fallback number of distinct foreign ToRs
+// sampled for an inter-ToR pinglist when NewPinglistGenerator is given a
+// non-positive size. It mirrors config.DefaultInterTorSampleSize.
+const DefaultInterTorSampleSize = 5
 
 // RnicSource is the subset of registry.RnicRegistry's read API required to
 // generate pinglists. It is declared here, at the point of use, so that
@@ -14,7 +20,15 @@ import (
 // rqlite-backed registry.
 type RnicSource interface {
 	GetRNICsByToR(ctx context.Context, torID string) ([]*controller_agent.RnicInfo, error)
-	GetSampleRNICsFromOtherToRs(ctx context.Context, excludeTorID string) ([]*controller_agent.RnicInfo, error)
+	// GetActiveRNICsInOtherToRs returns all active RNICs in ToRs other than
+	// excludeTorID, in random order. The generator - not the registry -
+	// samples one representative per ToR, after same-host / same-family
+	// filtering, so coverage is preserved (see GenerateInterTorPinglist).
+	GetActiveRNICsInOtherToRs(ctx context.Context, excludeTorID string) ([]*controller_agent.RnicInfo, error)
+	// ResolveHostnameByGID returns the hostname the requester GID is
+	// registered under, or "" when it is not registered (disabling same-host
+	// filtering and falling back to GID self-exclusion).
+	ResolveHostnameByGID(ctx context.Context, gid string) (string, error)
 }
 
 // PinglistGenerator generates probe target lists for agents.
@@ -25,12 +39,21 @@ type PinglistGenerator struct {
 	// ComputeFlowLabelCount (R-Pingmesh Eq.(1)). It is stamped into every
 	// PingTarget; the agent expands seed+count into the concrete label set.
 	flowLabelCount uint32
+	// interTorSampleSize caps the number of distinct foreign ToRs sampled for
+	// an inter-ToR pinglist. Sampling lives here (not in the registry) because
+	// it must run after same-host / same-family filtering to keep coverage.
+	interTorSampleSize int
 }
 
 // NewPinglistGenerator creates a new PinglistGenerator backed by the given
 // RNIC source. The ECMP config sizes how many distinct flow labels each
 // target is probed with (Eq.(1) coverage), computed once here.
-func NewPinglistGenerator(registry RnicSource, ecmp ECMPConfig) *PinglistGenerator {
+// interTorSampleSize caps distinct foreign ToRs per inter-ToR pinglist; a
+// non-positive value falls back to DefaultInterTorSampleSize.
+func NewPinglistGenerator(registry RnicSource, ecmp ECMPConfig, interTorSampleSize int) *PinglistGenerator {
+	if interTorSampleSize <= 0 {
+		interTorSampleSize = DefaultInterTorSampleSize
+	}
 	return &PinglistGenerator{
 		registry: registry,
 		flowLabelCount: ComputeFlowLabelCount(
@@ -38,12 +61,67 @@ func NewPinglistGenerator(registry RnicSource, ecmp ECMPConfig) *PinglistGenerat
 			ecmp.CoverageProbability,
 			ecmp.MaxFlowLabels,
 		),
+		interTorSampleSize: interTorSampleSize,
 	}
 }
 
-// GenerateTorMeshPinglist returns PingTargets for all RNICs in the same ToR,
-// excluding the requester's own RNIC. Each target carries deterministic
-// 5-tuple values derived from the requester-target GID pair.
+// requesterContext bundles the per-request filtering criteria derived once for
+// a pinglist request: the hostname the requester is registered under ("" when
+// it is not registered, which disables same-host filtering) and the requester
+// GID's address family.
+type requesterContext struct {
+	gid      string
+	hostname string
+	family   string
+}
+
+// resolveRequester derives the requester's same-host / same-family filtering
+// criteria. A hostname-lookup failure degrades to GID-based self-exclusion
+// (empty hostname) rather than failing the request: pinglist generation is
+// best-effort, and self-exclusion still prevents the requester from probing
+// itself. The address family is derived directly from the requester GID string.
+func (g *PinglistGenerator) resolveRequester(ctx context.Context, requesterGID string) requesterContext {
+	hostname, err := g.registry.ResolveHostnameByGID(ctx, requesterGID)
+	if err != nil {
+		log.Warn().Err(err).Str("requesterGID", requesterGID).
+			Msg("Failed to resolve requester hostname; falling back to GID self-exclusion only")
+		hostname = ""
+	}
+	return requesterContext{
+		gid:      requesterGID,
+		hostname: hostname,
+		family:   probe.GIDFamily(requesterGID),
+	}
+}
+
+// shouldProbe reports whether the requester should probe the given target RNIC.
+// It applies, in order:
+//   - self / same-host exclusion (issue #39): skip the requester's own RNIC and
+//     every RNIC on the same host. When the requester's hostname is known, all
+//     of its host's RNICs are matched by hostname; the GID check additionally
+//     covers the fallback case where the requester is unregistered (hostname
+//     unknown) so at least its own RNIC is still excluded. Same-host probes can
+//     hairpin without reaching the fabric, so their RTTs would skew ToR-level
+//     aggregates while telling nothing about the network.
+//   - same-address-family requirement (issue #41): skip targets whose GID
+//     address family differs from the requester's. A cross-family probe fails
+//     at ibv_create_ah() (route lookup) before reaching the wire, so pairing
+//     them would retry-and-fail forever and inflate probe_failed_total.
+func (rc requesterContext) shouldProbe(target *controller_agent.RnicInfo) bool {
+	if target.GetGid() == rc.gid {
+		return false
+	}
+	if rc.hostname != "" && target.GetHostName() == rc.hostname {
+		return false
+	}
+	return probe.GIDFamily(target.GetGid()) == rc.family
+}
+
+// GenerateTorMeshPinglist returns PingTargets for the RNICs in the same ToR
+// that the requester should probe: its own RNIC and every other RNIC on the
+// same host are excluded (issue #39), and cross-address-family targets are
+// dropped (issue #41). Each target carries deterministic 5-tuple values derived
+// from the requester-target GID pair.
 func (g *PinglistGenerator) GenerateTorMeshPinglist(
 	ctx context.Context,
 	requesterGID, torID string,
@@ -53,13 +131,13 @@ func (g *PinglistGenerator) GenerateTorMeshPinglist(
 		return nil, err
 	}
 
+	rc := g.resolveRequester(ctx, requesterGID)
+
 	targets := make([]*controller_agent.PingTarget, 0, len(rnics))
 	for _, rnic := range rnics {
-		// Skip the requester's own RNIC.
-		if rnic.GetGid() == requesterGID {
+		if !rc.shouldProbe(rnic) {
 			continue
 		}
-
 		targets = append(targets, g.buildPingTarget(requesterGID, rnic, controller_agent.PinglistType_TOR_MESH))
 	}
 
@@ -72,20 +150,40 @@ func (g *PinglistGenerator) GenerateTorMeshPinglist(
 	return targets, nil
 }
 
-// GenerateInterTorPinglist returns PingTargets sampled from ToRs other than
-// the requester's own. Each target carries deterministic 5-tuple values.
+// GenerateInterTorPinglist returns PingTargets sampled from ToRs other than the
+// requester's own: at most one representative RNIC per foreign ToR, up to
+// interTorSampleSize ToRs. Same-host (issue #39, for rail-optimized fabrics
+// where a host's NICs register under different ToR IDs) and cross-address-family
+// (issue #41) RNICs are filtered out BEFORE sampling, so a foreign ToR is only
+// dropped from coverage when it has no valid representative for this requester.
+// Each target carries deterministic 5-tuple values.
 func (g *PinglistGenerator) GenerateInterTorPinglist(
 	ctx context.Context,
 	requesterGID, torID string,
 ) ([]*controller_agent.PingTarget, error) {
-	rnics, err := g.registry.GetSampleRNICsFromOtherToRs(ctx, torID)
+	rnics, err := g.registry.GetActiveRNICsInOtherToRs(ctx, torID)
 	if err != nil {
 		return nil, err
 	}
 
-	targets := make([]*controller_agent.PingTarget, 0, len(rnics))
+	rc := g.resolveRequester(ctx, requesterGID)
+
+	// Rows arrive in random order, so picking the first valid RNIC per ToR
+	// yields a randomly-varying representative and ToR set across calls.
+	seenToRs := make(map[string]bool, g.interTorSampleSize)
+	targets := make([]*controller_agent.PingTarget, 0, g.interTorSampleSize)
 	for _, rnic := range rnics {
+		if !rc.shouldProbe(rnic) {
+			continue
+		}
+		if seenToRs[rnic.GetTorId()] {
+			continue
+		}
+		seenToRs[rnic.GetTorId()] = true
 		targets = append(targets, g.buildPingTarget(requesterGID, rnic, controller_agent.PinglistType_INTER_TOR))
+		if len(targets) >= g.interTorSampleSize {
+			break
+		}
 	}
 
 	log.Info().

--- a/rebuild/internal/controller/registry/registry.go
+++ b/rebuild/internal/controller/registry/registry.go
@@ -23,10 +23,6 @@ const (
 	// DefaultStaleThresholdSec is the window (in seconds) after which an
 	// RNIC entry is considered stale and eligible for removal.
 	DefaultStaleThresholdSec = 900
-
-	// DefaultInterTorSampleSize is the default number of distinct ToRs
-	// sampled for inter-ToR pinglist generation.
-	DefaultInterTorSampleSize = 5
 )
 
 // dbConn is the subset of gorqlite.Connection's API used by RnicRegistry. It
@@ -51,17 +47,17 @@ type RnicRegistry struct {
 	// staleThresholdSec is the window (seconds) after which entries are
 	// considered stale and removed or excluded.
 	staleThresholdSec int
-	// interTorSampleSize caps the number of distinct ToRs sampled by
-	// GetSampleRNICsFromOtherToRs.
-	interTorSampleSize int
 }
 
 // NewRnicRegistry creates a new RNIC registry connected to the given rqlite
 // URI. It initializes the database schema (table + indexes) before
-// returning. activeThresholdSec, staleThresholdSec, and interTorSampleSize
-// configure the thresholds described above; a value <= 0 falls back to the
-// corresponding Default* constant.
-func NewRnicRegistry(dbURI string, activeThresholdSec, staleThresholdSec, interTorSampleSize int) (*RnicRegistry, error) {
+// returning. activeThresholdSec and staleThresholdSec configure the thresholds
+// described above; a value <= 0 falls back to the corresponding Default*
+// constant. Inter-ToR sampling (one representative RNIC per foreign ToR) is
+// performed by the pinglist generator, not here, because it must run after the
+// generator's same-host / same-address-family filtering so that a ToR is only
+// dropped when it has no valid target for the requester (see issues #39, #41).
+func NewRnicRegistry(dbURI string, activeThresholdSec, staleThresholdSec int) (*RnicRegistry, error) {
 	log.Info().Str("dbURI", dbURI).Msg("Initializing RNIC registry with rqlite")
 
 	if activeThresholdSec <= 0 {
@@ -69,9 +65,6 @@ func NewRnicRegistry(dbURI string, activeThresholdSec, staleThresholdSec, interT
 	}
 	if staleThresholdSec <= 0 {
 		staleThresholdSec = DefaultStaleThresholdSec
-	}
-	if interTorSampleSize <= 0 {
-		interTorSampleSize = DefaultInterTorSampleSize
 	}
 
 	conn, err := gorqlite.Open(dbURI)
@@ -83,7 +76,6 @@ func NewRnicRegistry(dbURI string, activeThresholdSec, staleThresholdSec, interT
 		conn:               conn,
 		activeThresholdSec: activeThresholdSec,
 		staleThresholdSec:  staleThresholdSec,
-		interTorSampleSize: interTorSampleSize,
 	}
 
 	if err := registry.initializeSchema(); err != nil {
@@ -250,19 +242,23 @@ func (r *RnicRegistry) GetRNICsByToR(
 	return scanRnicInfoRows(result)
 }
 
-// GetSampleRNICsFromOtherToRs returns one representative RNIC from each ToR
-// other than the excluded one, up to interTorSampleSize distinct ToRs. Only
-// active entries (updated within the configured active-threshold window)
-// are considered. Candidate rows are fetched in random order (ORDER BY
-// RANDOM()) so that, across repeated calls, a different representative ToR
-// set and RNIC is chosen each time rather than always sampling the same
-// fixed 5 ToRs and RNICs (as GROUP BY without ORDER BY would, since SQLite
-// does not guarantee which row within a group is returned).
-func (r *RnicRegistry) GetSampleRNICsFromOtherToRs(
+// GetActiveRNICsInOtherToRs returns every active RNIC (updated within the
+// configured active-threshold window) that belongs to a ToR other than the
+// excluded one, in random order (ORDER BY RANDOM()).
+//
+// It intentionally does NOT sample one-per-ToR here: the pinglist generator
+// samples after filtering out same-host and cross-address-family targets, so
+// that inter-ToR coverage is only dropped for a foreign ToR when that ToR has
+// no valid representative for the requester. Sampling in SQL (or here) before
+// that filtering could silently blind a whole ToR whenever its randomly-chosen
+// representative happened to be a same-host or cross-family RNIC (issues #39,
+// #41). Rows are still returned in random order so the generator picks a
+// randomly-varying representative per ToR across repeated calls.
+func (r *RnicRegistry) GetActiveRNICsInOtherToRs(
 	ctx context.Context,
 	excludeTorID string,
 ) ([]*controller_agent.RnicInfo, error) {
-	log.Debug().Str("excludeTorID", excludeTorID).Msg("Getting sample RNICs from other ToRs")
+	log.Debug().Str("excludeTorID", excludeTorID).Msg("Getting active RNICs in other ToRs")
 
 	querySQL := `
 	SELECT rnic_gid, qpn, rnic_ip, hostname, tor_id, device_name
@@ -278,31 +274,32 @@ func (r *RnicRegistry) GetSampleRNICsFromOtherToRs(
 
 	result, err := r.conn.QueryOneParameterizedContext(ctx, stmt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query sample RNICs from other ToRs: %w", err)
+		return nil, fmt.Errorf("failed to query active RNICs in other ToRs: %w", err)
 	}
 
-	candidates, err := scanRnicInfoRows(result)
+	return scanRnicInfoRows(result)
+}
+
+// ResolveHostnameByGID returns the hostname the RNIC identified by gid is
+// registered under, or "" when no active entry matches (e.g. the requester has
+// not registered yet). A "" result signals the pinglist generator to fall back
+// to GID-based self-exclusion instead of same-host filtering. Genuine query
+// errors are propagated. It reuses GetRNICInfo's active-window GID lookup.
+func (r *RnicRegistry) ResolveHostnameByGID(
+	ctx context.Context,
+	gid string,
+) (string, error) {
+	if gid == "" {
+		return "", nil
+	}
+	info, err := r.GetRNICInfo(ctx, "", gid)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	// Pick at most one RNIC per distinct ToR, up to interTorSampleSize
-	// ToRs. Since candidates arrived in random order, this yields a
-	// randomly chosen representative ToR set and RNIC on each call.
-	seenToRs := make(map[string]bool, r.interTorSampleSize)
-	sampled := make([]*controller_agent.RnicInfo, 0, r.interTorSampleSize)
-	for _, rnic := range candidates {
-		if seenToRs[rnic.GetTorId()] {
-			continue
-		}
-		seenToRs[rnic.GetTorId()] = true
-		sampled = append(sampled, rnic)
-		if len(sampled) >= r.interTorSampleSize {
-			break
-		}
+	if info == nil {
+		return "", nil
 	}
-
-	return sampled, nil
+	return info.GetHostName(), nil
 }
 
 // GetRNICInfo looks up a single RNIC by GID (primary key) or IP address.

--- a/rebuild/internal/controller/registry/registry_test.go
+++ b/rebuild/internal/controller/registry/registry_test.go
@@ -85,7 +85,6 @@ func newTestRegistry(conn dbConn) *RnicRegistry {
 		conn:               conn,
 		activeThresholdSec: DefaultActiveThresholdSec,
 		staleThresholdSec:  DefaultStaleThresholdSec,
-		interTorSampleSize: DefaultInterTorSampleSize,
 	}
 }
 
@@ -330,11 +329,11 @@ func TestGetRNICsByToR_QueryErrorPropagates(t *testing.T) {
 	}
 }
 
-func TestGetSampleRNICsFromOtherToRs_UsesActiveThresholdAndExcludesToR(t *testing.T) {
+func TestGetActiveRNICsInOtherToRs_UsesActiveThresholdAndExcludesToR(t *testing.T) {
 	fake := &fakeConn{}
 	reg := newTestRegistry(fake)
 
-	if _, err := reg.GetSampleRNICsFromOtherToRs(context.Background(), "tor-1"); err != nil {
+	if _, err := reg.GetActiveRNICsInOtherToRs(context.Background(), "tor-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -347,12 +346,67 @@ func TestGetSampleRNICsFromOtherToRs_UsesActiveThresholdAndExcludesToR(t *testin
 	}
 }
 
-func TestGetSampleRNICsFromOtherToRs_QueryErrorPropagates(t *testing.T) {
+func TestGetActiveRNICsInOtherToRs_QueryErrorPropagates(t *testing.T) {
 	wantErr := errors.New("query failed")
 	fake := &fakeConn{queryOneParameterizedErr: wantErr}
 	reg := newTestRegistry(fake)
 
-	_, err := reg.GetSampleRNICsFromOtherToRs(context.Background(), "tor-1")
+	_, err := reg.GetActiveRNICsInOtherToRs(context.Background(), "tor-1")
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
+	}
+}
+
+// TestResolveHostnameByGID_EmptyGIDShortCircuits verifies that an empty GID
+// resolves to "" without touching the database, so callers get the
+// unregistered-fallback signal cheaply.
+func TestResolveHostnameByGID_EmptyGIDShortCircuits(t *testing.T) {
+	fake := &fakeConn{}
+	reg := newTestRegistry(fake)
+
+	hostname, err := reg.ResolveHostnameByGID(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hostname != "" {
+		t.Errorf("hostname = %q, want empty", hostname)
+	}
+	if len(fake.queryOneParameterizedCalls) != 0 {
+		t.Errorf("made %d queries, want 0 for an empty GID", len(fake.queryOneParameterizedCalls))
+	}
+}
+
+// TestResolveHostnameByGID_NotFoundReturnsEmpty verifies that a GID with no
+// active row resolves to "" (not an error), so the generator falls back to GID
+// self-exclusion rather than failing the request.
+func TestResolveHostnameByGID_NotFoundReturnsEmpty(t *testing.T) {
+	fake := &fakeConn{} // fakeConn yields an empty result set
+	reg := newTestRegistry(fake)
+
+	hostname, err := reg.ResolveHostnameByGID(context.Background(), "fe80::1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hostname != "" {
+		t.Errorf("hostname = %q, want empty for a GID with no active row", hostname)
+	}
+	if len(fake.queryOneParameterizedCalls) != 1 {
+		t.Fatalf("QueryOneParameterizedContext called %d times, want 1", len(fake.queryOneParameterizedCalls))
+	}
+	if !strings.Contains(fake.queryOneParameterizedCalls[0].Query, "rnic_gid = ?") {
+		t.Errorf("query = %q, want a GID lookup", fake.queryOneParameterizedCalls[0].Query)
+	}
+}
+
+// TestResolveHostnameByGID_QueryErrorPropagates verifies that a genuine query
+// failure is surfaced (not swallowed as ""), so it is distinguishable from a
+// not-found result.
+func TestResolveHostnameByGID_QueryErrorPropagates(t *testing.T) {
+	wantErr := errors.New("query failed")
+	fake := &fakeConn{queryOneParameterizedErr: wantErr}
+	reg := newTestRegistry(fake)
+
+	_, err := reg.ResolveHostnameByGID(context.Background(), "fe80::1")
 	if err == nil || !errors.Is(err, wantErr) {
 		t.Fatalf("got error %v, want wrapping %v", err, wantErr)
 	}

--- a/rebuild/internal/controller/service.go
+++ b/rebuild/internal/controller/service.go
@@ -14,9 +14,9 @@ import (
 // registryClient is the subset of registry.RnicRegistry's API used directly
 // by ControllerService (RegisterRNICs) and, via the embedded
 // PinglistGenerator, its read methods (GetRNICsByToR,
-// GetSampleRNICsFromOtherToRs). It is declared here, at the point of use, so
-// that RegisterAgent and GetPinglist can be unit tested against a fake
-// instead of a real rqlite-backed registry.
+// GetActiveRNICsInOtherToRs, ResolveHostnameByGID). It is declared here, at the
+// point of use, so that RegisterAgent and GetPinglist can be unit tested
+// against a fake instead of a real rqlite-backed registry.
 type registryClient interface {
 	pinglist.RnicSource
 	RegisterRNICs(ctx context.Context, agentID, agentIP string, rnics []*controller_agent.RnicInfo) error
@@ -45,12 +45,13 @@ type ControllerService struct {
 
 // NewControllerService creates a new ControllerService backed by the given
 // RNIC registry. A PinglistGenerator is automatically created from the
-// registry and the ECMP config, which sizes how many distinct flow labels
-// each target is probed with (Eq.(1) coverage).
-func NewControllerService(reg registryClient, ecmp pinglist.ECMPConfig) *ControllerService {
+// registry, the ECMP config (which sizes how many distinct flow labels each
+// target is probed with, Eq.(1) coverage), and interTorSampleSize (the number
+// of distinct foreign ToRs sampled per inter-ToR pinglist).
+func NewControllerService(reg registryClient, ecmp pinglist.ECMPConfig, interTorSampleSize int) *ControllerService {
 	return &ControllerService{
 		registry: reg,
-		pinglist: pinglist.NewPinglistGenerator(reg, ecmp),
+		pinglist: pinglist.NewPinglistGenerator(reg, ecmp, interTorSampleSize),
 	}
 }
 

--- a/rebuild/internal/controller/service_test.go
+++ b/rebuild/internal/controller/service_test.go
@@ -18,7 +18,7 @@ func newTestService(reg registryClient) *ControllerService {
 		PathsAssumed:        16,
 		CoverageProbability: 0.9,
 		MaxFlowLabels:       64,
-	})
+	}, pinglist.DefaultInterTorSampleSize)
 }
 
 // fakeRegistry implements registryClient without any real rqlite backend,
@@ -49,8 +49,15 @@ func (f *fakeRegistry) GetRNICsByToR(_ context.Context, _ string) ([]*controller
 	return f.torMeshRnics, f.torMeshErr
 }
 
-func (f *fakeRegistry) GetSampleRNICsFromOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
+func (f *fakeRegistry) GetActiveRNICsInOtherToRs(_ context.Context, _ string) ([]*controller_agent.RnicInfo, error) {
 	return f.interTorRnics, f.interTorErr
+}
+
+// ResolveHostnameByGID reports the requester as unregistered ("") so the
+// service-level tests exercise the GID self-exclusion fallback; the same-host
+// filtering itself is covered by the pinglist package's unit tests.
+func (f *fakeRegistry) ResolveHostnameByGID(_ context.Context, _ string) (string, error) {
+	return "", nil
 }
 
 func statusCode(t *testing.T, err error) codes.Code {

--- a/rebuild/internal/probe/probe.go
+++ b/rebuild/internal/probe/probe.go
@@ -292,3 +292,57 @@ func GIDToIPv4(gid [16]byte) string {
 	// Not IPv4-mapped, return full GID hex notation.
 	return FormatGID(gid)
 }
+
+// GID address-family classifications returned by GIDFamily. The controller's
+// pinglist generators use them to avoid pairing a native-IPv6 GID with an
+// IPv4-mapped one: ibv_create_ah() resolves the destination via a route lookup
+// that fails when the source and destination GID families differ, so a
+// cross-family probe can never leave the source host and every such pair would
+// retry-and-fail forever (see issue #41).
+const (
+	// GIDFamilyIPv4Mapped is an IPv4-mapped IPv6 GID (::ffff:a.b.c.d): bytes
+	// 0-9 are zero and bytes 10-11 are 0xff. These typically live on
+	// RoCE-capable management NICs.
+	GIDFamilyIPv4Mapped = "ipv4-mapped"
+	// GIDFamilyIPv6 is a native IPv6 GID (e.g. a fabric-rail link-local GID).
+	GIDFamilyIPv6 = "ipv6"
+	// GIDFamilyUnknown is returned when the GID string cannot be parsed. It is
+	// treated as its own family, so an unparseable GID never pairs with a
+	// parseable one while two unparseable GIDs still pair (see GIDFamily).
+	GIDFamilyUnknown = "unknown"
+)
+
+// GIDFamily classifies a textual GID into its address family so the controller
+// can skip cross-address-family probe pairs that ibv_create_ah() would reject.
+//
+// Why parse rather than string-match: GIDs travel in several textual forms. The
+// Zig bridge emits the full 8-group hex form (an IPv4-mapped address becomes
+// "0000:0000:0000:0000:0000:ffff:c0a8:0101"), while abbreviated inputs and
+// tests use "::ffff:a.b.c.d" or "fe80::1". Parsing to the 16-byte form and
+// inspecting the IPv4-mapped prefix classifies all of these consistently,
+// whereas a SQL/string `LIKE '::ffff:%'` would miss the full-hex form entirely.
+//
+// Why unparseable is its own family and not force-matched: we cannot know
+// whether a probe to an unparseable GID would succeed, so it only ever pairs
+// with another equally-unparseable GID. That keeps a parser quirk from silently
+// force-pairing (and log-spamming) against the parseable majority, while never
+// emitting a pair we already know ibv_create_ah() would reject. In practice all
+// production GIDs originate from the Zig bridge's canonical hex form and always
+// parse, so this branch is purely defensive.
+func GIDFamily(gid string) string {
+	parsed, err := ParseGID(gid)
+	if err != nil {
+		return GIDFamilyUnknown
+	}
+	// IPv4-mapped IPv6: bytes 0-9 zero, bytes 10-11 == 0xff (the same test
+	// GIDToIPv4 uses to switch to dotted-decimal rendering).
+	for i := 0; i < 10; i++ {
+		if parsed[i] != 0 {
+			return GIDFamilyIPv6
+		}
+	}
+	if parsed[10] == 0xff && parsed[11] == 0xff {
+		return GIDFamilyIPv4Mapped
+	}
+	return GIDFamilyIPv6
+}

--- a/rebuild/internal/probe/probe_test.go
+++ b/rebuild/internal/probe/probe_test.go
@@ -340,6 +340,41 @@ func TestGIDToIPv4_LoopbackMapped(t *testing.T) {
 	}
 }
 
+// TestGIDFamily classifies GIDs across every textual form the controller sees:
+// the Zig bridge's full 8-group hex form (production), abbreviated IPv6, the
+// abbreviated IPv4-mapped form, and unparseable junk. This is the classifier
+// the pinglist generators use to skip cross-address-family probe pairs that
+// ibv_create_ah() would reject (issue #41).
+func TestGIDFamily(t *testing.T) {
+	tests := []struct {
+		name string
+		gid  string
+		want string
+	}{
+		// Native IPv6.
+		{"native_ipv6_abbrev", "fe80::1", GIDFamilyIPv6},
+		{"native_ipv6_full", "fe80:0000:0000:0000:0001:0002:0003:0004", GIDFamilyIPv6},
+		// IPv4-mapped, both the full-hex form the Zig bridge emits and the
+		// abbreviated ::ffff: form used in configs/tests.
+		{"ipv4_mapped_full_hex", "0000:0000:0000:0000:0000:ffff:c0a8:0101", GIDFamilyIPv4Mapped},
+		{"ipv4_mapped_abbrev", "::ffff:192.168.1.1", GIDFamilyIPv4Mapped},
+		{"ipv4_mapped_loopback", "::ffff:127.0.0.1", GIDFamilyIPv4Mapped},
+		// All-zeros parses but is not IPv4-mapped (bytes 10-11 are not 0xff).
+		{"all_zeros", "::", GIDFamilyIPv6},
+		// Unparseable inputs fall back to the "unknown" family.
+		{"empty", "", GIDFamilyUnknown},
+		{"junk", "not-a-gid", GIDFamilyUnknown},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GIDFamily(tc.gid); got != tc.want {
+				t.Errorf("GIDFamily(%q) = %q, want %q", tc.gid, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCalculateRTT_RealisticTimestamps(t *testing.T) {
 	// Simulate a realistic datacenter probe with ~50us RTT.
 	baseNS := uint64(1_000_000_000_000) // 1000 seconds in nanoseconds


### PR DESCRIPTION
## Summary

Fixes #39 and fixes #41: since PR #31 every RNIC runs a prober, which exposed two pinglist-generation gaps that produce meaningless or always-failing probe pairs.

- **Same-host targets (#39):** `GenerateTorMeshPinglist` only excluded the requester's own GID, so on a multi-rail host each NIC probed its sibling NICs. Those probes measure the host, not the fabric, and skew ToR-level RTT/loss aggregates. The inter-ToR pinglist had the same gap on rail-optimized fabrics where a host's NICs register under different ToR IDs.
- **Cross-address-family targets (#41):** pinglists freely paired native IPv6 GIDs with IPv4-mapped GIDs (`::ffff:a.b.c.d`). `ibv_create_ah()` cannot resolve a route across families, so every such pair failed at every probe interval forever, inflating `probe_failed_total{reason="send_error"}` on a healthy network.

## Design

All pairing rules now live in the pinglist generator (`internal/controller/pinglist`), unit-testable against the existing fake `RnicSource`:

- A per-request `requesterContext` (GID, hostname, address family) drives a shared `shouldProbe` predicate: skip self GID, skip same-hostname targets, require matching GID address family.
- **Hostname, not agent_id, is the host key** — `agent_id` merely defaults to the hostname and can be overridden in config. The requester's hostname is resolved from its own registration row via a new `ResolveHostnameByGID` registry method; if the requester is not yet registered (or the lookup fails), the generator degrades gracefully to the previous GID-only self-exclusion instead of failing the request.
- **Filter before sampling:** the inter-ToR path previously sampled one representative RNIC per foreign ToR inside the registry, so a post-hoc filter could silently drop an entire ToR from coverage. Sampling now happens in the generator *after* filtering (`GetActiveRNICsInOtherToRs` returns all candidate rows), so a ToR only disappears when it has no valid representative at all.
- **Family classification parses the GID** (`probe.GIDFamily`: `ipv4-mapped` / `ipv6` / `unknown`) rather than using a SQL `LIKE '::ffff:%'` predicate — the registry stores GIDs in the Zig bridge's full 8-group hex form (e.g. `0000:...:ffff:c0a8:0101`), which a textual prefix match would never catch. Unparseable GIDs classify as `unknown`, which only pairs with `unknown`, preserving the status quo for exotic data instead of silently blinding monitoring.

No proto, agent, or Zig changes; controller-side only.

## Test plan

- [x] `internal/probe`: `TestGIDFamily` covers full-hex, abbreviated, `::ffff:` and unparseable GID forms.
- [x] `internal/controller/pinglist/filtering_test.go` (new): same-host exclusion in ToR-mesh; GID-fallback when the requester is unregistered; graceful degradation on resolve errors; cross-family exclusion in both directions; same-family pairs preserved; unparseable-GID handling; inter-ToR filtering happening *before* per-ToR sampling (coverage preserved); sample-size cap.
- [x] `internal/controller/registry`: `ResolveHostnameByGID` tests (empty-GID short-circuit, not-found → `""`, query-error propagation); inter-ToR query tests updated for the unsampled variant.
- [x] Local verification (macOS): `go vet ./...` clean; `go test -count=1 ./internal/controller/... ./internal/probe/... ./internal/config/...` all pass; `CGO_ENABLED=0 go build ./cmd/controller/` OK.
- Registry row-scanning against live rqlite and the agent binary link are covered by CI (Linux-only).

Codex review (gpt-5.6-sol, reasoning effort high) passed with no findings.

Not touched: `mise.toml`, memory files.